### PR TITLE
GcpNfsVolume Reconciler Unit Tests

### DIFF
--- a/pkg/skr/gcpnfsvolume/deleteKcpNfsInstance_test.go
+++ b/pkg/skr/gcpnfsvolume/deleteKcpNfsInstance_test.go
@@ -1,0 +1,114 @@
+package gcpnfsvolume
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+	"time"
+)
+
+type deleteKcpNfsInstanceSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *deleteKcpNfsInstanceSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *deleteKcpNfsInstanceSuite) TestWhenNfsVolumeNotDeleting() {
+	factory, err := newTestStateFactory()
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state := factory.newState()
+
+	//Call deleteKcpNfsInstance method.
+	err, _ctx := deleteKcpNfsInstance(ctx, state)
+
+	//validate expected return values
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), _ctx)
+
+	//Validate the NfsInstance object is not deleted.
+	nfsInstance := cloudcontrolv1beta1.NfsInstance{}
+	err = factory.kcpCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: gcpNfsVolume.Status.Id,
+			Namespace: kymaRef.Namespace},
+		&nfsInstance)
+	assert.Nil(suite.T(), err)
+	assert.True(suite.T(), nfsInstance.DeletionTimestamp.IsZero())
+}
+
+func (suite *deleteKcpNfsInstanceSuite) TestWhenNfsVolumeIsDeleting() {
+	factory, err := newTestStateFactory()
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state := factory.newStateWith(&deletedGcpNfsVolume)
+	state.KcpNfsInstance = &gcpNfsInstanceToDelete
+
+	//Call deleteKcpNfsInstance method.
+	err, _ctx := deleteKcpNfsInstance(ctx, state)
+
+	//validate expected return values
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(3*time.Second), err)
+	assert.Nil(suite.T(), _ctx)
+
+	//Validate the NfsInstance object is not deleted.
+	nfsInstance := cloudcontrolv1beta1.NfsInstance{}
+	err = factory.kcpCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: deletedGcpNfsVolume.Status.Id,
+			Namespace: kymaRef.Namespace},
+		&nfsInstance)
+	assert.Nil(suite.T(), err)
+	assert.False(suite.T(), nfsInstance.DeletionTimestamp.IsZero())
+}
+
+func (suite *deleteKcpNfsInstanceSuite) TestWhenKcpNfsInstanceDoNotExist() {
+	factory, err := newTestStateFactory()
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	nfsVol := cloudresourcesv1beta1.GcpNfsVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "not-matching-gcp-nfs-volume",
+			Namespace: "test",
+			DeletionTimestamp: &metav1.Time{
+				Time: time.Now(),
+			},
+		},
+		Status: cloudresourcesv1beta1.GcpNfsVolumeStatus{
+			Id: "not-matching-gcp-nfs-instance",
+		},
+	}
+	state := factory.newStateWith(&nfsVol)
+
+	//Call deleteKcpNfsInstance method.
+	err, _ctx := deleteKcpNfsInstance(ctx, state)
+
+	//validate expected return values
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), _ctx)
+}
+
+func TestDeleteKcpNfsInstanceSuite(t *testing.T) {
+	suite.Run(t, new(deleteKcpNfsInstanceSuite))
+}

--- a/pkg/skr/gcpnfsvolume/deletePersistenceVolume_test.go
+++ b/pkg/skr/gcpnfsvolume/deletePersistenceVolume_test.go
@@ -1,0 +1,193 @@
+package gcpnfsvolume
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+	"time"
+)
+
+type deletePersistenceVolumeSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *deletePersistenceVolumeSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *deletePersistenceVolumeSuite) TestWhenNfsVolumeNotDeleting() {
+	factory, err := newTestStateFactory()
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Create PV
+	pv := pvGcpNfsVolume.DeepCopy()
+	err = factory.skrCluster.K8sClient().Create(ctx, pv)
+	assert.Nil(suite.T(), err)
+
+	//Get state object with GcpNfsVolume
+	state := factory.newState()
+	state.PV = pv
+
+	//Call deletePersistenceVolume.
+	err, _ctx := deletePersistenceVolume(ctx, state)
+
+	//validate expected return values
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), _ctx)
+
+	//Validate the PV is not deleted.
+	pv = &v1.PersistentVolume{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: pvGcpNfsVolume.Name}, pv)
+	assert.Nil(suite.T(), err)
+	assert.True(suite.T(), pv.DeletionTimestamp.IsZero())
+}
+
+func (suite *deletePersistenceVolumeSuite) TestWhenNfsVolumeIsDeleting() {
+	factory, err := newTestStateFactory()
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Create PV
+	pv := pvDeletingGcpNfsVolume.DeepCopy()
+	err = factory.skrCluster.K8sClient().Create(ctx, pv)
+	assert.Nil(suite.T(), err)
+
+	//Get state object with GcpNfsVolume
+	state := factory.newStateWith(&deletedGcpNfsVolume)
+	state.PV = &pvDeletingGcpNfsVolume
+
+	//Call deletePersistenceVolume method.
+	err, _ctx := deletePersistenceVolume(ctx, state)
+
+	//validate expected return values
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(3*time.Second), err)
+	assert.Nil(suite.T(), _ctx)
+
+	//Validate the PV object is not deleted.
+	pv = &v1.PersistentVolume{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: pvDeletingGcpNfsVolume.Name}, pv)
+	assert.Nil(suite.T(), err)
+	assert.False(suite.T(), pv.DeletionTimestamp.IsZero())
+}
+
+func (suite *deletePersistenceVolumeSuite) TestWhenPVDoNotExist() {
+	factory, err := newTestStateFactory()
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state := factory.newState()
+
+	//Call deletePersistenceVolume method.
+	err, _ctx := deletePersistenceVolume(ctx, state)
+
+	//validate expected return values
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), _ctx)
+}
+
+func (suite *deletePersistenceVolumeSuite) TestWhenPVHasWrongPhase() {
+	factory, err := newTestStateFactory()
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Create PV
+	pv := pvDeletingGcpNfsVolume.DeepCopy()
+	pv.Status.Phase = "Bound"
+	err = factory.skrCluster.K8sClient().Create(ctx, pv)
+	assert.Nil(suite.T(), err)
+
+	//Get state object with GcpNfsVolume
+	state := factory.newStateWith(&deletedGcpNfsVolume)
+	state.PV = pv
+
+	//Call deletePersistenceVolume method.
+	err, _ctx := deletePersistenceVolume(ctx, state)
+
+	//validate expected return values
+	assert.Equal(suite.T(), composed.StopAndForget, err)
+	assert.Nil(suite.T(), _ctx)
+
+	//Validate the Error Status is removed.
+	nfsVolume := cloudresourcesv1beta1.GcpNfsVolume{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: deletedGcpNfsVolume.Name, Namespace: deletedGcpNfsVolume.Namespace},
+		&nfsVolume)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), 1, len(nfsVolume.Status.Conditions))
+}
+
+func (suite *deletePersistenceVolumeSuite) TestWhenPVBecomesReadyToDelete() {
+	factory, err := newTestStateFactory()
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Create PV with Available Phase
+	pv := pvDeletingGcpNfsVolume.DeepCopy()
+	err = factory.skrCluster.K8sClient().Create(ctx, pv)
+	assert.Nil(suite.T(), err)
+
+	//Add Error Condition to GcpNfsVolume.
+	nfsVolume := cloudresourcesv1beta1.GcpNfsVolume{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: deletedGcpNfsVolume.Name, Namespace: deletedGcpNfsVolume.Namespace},
+		&nfsVolume)
+	assert.Nil(suite.T(), err)
+	nfsVolume.Status.Conditions = []metav1.Condition{
+		{
+			Type:    cloudresourcesv1beta1.ConditionTypeError,
+			Status:  "True",
+			Reason:  cloudresourcesv1beta1.ConditionReasonPVNotReadyForDeletion,
+			Message: "test",
+		},
+	}
+
+	//Update status
+	err = factory.skrCluster.K8sClient().Status().Update(ctx, &nfsVolume)
+	assert.Nil(suite.T(), err)
+
+	//Get state object with GcpNfsVolume
+	state := factory.newStateWith(&nfsVolume)
+	state.PV = pv
+
+	//Call deletePersistenceVolume method.
+	err, _ctx := deletePersistenceVolume(ctx, state)
+
+	//validate expected return values
+	assert.Equal(suite.T(), composed.StopWithRequeue, err)
+	assert.Nil(suite.T(), _ctx)
+
+	//Validate the Error Status is removed.
+	nfsVolume = cloudresourcesv1beta1.GcpNfsVolume{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: deletedGcpNfsVolume.Name, Namespace: deletedGcpNfsVolume.Namespace},
+		&nfsVolume)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), 0, len(nfsVolume.Status.Conditions))
+}
+
+func TestDeletePersistenceVolumeSuite(t *testing.T) {
+	suite.Run(t, new(deletePersistenceVolumeSuite))
+}

--- a/pkg/skr/gcpnfsvolume/loadKcpIpRange_test.go
+++ b/pkg/skr/gcpnfsvolume/loadKcpIpRange_test.go
@@ -3,7 +3,6 @@ package gcpnfsvolume
 import (
 	"context"
 	"github.com/go-logr/logr"
-	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -12,16 +11,16 @@ import (
 	"testing"
 )
 
-type loadKcpNfsInstanceSuite struct {
+type loadKcpIpRangeSuite struct {
 	suite.Suite
 	ctx context.Context
 }
 
-func (suite *loadKcpNfsInstanceSuite) SetupTest() {
+func (suite *loadKcpIpRangeSuite) SetupTest() {
 	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
 }
 
-func (suite *loadKcpNfsInstanceSuite) TestWithMatchingNfsInstance() {
+func (suite *loadKcpIpRangeSuite) TestWithMatchingIpRange() {
 	factory, err := newTestStateFactory()
 	assert.Nil(suite.T(), err)
 
@@ -31,23 +30,32 @@ func (suite *loadKcpNfsInstanceSuite) TestWithMatchingNfsInstance() {
 	//Get state object with GcpNfsVolume
 	state := factory.newState()
 
-	err, _ctx := loadKcpNfsInstance(ctx, state)
+	//Add an IPRange to KCP.
+	ipRange := kcpIpRange.DeepCopy()
+	err = factory.kcpCluster.K8sClient().Create(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	err, _ctx := loadKcpIpRange(ctx, state)
 
 	//validate expected return values
 	assert.Nil(suite.T(), err)
 	assert.Nil(suite.T(), _ctx)
 
-	//Validate the NfsInstance object
-	assert.NotNil(suite.T(), state.KcpNfsInstance)
-	assert.Equal(suite.T(), gcpNfsVolume.Status.Id, state.KcpNfsInstance.Name)
+	//Validate the IpRange object
+	assert.NotNil(suite.T(), state.KcpIpRange)
 }
 
-func (suite *loadKcpNfsInstanceSuite) TestWithNotMatchingNfsInstance() {
+func (suite *loadKcpIpRangeSuite) TestWithNotMatchingIpRange() {
 	factory, err := newTestStateFactory()
 	assert.Nil(suite.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	//Add an IPRange to KCP.
+	ipRange := kcpIpRange.DeepCopy()
+	err = factory.kcpCluster.K8sClient().Create(ctx, ipRange)
+	assert.Nil(suite.T(), err)
 
 	//Get state object with GcpNfsVolume
 	nfsVol := cloudresourcesv1beta1.GcpNfsVolume{
@@ -58,51 +66,47 @@ func (suite *loadKcpNfsInstanceSuite) TestWithNotMatchingNfsInstance() {
 	}
 	state := factory.newStateWith(&nfsVol)
 
-	err, _ctx := loadKcpNfsInstance(ctx, state)
+	err, _ctx := loadKcpIpRange(ctx, state)
 
 	//validate expected return values
 	assert.Nil(suite.T(), err)
 	assert.Nil(suite.T(), _ctx)
 
-	//Validate the NfsInstance object
-	assert.Nil(suite.T(), state.KcpNfsInstance)
+	//Validate the IpRange object
+	assert.Nil(suite.T(), state.KcpIpRange)
 }
 
-func (suite *loadKcpNfsInstanceSuite) TestWithMultipleMatchingNfsInstances() {
+func (suite *loadKcpIpRangeSuite) TestWithMultipleMatchingIpRanges() {
 	factory, err := newTestStateFactory()
 	assert.Nil(suite.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	//Get NfsInstance2 object from KcpCluster
-	nfsInstance2 := cloudcontrolv1beta1.NfsInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-gcp-nfs-volume-2",
-			Namespace: kymaRef.Namespace,
-			Labels: map[string]string{
-				cloudcontrolv1beta1.LabelKymaName:        kymaRef.Name,
-				cloudcontrolv1beta1.LabelRemoteName:      "test-gcp-nfs-volume",
-				cloudcontrolv1beta1.LabelRemoteNamespace: "test",
-			},
-		},
-	}
-	err = factory.kcpCluster.K8sClient().Create(ctx, &nfsInstance2)
+	//Add an IPRange to KCP.
+	ipRange := kcpIpRange.DeepCopy()
+	err = factory.kcpCluster.K8sClient().Create(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Add another IPRange to KCP.
+	ipRange2 := kcpIpRange.DeepCopy()
+	ipRange2.Name = "test-ip-range-2"
+	err = factory.kcpCluster.K8sClient().Create(ctx, ipRange2)
 	assert.Nil(suite.T(), err)
 
 	//Get state object with GcpNfsVolume
 	state := factory.newState()
 
-	err, _ctx := loadKcpNfsInstance(ctx, state)
+	err, _ctx := loadKcpIpRange(ctx, state)
 
 	//validate expected return values
 	assert.Nil(suite.T(), err)
 	assert.Nil(suite.T(), _ctx)
 
-	//Validate the NfsInstance object
-	assert.NotNil(suite.T(), state.KcpNfsInstance)
+	//Validate the IpRange object
+	assert.NotNil(suite.T(), state.KcpIpRange)
 }
 
-func TestLoadKcpNfsInstanceSuite(t *testing.T) {
-	suite.Run(t, new(loadKcpNfsInstanceSuite))
+func TestLoadKcpIpRangeSuite(t *testing.T) {
+	suite.Run(t, new(loadKcpIpRangeSuite))
 }


### PR DESCRIPTION
**Description**

GcpNfsVolume Reconciler Unit Tests for
- Delete KCP NfsInstance
- Delete PV
- Load KCP IPRange
- Load KCP NfsInstance
- Load PV

**Related issue(s)**
https://jira.tools.sap/projects/PHX/issues/PHX-52