### PR TITLE
AwsNfsVolume deprovisioning

### DIFF
--- a/api/cloud-resources/v1beta1/condition.go
+++ b/api/cloud-resources/v1beta1/condition.go
@@ -19,3 +19,10 @@ const (
 	// ConditionReasonIpRangeNotFound used with ConditionTypeError in case IpRange specified in object does not exist
 	ConditionReasonIpRangeNotFound = "IpRangeNotFound"
 )
+
+const (
+	ConditionTypeDeleting = "Deleting"
+
+	ConditionReasonDeletingPV       = "DeletingPersistentVolume"
+	ConditionReasonDeletingInstance = "DeletingInstance"
+)

--- a/api/cloud-resources/v1beta1/labels.go
+++ b/api/cloud-resources/v1beta1/labels.go
@@ -1,7 +1,8 @@
 package v1beta1
 
 const (
-	LabelId         = "cloud-resources.kyma-project.io/id"
-	LabelNfsVolName = "cloud-resources.kyma-project.io/nfsVolumeName"
-	LabelNfsVolNS   = "cloud-resources.kyma-project.io/nfsVolumeNamespace"
+	LabelCloudManaged = "cloud-resources.kyma-project.io/managed"
+	LabelId           = "cloud-resources.kyma-project.io/id"
+	LabelNfsVolName   = "cloud-resources.kyma-project.io/nfsVolumeName"
+	LabelNfsVolNS     = "cloud-resources.kyma-project.io/nfsVolumeNamespace"
 )

--- a/internal/controller/cloud-resources/awsnfsvolume_test.go
+++ b/internal/controller/cloud-resources/awsnfsvolume_test.go
@@ -10,22 +10,20 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("Created SKR AwsNfsVolume is projected into KCP and it gets Ready condition and PV created", Ordered, func() {
+var _ = Describe("Feature: SKR AwsNfsVolume", func() {
 
-	Context("Given SKR Cluster", Ordered, func() {
-
-		It("And Given SKR namespace exists", func() {
-			Eventually(CreateNamespace).
-				WithArguments(infra.Ctx(), infra.SKR().Client(), &corev1.Namespace{}).
-				Should(Succeed())
-		})
+	It("Scenario: SKR AwsNfsVolume is created", func() {
 
 		skrIpRangeName := "aws-nfs-iprange-1"
 		skrIpRange := &cloudresourcesv1beta1.IpRange{}
 		skrIpRangeId := "db018167-dd48-4d8c-aa3c-ea9e2ed05307"
 
-		It("And Given SKR IpRange exists", func() {
-
+		By("Given SKR namespace exists", func() {
+			Eventually(CreateNamespace).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), &corev1.Namespace{}).
+				Should(Succeed())
+		})
+		By("And Given SKR IpRange exists", func() {
 			// tell skriprange reconciler to ignore this SKR IpRange
 			skriprange.Ignore.AddName(skrIpRangeName)
 
@@ -36,8 +34,7 @@ var _ = Describe("Created SKR AwsNfsVolume is projected into KCP and it gets Rea
 				).
 				Should(Succeed())
 		})
-
-		It("And SKR IpRange has Ready condition", func() {
+		By("And Given SKR IpRange has Ready condition", func() {
 			Eventually(UpdateStatus).
 				WithArguments(
 					infra.Ctx(), infra.SKR().Client(), skrIpRange,
@@ -48,14 +45,15 @@ var _ = Describe("Created SKR AwsNfsVolume is projected into KCP and it gets Rea
 				Should(Succeed())
 		})
 
+		awsNfsVolumeName := "aws-nfs-volume-1"
 		awsNfsVolume := &cloudresourcesv1beta1.AwsNfsVolume{}
 		awsNfsVolumeCapacity := "100G"
 
-		It("When AwsNfsVolume is created", func() {
+		By("When AwsNfsVolume is created", func() {
 			Eventually(CreateAwsNfsVolume).
 				WithArguments(
 					infra.Ctx(), infra.SKR().Client(), awsNfsVolume,
-					WithName("aws-nfs-volume-1"),
+					WithName(awsNfsVolumeName),
 					WithNfsVolumeIpRange(skrIpRange.Name),
 					WithAwsNfsVolumeCapacity(awsNfsVolumeCapacity),
 				).
@@ -64,7 +62,7 @@ var _ = Describe("Created SKR AwsNfsVolume is projected into KCP and it gets Rea
 
 		kcpNfsInstance := &cloudcontrolv1beta1.NfsInstance{}
 
-		It("Then KCP NfsInstance is created", func() {
+		By("Then KCP NfsInstance is created", func() {
 			// load SKR AwsNfsVolume to get ID
 			Eventually(LoadAndCheck).
 				WithArguments(
@@ -72,7 +70,7 @@ var _ = Describe("Created SKR AwsNfsVolume is projected into KCP and it gets Rea
 					infra.SKR().Client(),
 					awsNfsVolume,
 					NewObjActions(),
-					AssertAwsNfsVolumeHasId(),
+					WhereAwsNfsVolumeHasId(),
 				).
 				Should(Succeed(), "expected SKR AwsNfsVolume to get status.id")
 
@@ -111,7 +109,7 @@ var _ = Describe("Created SKR AwsNfsVolume is projected into KCP and it gets Rea
 			Expect(kcpNfsInstance.Spec.IpRange.Name).To(Equal(skrIpRange.Status.Id))
 		})
 
-		It("When KCP NfsInstance gets Ready condition", func() {
+		By("When KCP NfsInstance has Ready condition", func() {
 			Eventually(UpdateStatus).
 				WithArguments(
 					infra.Ctx(),
@@ -123,7 +121,7 @@ var _ = Describe("Created SKR AwsNfsVolume is projected into KCP and it gets Rea
 				Should(Succeed())
 		})
 
-		It("Then SKR AwsNfsVolume will get Ready condition", func() {
+		By("Then SKR AwsNfsVolume has Ready condition", func() {
 			Eventually(LoadAndCheck).
 				WithArguments(
 					infra.Ctx(),
@@ -136,7 +134,7 @@ var _ = Describe("Created SKR AwsNfsVolume is projected into KCP and it gets Rea
 		})
 
 		pv := &corev1.PersistentVolume{}
-		It("And Then SKR PersistentVolume will be created", func() {
+		By("And Then SKR PersistentVolume is created", func() {
 			Eventually(LoadAndCheck).
 				WithArguments(
 					infra.Ctx(),
@@ -149,6 +147,141 @@ var _ = Describe("Created SKR AwsNfsVolume is projected into KCP and it gets Rea
 				Should(Succeed())
 		})
 
+		By("And Then SKR PersistentVolume has owner reference", func() {
+			Expect(pv.OwnerReferences).To(HaveLen(1), "expected PV to have one owner reference")
+			ref := pv.OwnerReferences[0]
+			Expect(ref.Kind).To(Equal("AwsNfsVolume"))
+			Expect(ref.Name).To(Equal(awsNfsVolume.Name))
+			Expect(ref.UID).To(Equal(awsNfsVolume.UID))
+		})
 	})
 
+	It("Scenario: SKR AwsNfsVolume is deleted", func() {
+
+		skrIpRangeName := "aws-nfs-iprange-2"
+		skrIpRange := &cloudresourcesv1beta1.IpRange{}
+		skrIpRangeId := "034fd495-3222-465c-8dc9-4617f7ff0013"
+
+		By("Given SKR namespace exists", func() {
+			Eventually(CreateNamespace).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), &corev1.Namespace{}).
+				Should(Succeed())
+		})
+		By("And Given SKR IpRange exists", func() {
+			// tell skriprange reconciler to ignore this SKR IpRange
+			skriprange.Ignore.AddName(skrIpRangeName)
+
+			Eventually(CreateSkrIpRange).
+				WithArguments(
+					infra.Ctx(), infra.SKR().Client(), skrIpRange,
+					WithName(skrIpRangeName),
+				).
+				Should(Succeed())
+		})
+		By("And Given SKR IpRange has Ready condition", func() {
+			Eventually(UpdateStatus).
+				WithArguments(
+					infra.Ctx(), infra.SKR().Client(), skrIpRange,
+					WithSkrIpRangeStatusCidr(skrIpRange.Spec.Cidr),
+					WithSkrIpRangeStatusId(skrIpRangeId),
+					WithConditions(SkrReadyCondition()),
+				).
+				Should(Succeed())
+		})
+
+		awsNfsVolumeName := "aws-nfs-volume-2"
+		awsNfsVolume := &cloudresourcesv1beta1.AwsNfsVolume{}
+		awsNfsVolumeCapacity := "100G"
+
+		By("And Given AwsNfsVolume is created", func() {
+			Eventually(CreateAwsNfsVolume).
+				WithArguments(
+					infra.Ctx(), infra.SKR().Client(), awsNfsVolume,
+					WithName(awsNfsVolumeName),
+					WithNfsVolumeIpRange(skrIpRange.Name),
+					WithAwsNfsVolumeCapacity(awsNfsVolumeCapacity),
+				).
+				Should(Succeed())
+		})
+
+		kcpNfsInstance := &cloudcontrolv1beta1.NfsInstance{}
+
+		By("And Given KCP NfsInstance is created", func() {
+			// load SKR AwsNfsVolume to get ID
+			Eventually(LoadAndCheck).
+				WithArguments(
+					infra.Ctx(),
+					infra.SKR().Client(),
+					awsNfsVolume,
+					NewObjActions(),
+					WhereAwsNfsVolumeHasId(),
+				).
+				Should(Succeed(), "expected SKR AwsNfsVolume to get status.id")
+
+			Eventually(LoadAndCheck).
+				WithArguments(
+					infra.Ctx(),
+					infra.KCP().Client(),
+					kcpNfsInstance,
+					NewObjActions(
+						WithName(awsNfsVolume.Status.Id),
+					),
+				).
+				Should(Succeed())
+		})
+
+		By("And Given KCP NfsInstance has Ready condition", func() {
+			Eventually(UpdateStatus).
+				WithArguments(
+					infra.Ctx(),
+					infra.KCP().Client(),
+					kcpNfsInstance,
+					WithNfsInstanceStatusHost(""),
+					WithConditions(KcpReadyCondition()),
+				).
+				Should(Succeed(), "failed setting KCP NfsInstance Ready condition")
+		})
+
+		By("And Given SKR AwsNfsVolume has Ready condition", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(
+					infra.Ctx(),
+					infra.SKR().Client(),
+					awsNfsVolume,
+					NewObjActions(),
+					AssertHasConditionTrue(cloudresourcesv1beta1.ConditionTypeReady),
+				).
+				Should(Succeed(), "expected AwsNfsVolume to exist and have Ready condition")
+		})
+
+		pv := &corev1.PersistentVolume{}
+		By("And Given SKR PersistentVolume is created", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(
+					infra.Ctx(),
+					infra.SKR().Client(),
+					pv,
+					NewObjActions(
+						WithName(awsNfsVolume.Name),
+					),
+				).
+				Should(Succeed(), "failed creating PV")
+		})
+
+		// DELETE
+
+		By("When AwsNfsVolume is deleted", func() {
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), awsNfsVolume).
+				Should(Succeed(), "failed deleting PV")
+		})
+
+		By("Then SKR PersistentVolume is deleted", func() {
+			Eventually(IsDeleted).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), pv).
+				Should(Succeed(), "expected PV not to exist")
+		})
+
+		// TODO: And Then KCP NfsInstance is deleted
+	})
 })

--- a/internal/controller/cloud-resources/gcpnfsvolume_test.go
+++ b/internal/controller/cloud-resources/gcpnfsvolume_test.go
@@ -461,21 +461,21 @@ var _ = Describe("SKR GcpNfsVolume workflows", func() {
 						WithArguments(
 							infra.Ctx(), infra.SKR().Client(), pv,
 						).
-						Should(BeTrue())
+						Should(Succeed())
 					By("And the PersistentVolume in SKR is deleted.")
 
 					Eventually(IsDeleted, timeout, interval).
 						WithArguments(
 							infra.Ctx(), infra.KCP().Client(), kcpNfsInstance,
 						).
-						Should(BeTrue())
+						Should(Succeed())
 					By("And the NfsInstance in KCP is deleted.")
 
 					Eventually(IsDeleted, timeout, interval).
 						WithArguments(
 							infra.Ctx(), infra.SKR().Client(), gcpNfsVolume,
 						).
-						Should(BeTrue())
+						Should(Succeed())
 					By("And the GcpNfsVolume in SKR is deleted.")
 				})
 			})

--- a/internal/controller/cloud-resources/suite_test.go
+++ b/internal/controller/cloud-resources/suite_test.go
@@ -62,6 +62,9 @@ var _ = BeforeSuite(func() {
 		NotTo(HaveOccurred(), "failed creating namespace %s in Garden", infra.Garden().Namespace())
 
 	// Setup controllers
+	// Test Only PV Controller
+	Expect(testinfra.SetupPvController(infra.Registry())).
+		NotTo(HaveOccurred())
 	// CloudResources
 	Expect(SetupCloudResourcesReconciler(infra.Registry())).
 		NotTo(HaveOccurred())

--- a/pkg/composed/errors.go
+++ b/pkg/composed/errors.go
@@ -50,7 +50,7 @@ func IsStopWithRequeueDelay(err error) bool {
 }
 
 func IsBreak(err error) bool {
-	return err == Break
+	return errors.Is(err, Break)
 }
 
 func IsTerminal(err error) bool {

--- a/pkg/composed/updateStatus.go
+++ b/pkg/composed/updateStatus.go
@@ -29,6 +29,7 @@ type UpdateStatusBuilder struct {
 	successLogMsg      string
 	failedError        error
 	successError       error
+	successErrorNil    bool
 	updateErrorWrapper func(err error) error
 	onUpdateError      func(ctx context.Context, err error) (error, context.Context)
 	onUpdateSuccess    func(ctx context.Context) (error, context.Context)
@@ -118,6 +119,12 @@ func (b *UpdateStatusBuilder) SuccessError(err error) *UpdateStatusBuilder {
 	return b
 }
 
+func (b *UpdateStatusBuilder) SuccessErrorNil() *UpdateStatusBuilder {
+	b.successErrorNil = true
+	b.successError = nil
+	return b
+}
+
 func (b *UpdateStatusBuilder) Run(ctx context.Context, state State) (error, context.Context) {
 	b.setDefaults()
 
@@ -166,7 +173,7 @@ func (b *UpdateStatusBuilder) setDefaults() {
 		}
 	}
 
-	if b.successError == nil {
+	if b.successError == nil && !b.successErrorNil {
 		b.successError = StopAndForget
 	}
 	if b.failedError == nil {

--- a/pkg/skr/awsnfsvolume/deletePv.go
+++ b/pkg/skr/awsnfsvolume/deletePv.go
@@ -1,0 +1,50 @@
+package awsnfsvolume
+
+import (
+	"context"
+	"fmt"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func deletePv(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	if !composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
+
+	if state.Volume == nil {
+		return nil, nil
+	}
+
+	if !state.Volume.DeletionTimestamp.IsZero() {
+		return nil, nil
+	}
+
+	err, _ := composed.UpdateStatus(state.ObjAsAwsNfsVolume()).
+		SetCondition(metav1.Condition{
+			Type:    cloudresourcesv1beta1.ConditionTypeDeleting,
+			Status:  metav1.ConditionTrue,
+			Reason:  cloudresourcesv1beta1.ConditionReasonDeletingPV,
+			Message: fmt.Sprintf("Deleting PersistentVolume %s", state.Volume.Name),
+		}).
+		ErrorLogMessage("Error setting ConditionReasonDeletingPV condition on AwsNfsVolume").
+		SuccessErrorNil().
+		FailedError(composed.StopWithRequeue).
+		Run(ctx, state)
+	if err != nil {
+		return err, nil
+	}
+
+	logger.Info("Deleting PV for AwsNfsVolume")
+
+	err = state.Cluster().K8sClient().Delete(ctx, state.Volume)
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error deleting PV for AwsNfsVolume", composed.StopWithRequeue, ctx)
+	}
+
+	return composed.StopWithRequeue, nil
+}

--- a/pkg/skr/awsnfsvolume/reconciler.go
+++ b/pkg/skr/awsnfsvolume/reconciler.go
@@ -48,6 +48,12 @@ func (r *reconciler) newAction() composed.Action {
 		createKcpNfsInstance,
 		updateStatus,
 		createVolume,
+
+		deletePv,
+		waitPvDeleted,
+
+		requeueWaitKcpStatus,
+
 		composed.StopAndForgetAction,
 	)
 }

--- a/pkg/skr/awsnfsvolume/requeueWaitKcpStatus.go
+++ b/pkg/skr/awsnfsvolume/requeueWaitKcpStatus.go
@@ -1,0 +1,19 @@
+package awsnfsvolume
+
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"time"
+)
+
+func requeueWaitKcpStatus(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+
+	isBeingDeleted := composed.MarkedForDeletionPredicate(ctx, st)
+
+	if !isBeingDeleted && len(state.ObjAsAwsNfsVolume().Status.Conditions) > 0 {
+		return nil, nil
+	}
+
+	return composed.StopWithRequeueDelay(200 * time.Millisecond), nil
+}

--- a/pkg/skr/awsnfsvolume/updateStatus.go
+++ b/pkg/skr/awsnfsvolume/updateStatus.go
@@ -7,12 +7,10 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 func updateStatus(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
-
 	logger := composed.LoggerFromCtx(ctx)
 
 	kcpCondErr := meta.FindStatusCondition(state.KcpNfsInstance.Status.Conditions, cloudcontrolv1beta1.ConditionTypeError)
@@ -32,12 +30,8 @@ func updateStatus(ctx context.Context, st composed.State) (error, context.Contex
 			}).
 			RemoveConditions(cloudresourcesv1beta1.ConditionTypeReady).
 			ErrorLogMessage("Error updating KCP AwsNfsVolume status with not ready condition due to KCP error").
-			SuccessError(composed.StopAndForget). // do not continue further with the flow
+			SuccessError(composed.StopWithRequeue).
 			Run(ctx, state)
-	}
-	if kcpCondErr != nil && skrCondErr != nil {
-		// already with Error condition
-		return composed.StopAndForget, nil
 	}
 
 	if kcpCondReady != nil && skrCondReady == nil {
@@ -54,23 +48,9 @@ func updateStatus(ctx context.Context, st composed.State) (error, context.Contex
 			}).
 			RemoveConditions(cloudresourcesv1beta1.ConditionTypeError).
 			ErrorLogMessage("Error updating KCP AwsNfsVolume status with ready condition").
-			SuccessError(composed.StopWithRequeue). // have to continue and requeue to create PV
-			Run(ctx, state)
-	}
-	if kcpCondReady != nil && skrCondReady != nil {
-		// already with Ready condition
-		// continue with next actions to create PV
-		return nil, nil
-	}
-
-	if skrCondReady != nil || skrCondErr != nil {
-		state.ObjAsAwsNfsVolume().Status.Conditions = nil
-		return composed.UpdateStatus(state.ObjAsAwsNfsVolume()).
 			SuccessError(composed.StopWithRequeue).
 			Run(ctx, state)
 	}
 
-	// no conditions on KCP NfsInstance
-	// keep looping until KCP NfsInstance gets some condition
-	return composed.StopWithRequeueDelay(200 * time.Millisecond), nil
+	return nil, nil
 }

--- a/pkg/skr/awsnfsvolume/waitPvDeleted.go
+++ b/pkg/skr/awsnfsvolume/waitPvDeleted.go
@@ -1,0 +1,28 @@
+package awsnfsvolume
+
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"time"
+)
+
+func waitPvDeleted(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	if !composed.MarkedForDeletionPredicate(ctx, state) {
+		return nil, nil
+	}
+
+	logger.Info("waitPvDeleted: start")
+
+	if state.Volume == nil {
+		logger.Info("waitPvDeleted: no vol")
+		return nil, nil
+	}
+
+	logger.Info("waitPvDeleted: wait for pv is deleted")
+
+	// wait until PV does not exist
+	return composed.StopWithRequeueDelay(250 * time.Millisecond), nil
+}

--- a/pkg/testinfra/dsl/awsNfsVolume.go
+++ b/pkg/testinfra/dsl/awsNfsVolume.go
@@ -73,7 +73,7 @@ func CreateAwsNfsVolume(ctx context.Context, clnt client.Client, obj *cloudresou
 	return err
 }
 
-func AssertAwsNfsVolumeHasId() ObjAssertion {
+func WhereAwsNfsVolumeHasId() ObjAssertion {
 	return func(obj client.Object) error {
 		x, ok := obj.(*cloudresourcesv1beta1.AwsNfsVolume)
 		if !ok {

--- a/pkg/testinfra/dsl/loadAndCheck.go
+++ b/pkg/testinfra/dsl/loadAndCheck.go
@@ -5,14 +5,9 @@ import (
 	"errors"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-func Check(obj client.Object, asserts ...ObjAssertion) error {
-	err := NewObjAssertions(asserts).
-		AssertObj(obj)
-	return err
-}
 
 func LoadAndCheck(ctx context.Context, clnt client.Client, obj client.Object, loadingOps ObjActions, asserts ...ObjAssertion) error {
 	if obj == nil {
@@ -42,4 +37,37 @@ func LoadAndCheck(ctx context.Context, clnt client.Client, obj client.Object, lo
 	err := NewObjAssertions(asserts).
 		AssertObj(obj)
 	return err
+}
+
+func IsDeleted(ctx context.Context, clnt client.Client, obj client.Object, opts ...ObjAction) error {
+	if obj == nil {
+		return errors.New("the IsDeleted object can not be nil")
+	}
+
+	actions := NewObjActions(opts...)
+
+	switch obj.(type) {
+	case *cloudcontrolv1beta1.IpRange,
+		*cloudcontrolv1beta1.NfsInstance,
+		*cloudcontrolv1beta1.Scope,
+		*cloudcontrolv1beta1.VpcPeering:
+		actions = actions.Append(WithNamespace(DefaultKcpNamespace))
+	case *cloudresourcesv1beta1.IpRange,
+		*cloudresourcesv1beta1.AwsNfsVolume,
+		*cloudresourcesv1beta1.GcpNfsVolume:
+		actions = actions.Append(WithNamespace(DefaultSkrNamespace))
+	}
+
+	actions.ApplyOnObject(obj)
+
+	err := clnt.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	return errors.New("object is not deleted")
 }

--- a/pkg/testinfra/dsl/objActions.go
+++ b/pkg/testinfra/dsl/objActions.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -152,9 +151,4 @@ func Delete(ctx context.Context, client client.Client, obj client.Object) error 
 
 	err = client.Delete(ctx, obj)
 	return err
-}
-
-func IsDeleted(ctx context.Context, clnt client.Client, obj client.Object) bool {
-	err := clnt.Get(ctx, client.ObjectKeyFromObject(obj), obj)
-	return err != nil && apierrors.IsNotFound(err)
 }

--- a/pkg/testinfra/pvController.go
+++ b/pkg/testinfra/pvController.go
@@ -1,0 +1,66 @@
+package testinfra
+
+import (
+	"context"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	skrruntime "github.com/kyma-project/cloud-manager/pkg/skr/runtime"
+	reconcile2 "github.com/kyma-project/cloud-manager/pkg/skr/runtime/reconcile"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type pvControllerFactory struct{}
+
+func (f *pvControllerFactory) New(args reconcile2.ReconcilerArguments) reconcile.Reconciler {
+	return &pvController{
+		skrCluster: args.SkrCluster,
+	}
+}
+
+type pvController struct {
+	skrCluster cluster.Cluster
+}
+
+func (c *pvController) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	pv := &corev1.PersistentVolume{}
+	err := c.skrCluster.GetClient().Get(ctx, request.NamespacedName, pv)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if pv.Spec.NFS == nil {
+		return ctrl.Result{}, nil
+	}
+	isLabeled := false
+	if pv.Labels != nil {
+		_, isLabeled = pv.Labels[cloudresourcesv1beta1.LabelCloudManaged]
+	}
+	if !isLabeled {
+		return ctrl.Result{}, nil
+	}
+
+	if pv.DeletionTimestamp.IsZero() && pv.Status.Phase == corev1.VolumePending {
+		pv.Status.Phase = corev1.VolumeAvailable
+		err = c.skrCluster.GetClient().Status().Update(ctx, pv)
+		return ctrl.Result{}, err
+	}
+
+	if !pv.DeletionTimestamp.IsZero() && pv.Status.Phase == corev1.VolumeAvailable {
+		controllerutil.RemoveFinalizer(pv, "kubernetes.io/pv-protection")
+		err = c.skrCluster.GetClient().Update(ctx, pv)
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func SetupPvController(reg skrruntime.SkrRegistry) error {
+	return reg.Register().
+		WithFactory(&pvControllerFactory{}).
+		For(&corev1.PersistentVolume{}).
+		Complete()
+}

--- a/pkg/testinfra/run.go
+++ b/pkg/testinfra/run.go
@@ -68,6 +68,16 @@ func Start() (Infra, error) {
 			return nil, fmt.Errorf("error starting cluster %s: %w", name, err)
 		}
 
+		kubeconfigFilePath := filepath.Join(configDir, fmt.Sprintf("kubeconfig-%s", name))
+		b, err := kubeconfigToBytes(restConfigToKubeconfig(cfg))
+		if err != nil {
+			return nil, fmt.Errorf("error getting %s kubeconfig bytes: %w", name, err)
+		}
+		err = os.WriteFile(kubeconfigFilePath, b, 0644)
+		if err != nil {
+			return nil, fmt.Errorf("error saving %s kubeconfig: %w", name, err)
+		}
+
 		k8sClient, err := ctrlclient.New(cfg, ctrlclient.Options{Scheme: sch})
 		if err != nil {
 			return nil, fmt.Errorf("error creating client for %s: %w", name, err)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- AwsNfsVolume deprovisioning
- PvController to handle Pending phase stuck for unmountable NFS servers in tests
- Modified `testinfra/dsl/IsDeleted()` to return `error` instead of `bool` and improved it to add default namespace and support ObjActions
- Added `composed/UpdateStatusBuilder.SuccessErrorNil()` to cover the case when it has to return `nil` instead of default `StopAndForget` 
- Added kubeconfig save to `./bin/cloud-manager/config` in `testinfra.Start()` so we can block it at a breakpoint and do `KUBECONFIG=./bin/cloud-manager/config/kubeconfig-[kcp|skr|garden] kubectl something` to inspect the envtest cluster resources

Not yet done, but doing a sync due to a lot of changes and added pv-controller for tests.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
