### PR TITLE
Adding negative automated test to gcp nfs instance

### DIFF
--- a/internal/controller/cloud-control/nfsinstance_gcp_test.go
+++ b/internal/controller/cloud-control/nfsinstance_gcp_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/util/debugged"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/api/googleapi"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 )
 
-var _ = Describe("KCP NFSVolume for GCP", Ordered, func() {
+var _ = Describe("KCP NFSVolume for GCP", func() {
 	const (
 		kymaName = "5b30a61a-c4ae-49da-a8ad-903a71696d8b"
 
@@ -28,16 +29,16 @@ var _ = Describe("KCP NFSVolume for GCP", Ordered, func() {
 	if debugged.Debugged {
 		timeout = time.Minute * 20
 	}
-
-	gcpNfsInstance := &cloudcontrolv1beta1.NfsInstance{}
-
-	Describe("Created NFSVolume is projected into FileStore and it gets Ready condition", func() {
-		Context("Given KCP Cluster", func() {
-
-			// Tell Scope reconciler to ignore this kymaName
-			scopePkg.Ignore.AddName(kymaName)
+	Context("GCP NFSVolume Happy Path", Ordered, func() {
+		gcpNfsInstance := &cloudcontrolv1beta1.NfsInstance{}
+		It("GCP NFSVolume Creation", func() {
 			scope := &cloudcontrolv1beta1.Scope{}
-			It("And Given KCP Scope exists", func() {
+			By("Given KCP Cluster", func() {
+
+				// Tell Scope reconciler to ignore this kymaName
+				scopePkg.Ignore.AddName(kymaName)
+			})
+			By("And Given KCP Scope exists", func() {
 
 				// Given Scope exists
 				Expect(
@@ -57,7 +58,7 @@ var _ = Describe("KCP NFSVolume for GCP", Ordered, func() {
 
 			// Tell IpRange reconciler to ignore this kymaName
 			iprangePkg.Ignore.AddName(kcpIpRangeName)
-			It("And Given KCP IPRange exists", func() {
+			By("And Given KCP IPRange exists", func() {
 				Eventually(CreateKcpIpRange).
 					WithArguments(
 						infra.Ctx(), infra.KCP().Client(), kcpIpRange,
@@ -67,7 +68,7 @@ var _ = Describe("KCP NFSVolume for GCP", Ordered, func() {
 					Should(Succeed())
 			})
 
-			It("And Given KCP IpRange has Ready condition", func() {
+			By("And Given KCP IpRange has Ready condition", func() {
 				Eventually(UpdateStatus).
 					WithArguments(
 						infra.Ctx(), infra.KCP().Client(), kcpIpRange,
@@ -77,18 +78,19 @@ var _ = Describe("KCP NFSVolume for GCP", Ordered, func() {
 					Should(Succeed())
 			})
 
-			It("When KCP NfsVolume is created", func() {
+			By("When KCP NfsVolume is created", func() {
 				Eventually(CreateNfsInstance).
 					WithArguments(
 						infra.Ctx(), infra.KCP().Client(), gcpNfsInstance,
 						WithName("gcp-nfs-instance-1"),
+						WithRemoteRef("gcp-nfs-instance-1"),
 						WithNfsInstanceScope(scope.Name),
 						WithNfsInstanceIpRange(kcpIpRange.Name),
 						WithNfsInstanceGcp(scope.Spec.Region),
 					).
 					Should(Succeed())
 			})
-			It("Then KCP NfsVolume will get Ready condition", func() {
+			By("Then KCP NfsVolume will get Ready condition", func() {
 				Eventually(func() (exists bool, err error) {
 					err = infra.KCP().Client().Get(infra.Ctx(), client.ObjectKeyFromObject(gcpNfsInstance), gcpNfsInstance)
 					if err != nil {
@@ -99,23 +101,23 @@ var _ = Describe("KCP NFSVolume for GCP", Ordered, func() {
 				}, timeout, interval).
 					Should(BeTrue(), "expected NfsInstance for GCP with Ready condition")
 			})
-			It("And KCP NfsVolume has Ready state", func() {
+			By("And KCP NfsVolume has Ready state", func() {
 				Expect(gcpNfsInstance.Status.State).To(Equal(cloudcontrolv1beta1.ReadyState))
 			})
 		})
-	})
 
-	Describe("Patching NFSVolume, at first it gets DeleteFilestore state and eventually it gets removed", func() {
-		Context("Given NfsVolume is Ready", func() {
+		It("GCP NFSVolume Updating", func() {
+			By("Given NfsVolume is Ready", func() {
+			})
 
-			It("When KCP NfsVolume is patched", func() {
+			By("When KCP NfsVolume is updated", func() {
 				Eventually(UpdateNfsInstance).
 					WithArguments(
 						infra.Ctx(), infra.KCP().Client(), gcpNfsInstance,
 					).
 					Should(Succeed())
 			})
-			It("Then at first KCP NfsVolume will get SyncFilestore state", func() {
+			By("Then at first KCP NfsVolume will get SyncFilestore state", func() {
 				Eventually(func() (exists bool, err error) {
 					err = infra.KCP().Client().Get(infra.Ctx(), client.ObjectKeyFromObject(gcpNfsInstance), gcpNfsInstance)
 					if err != nil {
@@ -125,10 +127,10 @@ var _ = Describe("KCP NFSVolume for GCP", Ordered, func() {
 					return exists, nil
 				}, timeout, interval)
 			})
-			It("And NfsVolume keeps Ready state", func() {
+			By("And NfsVolume keeps Ready state", func() {
 				Expect(meta.IsStatusConditionTrue(gcpNfsInstance.Status.Conditions, cloudcontrolv1beta1.ConditionTypeReady)).To(BeTrue())
 			})
-			It("And eventually KCP NfsVolume will get Ready state", func() {
+			By("And eventually KCP NfsVolume will get Ready state", func() {
 				Eventually(func() (exists bool, err error) {
 					err = infra.KCP().Client().Get(infra.Ctx(), client.ObjectKeyFromObject(gcpNfsInstance), gcpNfsInstance)
 					if err != nil {
@@ -139,19 +141,18 @@ var _ = Describe("KCP NFSVolume for GCP", Ordered, func() {
 				}, timeout, interval)
 			})
 		})
-	})
 
-	Describe("Deleting NFSVolume, at first it gets Deleted state and eventually it gets permanently deleted", func() {
-		Context("Given NfsVolume is Ready", func() {
-
-			It("When KCP NfsVolume is deleted", func() {
+		It("GCP NFSVolume Deletion", func() {
+			By("Given NfsVolume is Ready", func() {
+			})
+			By("When KCP NfsVolume is deleted", func() {
 				Eventually(DeleteNfsInstance).
 					WithArguments(
 						infra.Ctx(), infra.KCP().Client(), gcpNfsInstance,
 					).
 					Should(Succeed())
 			})
-			It("Then at first KCP NfsVolume will get Deleted state", func() {
+			By("Then at first KCP NfsVolume will get Deleted state", func() {
 				Eventually(func() (exists bool, err error) {
 					err = infra.KCP().Client().Get(infra.Ctx(), client.ObjectKeyFromObject(gcpNfsInstance), gcpNfsInstance)
 					if err != nil {
@@ -161,10 +162,10 @@ var _ = Describe("KCP NFSVolume for GCP", Ordered, func() {
 					return exists, nil
 				}, timeout, interval)
 			})
-			It("And NfsVolume keeps Ready state", func() {
+			By("And NfsVolume keeps Ready state", func() {
 				Expect(meta.IsStatusConditionTrue(gcpNfsInstance.Status.Conditions, cloudcontrolv1beta1.ConditionTypeReady)).To(BeTrue())
 			})
-			It("And eventually KCP NfsVolume will get permanently removed", func() {
+			By("And eventually KCP NfsVolume will get permanently removed", func() {
 				Eventually(func() (exists bool, err error) {
 					err = infra.KCP().Client().Get(infra.Ctx(), client.ObjectKeyFromObject(gcpNfsInstance), gcpNfsInstance)
 					exists = apierrors.IsNotFound(err)
@@ -174,4 +175,269 @@ var _ = Describe("KCP NFSVolume for GCP", Ordered, func() {
 		})
 	})
 
+	Context("GCP NFSVolume Unhappy Path", Ordered, func() {
+		gcpNfsInstance := &cloudcontrolv1beta1.NfsInstance{}
+		scope := &cloudcontrolv1beta1.Scope{}
+		kcpIpRangeName := "gcp-nfs-iprange-1"
+		kcpIpRange := &cloudcontrolv1beta1.IpRange{}
+		It("GCP NFSVolume Creation Get Failure", func() {
+			By("Given KCP Cluster", func() {
+
+				// Tell Scope reconciler to ignore this kymaName
+				scopePkg.Ignore.AddName(kymaName)
+			})
+			By("And Given KCP Scope exists", func() {
+
+				// Given Scope exists
+				Expect(
+					infra.GivenScopeGcpExists(kymaName),
+				).NotTo(HaveOccurred())
+
+				// Load created scope
+				Eventually(func() (exists bool, err error) {
+					err = infra.KCP().Client().Get(infra.Ctx(), infra.KCP().ObjKey(kymaName), scope)
+					exists = err == nil
+					return exists, client.IgnoreNotFound(err)
+				}, timeout, interval).
+					Should(BeTrue(), "expected Scope to get created")
+			})
+
+			// Tell IpRange reconciler to ignore this kymaName
+			iprangePkg.Ignore.AddName(kcpIpRangeName)
+			By("And Given KCP IPRange exists", func() {
+				Eventually(CreateKcpIpRange).
+					WithArguments(
+						infra.Ctx(), infra.KCP().Client(), kcpIpRange,
+						WithName(kcpIpRangeName),
+						WithKcpIpRangeSpecScope(scope.Name),
+					).
+					Should(Succeed())
+			})
+
+			By("And Given KCP IpRange has Ready condition", func() {
+				Eventually(UpdateStatus).
+					WithArguments(
+						infra.Ctx(), infra.KCP().Client(), kcpIpRange,
+						WithKcpIpRangeStatusCidr(kcpIpRange.Spec.Cidr),
+						WithConditions(KcpReadyCondition()),
+					).WithTimeout(timeout).WithPolling(interval).
+					Should(Succeed())
+			})
+
+			By("When KCP NfsVolume is created but Filestore Get call fails", func() {
+				infra.GcpMock().SetGetError(sample500Error())
+				Eventually(CreateNfsInstance, timeout, interval).
+					WithArguments(
+						infra.Ctx(), infra.KCP().Client(), gcpNfsInstance,
+						WithName("gcp-nfs-instance-2"),
+						WithRemoteRef("gcp-nfs-instance-2"),
+						WithNfsInstanceScope(scope.Name),
+						WithNfsInstanceIpRange(kcpIpRange.Name),
+						WithNfsInstanceGcp(scope.Spec.Region),
+					).
+					Should(Succeed())
+			})
+			By("Then KCP NfsVolume will get Error condition", func() {
+				Eventually(func() (exists bool, err error) {
+					err = infra.KCP().Client().Get(infra.Ctx(), client.ObjectKeyFromObject(gcpNfsInstance), gcpNfsInstance)
+					if err != nil {
+						return false, err
+					}
+					exists = meta.IsStatusConditionTrue(gcpNfsInstance.Status.Conditions, cloudcontrolv1beta1.ConditionTypeError)
+					return exists, nil
+				}, timeout, interval).
+					Should(BeTrue(), "expected NfsInstance for GCP with Error condition")
+			})
+			By("And KCP NfsVolume has empty state", func() {
+				Expect(len(gcpNfsInstance.Status.State)).To(Equal(0))
+			})
+
+		})
+		It("GCP NFSVolume Creation Call Failure", func() {
+			By("Given KCP NfsVolume is created", func() {
+				infra.GcpMock().SetGetError(nil)
+			})
+			By("When Filestore creation call fails", func() {
+				infra.GcpMock().SetCreateError(sample500Error())
+				// CreateNfsInstance is already called in previous test case
+			})
+			By("Then KCP NfsVolume has SyncFilestore state", func() {
+				Eventually(func() (exists bool, err error) {
+					err = infra.KCP().Client().Get(infra.Ctx(), client.ObjectKeyFromObject(gcpNfsInstance), gcpNfsInstance)
+					if err != nil {
+						return false, err
+					}
+					exists = gcpNfsInstance.Status.State == client2.SyncFilestore
+					return exists, nil
+				}, timeout, interval).
+					Should(BeTrue(), "expected NfsInstance for GCP with SyncFilestore state")
+				//Expect(gcpNfsInstance.Status.State).To(Equal(client2.SyncFilestore))
+			})
+			By("And KCP NfsVolume will get Error condition", func() {
+				Expect(meta.IsStatusConditionTrue(gcpNfsInstance.Status.Conditions, cloudcontrolv1beta1.ConditionTypeError)).To(BeTrue())
+			})
+		})
+		It("GCP NFSVolume Creation Operation Failure", func() {
+			By("Given KCP NfsVolume is created", func() {
+			})
+			By("And Filestore creation submitted", func() {
+				infra.GcpMock().SetCreateError(nil)
+			})
+			By("When creation operation fails", func() {
+				infra.GcpMock().SetOperationError(sample500Error())
+			})
+			By("Then KCP NfsVolume will get Error condition", func() {
+				Eventually(func() (exists bool, err error) {
+					err = infra.KCP().Client().Get(infra.Ctx(), client.ObjectKeyFromObject(gcpNfsInstance), gcpNfsInstance)
+					if err != nil {
+						return false, err
+					}
+					exists = meta.IsStatusConditionTrue(gcpNfsInstance.Status.Conditions, cloudcontrolv1beta1.ConditionTypeError)
+					return exists, nil
+				}, timeout, interval).
+					Should(BeTrue(), "expected NfsInstance for GCP with Error condition")
+			})
+			By("And KCP NfsVolume has SyncFilestore state", func() {
+				Expect(gcpNfsInstance.Status.State).To(Equal(client2.SyncFilestore))
+			})
+
+		})
+		It("GCP NFSVolume Update call Failure", func() {
+			By("Given KCP NfsVolume has ready condition", func() {
+				infra.GcpMock().SetOperationError(nil)
+				Eventually(func() (exists bool, err error) {
+					err = infra.KCP().Client().Get(infra.Ctx(), client.ObjectKeyFromObject(gcpNfsInstance), gcpNfsInstance)
+					if err != nil {
+						return false, err
+					}
+					exists = meta.IsStatusConditionTrue(gcpNfsInstance.Status.Conditions, cloudcontrolv1beta1.ConditionTypeReady)
+					return exists, nil
+				}, timeout, interval).
+					Should(BeTrue(), "expected NfsInstance for GCP with Ready condition")
+			})
+			By("When KCP NfsVolume is updated", func() {
+				infra.GcpMock().SetPatchError(sample500Error())
+				Eventually(UpdateNfsInstance).
+					WithArguments(
+						infra.Ctx(), infra.KCP().Client(), gcpNfsInstance,
+					).
+					Should(Succeed())
+			})
+			By("And FileStore patch request fails", func() {
+			})
+			By("Then KCP NfsVolume will get Error condition", func() {
+				Eventually(func() (exists bool, err error) {
+					err = infra.KCP().Client().Get(infra.Ctx(), client.ObjectKeyFromObject(gcpNfsInstance), gcpNfsInstance)
+					if err != nil {
+						return false, err
+					}
+					exists = meta.IsStatusConditionTrue(gcpNfsInstance.Status.Conditions, cloudcontrolv1beta1.ConditionTypeError)
+					return exists, nil
+				}, timeout, interval).
+					Should(BeTrue(), "expected NfsInstance for GCP with Error condition")
+			})
+			By("And KCP NfsVolume has SyncFilestore state", func() {
+				Expect(gcpNfsInstance.Status.State).To(Equal(client2.SyncFilestore))
+			})
+
+		})
+		It("GCP NFSVolume Update Operation Failure", func() {
+			By("Given NfsVolume is updated", func() {
+				// Already updated. No need to call again
+			})
+			By("And Filestore patch request submitted", func() {
+				infra.GcpMock().SetPatchError(nil)
+			})
+			By("When Filestore patch operation fails", func() {
+				infra.GcpMock().SetOperationError(sample500Error())
+			})
+			By("Then KCP NfsVolume will get Error condition", func() {
+				Eventually(func() (exists bool, err error) {
+					err = infra.KCP().Client().Get(infra.Ctx(), client.ObjectKeyFromObject(gcpNfsInstance), gcpNfsInstance)
+					if err != nil {
+						return false, err
+					}
+					exists = meta.IsStatusConditionTrue(gcpNfsInstance.Status.Conditions, cloudcontrolv1beta1.ConditionTypeError)
+					return exists, nil
+				}, timeout, interval).
+					Should(BeTrue(), "expected NfsInstance for GCP with Error condition")
+			})
+			By("And KCP NfsVolume has SyncFilestore state", func() {
+				Expect(gcpNfsInstance.Status.State).To(Equal(client2.SyncFilestore))
+			})
+
+		})
+		It("GCP NFSVolume Delete call Failure", func() {
+			By("Given KCP NfsVolume has ready condition", func() {
+				infra.GcpMock().SetOperationError(nil)
+				Eventually(func() (exists bool, err error) {
+					err = infra.KCP().Client().Get(infra.Ctx(), client.ObjectKeyFromObject(gcpNfsInstance), gcpNfsInstance)
+					if err != nil {
+						return false, err
+					}
+					exists = meta.IsStatusConditionTrue(gcpNfsInstance.Status.Conditions, cloudcontrolv1beta1.ConditionTypeReady)
+					return exists, nil
+				}, timeout, interval).
+					Should(BeTrue(), "expected NfsInstance for GCP with Ready condition")
+			})
+			By("When KCP NfsVolume is deleted", func() {
+				infra.GcpMock().SetDeleteError(sample500Error())
+				Eventually(DeleteNfsInstance).
+					WithArguments(
+						infra.Ctx(), infra.KCP().Client(), gcpNfsInstance,
+					).
+					Should(Succeed())
+			})
+			By("And Delete patch request fails", func() {
+				// We set the DeleteError on mock client to simulate the failure
+			})
+			By("Then KCP NfsVolume will get Error condition", func() {
+				Eventually(func() (exists bool, err error) {
+					err = infra.KCP().Client().Get(infra.Ctx(), client.ObjectKeyFromObject(gcpNfsInstance), gcpNfsInstance)
+					if err != nil {
+						return false, err
+					}
+					exists = meta.IsStatusConditionTrue(gcpNfsInstance.Status.Conditions, cloudcontrolv1beta1.ConditionTypeError)
+					return exists, nil
+				}, timeout, interval).
+					Should(BeTrue(), "expected NfsInstance for GCP with Error condition")
+			})
+			By("And KCP NfsVolume has SyncFilestore state", func() {
+				Expect(gcpNfsInstance.Status.State).To(Equal(client2.SyncFilestore))
+			})
+
+		})
+		It("GCP NFSVolume Delete Operation Failure", func() {
+			By("Given NfsVolume is deleted", func() {
+				// Already updated. No need to call again
+			})
+			By("And Filestore delete request submitted", func() {
+				infra.GcpMock().SetPatchError(nil)
+			})
+			By("When Filestore delete operation fails", func() {
+				infra.GcpMock().SetOperationError(sample500Error())
+			})
+			By("Then KCP NfsVolume will get Error condition", func() {
+				Eventually(func() (exists bool, err error) {
+					err = infra.KCP().Client().Get(infra.Ctx(), client.ObjectKeyFromObject(gcpNfsInstance), gcpNfsInstance)
+					if err != nil {
+						return false, err
+					}
+					exists = meta.IsStatusConditionTrue(gcpNfsInstance.Status.Conditions, cloudcontrolv1beta1.ConditionTypeError)
+					return exists, nil
+				}, timeout, interval).
+					Should(BeTrue(), "expected NfsInstance for GCP with Error condition")
+			})
+			By("And KCP NfsVolume has SyncFilestore state", func() {
+				Expect(gcpNfsInstance.Status.State).To(Equal(client2.SyncFilestore))
+			})
+			// Let it be deleted
+			infra.GcpMock().SetOperationError(nil)
+		})
+
+	})
 })
+
+func sample500Error() *googleapi.Error {
+	return &googleapi.Error{Code: 500, Message: "Internal Server Error"}
+}

--- a/pkg/kcp/provider/gcp/mock/nfsStore.go
+++ b/pkg/kcp/provider/gcp/mock/nfsStore.go
@@ -11,10 +11,18 @@ import (
 )
 
 type nfsStore struct {
-	instances []*file.Instance
+	instances      []*file.Instance
+	createError    *googleapi.Error
+	patchError     *googleapi.Error
+	deleteError    *googleapi.Error
+	getError       *googleapi.Error
+	operationError *googleapi.Error
 }
 
 func (s *nfsStore) GetFilestoreInstance(ctx context.Context, projectId, location, instanceId string) (*file.Instance, error) {
+	if s.getError != nil {
+		return nil, s.getError
+	}
 	if isContextCanceled(ctx) {
 		return nil, context.Canceled
 	}
@@ -36,6 +44,9 @@ func (s *nfsStore) GetFilestoreInstance(ctx context.Context, projectId, location
 	}
 }
 func (s *nfsStore) CreateFilestoreInstance(ctx context.Context, projectId, location, instanceId string, instance *file.Instance) (*file.Operation, error) {
+	if s.createError != nil {
+		return nil, s.createError
+	}
 	if isContextCanceled(ctx) {
 		return nil, context.Canceled
 	}
@@ -44,12 +55,23 @@ func (s *nfsStore) CreateFilestoreInstance(ctx context.Context, projectId, locat
 
 	completeId := fmt.Sprintf("projects/%s/locations/%s/instances/%s", projectId, location, instanceId)
 	instance.Name = completeId
+	for _, existing := range s.instances {
+		if existing.Name == completeId {
+			return nil, &googleapi.Error{
+				Code:    409,
+				Message: "Resource already exists",
+			}
+		}
+	}
 	s.instances = append(s.instances, instance)
 	logger.WithName("CreateFilestoreInstance - mock").Info(fmt.Sprintf("Length :: %d", len(s.instances)))
 
 	return newOperation("", false), nil
 }
 func (s *nfsStore) DeleteFilestoreInstance(ctx context.Context, projectId, location, instanceId string) (*file.Operation, error) {
+	if s.deleteError != nil {
+		return nil, s.deleteError
+	}
 	if isContextCanceled(ctx) {
 		return nil, context.Canceled
 	}
@@ -60,15 +82,21 @@ func (s *nfsStore) DeleteFilestoreInstance(ctx context.Context, projectId, locat
 	for i, instance := range s.instances {
 		if completeId == instance.Name {
 			s.instances = append(s.instances[:i], s.instances[i+1:]...)
-			break
+			logger.WithName("DeleteFilestoreInstance - mock").Info(fmt.Sprintf("Length :: %d", len(s.instances)))
+			return newOperation("", false), nil
 		}
 	}
+	return nil, &googleapi.Error{
+		Code:    404,
+		Message: "Resource not found",
+	}
 
-	logger.WithName("DeleteFilestoreInstance - mock").Info(fmt.Sprintf("Length :: %d", len(s.instances)))
-	return newOperation("", false), nil
 }
 
 func (s *nfsStore) GetFilestoreOperation(ctx context.Context, _, operationName string) (*file.Operation, error) {
+	if s.operationError != nil {
+		return nil, s.operationError
+	}
 	if isContextCanceled(ctx) {
 		return nil, context.Canceled
 	}
@@ -76,6 +104,9 @@ func (s *nfsStore) GetFilestoreOperation(ctx context.Context, _, operationName s
 	return &file.Operation{Name: operationName, Done: true}, nil
 }
 func (s *nfsStore) PatchFilestoreInstance(ctx context.Context, projectId, location, instanceId, updateMask string, instance *file.Instance) (*file.Operation, error) {
+	if s.patchError != nil {
+		return nil, s.patchError
+	}
 	if isContextCanceled(ctx) {
 		return nil, context.Canceled
 	}

--- a/pkg/kcp/provider/gcp/mock/server.go
+++ b/pkg/kcp/provider/gcp/mock/server.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	iprangeclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/iprange/client"
 	nfsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsinstance/client"
+	"google.golang.org/api/googleapi"
 )
 
 var _ Server = &server{}
@@ -20,6 +21,26 @@ func New() Server {
 type server struct {
 	*iprangeStore
 	*nfsStore
+}
+
+func (s *server) SetCreateError(error *googleapi.Error) {
+	s.createError = error
+}
+
+func (s *server) SetPatchError(error *googleapi.Error) {
+	s.patchError = error
+}
+
+func (s *server) SetDeleteError(error *googleapi.Error) {
+	s.deleteError = error
+}
+
+func (s *server) SetGetError(error *googleapi.Error) {
+	s.getError = error
+}
+
+func (s *server) SetOperationError(error *googleapi.Error) {
+	s.operationError = error
 }
 
 func (s *server) ServiceNetworkingClientProvider() client.ClientProvider[iprangeclient.ServiceNetworkingClient] {

--- a/pkg/kcp/provider/gcp/mock/type.go
+++ b/pkg/kcp/provider/gcp/mock/type.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	iprangeclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/iprange/client"
 	nfsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsinstance/client"
+	"google.golang.org/api/googleapi"
 )
 
 type IpRangeClient interface {
@@ -26,8 +27,19 @@ type Providers interface {
 	FilestoreClientProvider() client.ClientProvider[nfsclient.FilestoreClient]
 }
 
+// ClientErrors is an interface for setting errors on the mock client to simulate Hyperscaler API errors
+type ClientErrors interface {
+	SetCreateError(error *googleapi.Error)
+	SetPatchError(error *googleapi.Error)
+	SetDeleteError(error *googleapi.Error)
+	SetGetError(error *googleapi.Error)
+	SetOperationError(error *googleapi.Error)
+}
+
 type Server interface {
 	Clients
 
 	Providers
+
+	ClientErrors
 }

--- a/pkg/testinfra/dsl/nfsInstance.go
+++ b/pkg/testinfra/dsl/nfsInstance.go
@@ -79,6 +79,22 @@ func WithNfsInstanceScope(scopeName string) ObjAction {
 	}
 }
 
+func WithRemoteRef(name string) ObjAction {
+	remoteRef := &cloudcontrolv1beta1.RemoteRef{
+		Name:      name,
+		Namespace: DefaultSkrNamespace,
+	}
+	return &objAction{
+		f: func(obj client.Object) {
+			if x, ok := obj.(*cloudcontrolv1beta1.NfsInstance); ok {
+				x.Spec.RemoteRef = *remoteRef
+				return
+			}
+			panic("unhandled type in WithNfsInstanceScope")
+		},
+	}
+}
+
 func CreateNfsInstance(ctx context.Context, clnt client.Client, obj *cloudcontrolv1beta1.NfsInstance, opts ...ObjAction) error {
 	if obj == nil {
 		obj = &cloudcontrolv1beta1.NfsInstance{}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- adding negative automated test for gcp nfs instance
- enhancing mocks to return specified errors to simulate Filestore API errors
- Refactoring KCP GCP NfsInstance tests into limited It() to obtain better log in case of an error

**Related issue(s)**
https://jira.tools.sap/browse/PHX-47
