### PR TITLE
gcp nfsInstance unit test for validateAlways

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -146,7 +146,7 @@ func main() {
 	if err = cloudcontrolcontroller.SetupNfsInstanceReconciler(
 		mgr,
 		awsnfsinstanceclient.NewClientProvider(),
-		gcpFilestoreClient.NewFilestoreClient(),
+		gcpFilestoreClient.NewFilestoreClientProvider(),
 	); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NfsInstance")
 		os.Exit(1)

--- a/pkg/kcp/nfsinstance/state.go
+++ b/pkg/kcp/nfsinstance/state.go
@@ -1,7 +1,7 @@
 package nfsinstance
 
 import (
-	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common/actions/focal"
 	"github.com/kyma-project/cloud-manager/pkg/kcp/nfsinstance/types"
 )
@@ -9,18 +9,18 @@ import (
 type state struct {
 	focal.State
 
-	ipRange *cloudresourcesv1beta1.IpRange
+	ipRange *cloudcontrolv1beta1.IpRange
 }
 
-func (s *state) ObjAsNfsInstance() *cloudresourcesv1beta1.NfsInstance {
-	return s.Obj().(*cloudresourcesv1beta1.NfsInstance)
+func (s *state) ObjAsNfsInstance() *cloudcontrolv1beta1.NfsInstance {
+	return s.Obj().(*cloudcontrolv1beta1.NfsInstance)
 }
 
-func (s *state) IpRange() *cloudresourcesv1beta1.IpRange {
+func (s *state) IpRange() *cloudcontrolv1beta1.IpRange {
 	return s.ipRange
 }
 
-func (s *state) SetIpRange(r *cloudresourcesv1beta1.IpRange) {
+func (s *state) SetIpRange(r *cloudcontrolv1beta1.IpRange) {
 	s.ipRange = r
 }
 

--- a/pkg/kcp/provider/gcp/nfsinstance/client/filestoreClient.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/client/filestoreClient.go
@@ -17,7 +17,7 @@ type FilestoreClient interface {
 	PatchFilestoreInstance(ctx context.Context, projectId, location, instanceId, updateMask string, instance *file.Instance) (*file.Operation, error)
 }
 
-func NewFilestoreClient() client.ClientProvider[FilestoreClient] {
+func NewFilestoreClientProvider() client.ClientProvider[FilestoreClient] {
 	return client.NewCachedClientProvider(
 		func(ctx context.Context, saJsonKeyPath string) (FilestoreClient, error) {
 			httpClient, err := client.GetCachedGcpClient(ctx, saJsonKeyPath)
@@ -29,12 +29,12 @@ func NewFilestoreClient() client.ClientProvider[FilestoreClient] {
 			if err != nil {
 				return nil, err
 			}
-			return newFilestoreClient(fsClient), nil
+			return NewFilestoreClient(fsClient), nil
 		},
 	)
 }
 
-func newFilestoreClient(svcFilestore *file.Service) FilestoreClient {
+func NewFilestoreClient(svcFilestore *file.Service) FilestoreClient {
 	return &filestoreClient{svcFilestore: svcFilestore}
 }
 

--- a/pkg/kcp/provider/gcp/nfsinstance/state_test.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/state_test.go
@@ -1,0 +1,243 @@
+package nfsinstance
+
+import (
+	"context"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
+	"github.com/kyma-project/cloud-manager/pkg/common/actions/focal"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	nfsTypes "github.com/kyma-project/cloud-manager/pkg/kcp/nfsinstance/types"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	client2 "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsinstance/client"
+	"google.golang.org/api/file/v1"
+	"google.golang.org/api/option"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"time"
+)
+
+var kymaRef = klog.ObjectRef{
+	Name:      "skr",
+	Namespace: "test",
+}
+
+func getDeletedGcpNfsInstance() *cloudcontrolv1beta1.NfsInstance {
+	return &cloudcontrolv1beta1.NfsInstance{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "deleted-gcp-nfs-instance",
+			Namespace: "kcp-system",
+			DeletionTimestamp: &v1.Time{
+				Time: time.Now(),
+			},
+			Finalizers: []string{"test-finalizer"},
+		},
+		Spec: cloudcontrolv1beta1.NfsInstanceSpec{},
+	}
+}
+
+func getGcpNfsInstance() *cloudcontrolv1beta1.NfsInstance {
+	return &cloudcontrolv1beta1.NfsInstance{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-gcp-nfs-instance",
+			Namespace: kymaRef.Namespace,
+			Labels: map[string]string{
+				cloudcontrolv1beta1.LabelKymaName:        kymaRef.Name,
+				cloudcontrolv1beta1.LabelRemoteName:      "test-gcp-nfs-volume",
+				cloudcontrolv1beta1.LabelRemoteNamespace: "test",
+			},
+		},
+		Spec: cloudcontrolv1beta1.NfsInstanceSpec{
+			RemoteRef: cloudcontrolv1beta1.RemoteRef{
+				Namespace: "test",
+				Name:      "test-gcp-nfs-volume",
+			},
+			IpRange: cloudcontrolv1beta1.IpRangeRef{
+				Name: "test-gcp-ip-range",
+			},
+			Scope: cloudcontrolv1beta1.ScopeRef{
+				Name: kymaRef.Name,
+			},
+			Instance: cloudcontrolv1beta1.NfsInstanceInfo{
+				Gcp: &cloudcontrolv1beta1.NfsInstanceGcp{
+					Location:      "us-west1",
+					Tier:          "BASIC_HDD",
+					FileShareName: "vol1",
+					CapacityGb:    1024,
+					ConnectMode:   cloudcontrolv1beta1.PRIVATE_SERVICE_ACCESS,
+				},
+			},
+		},
+		Status: cloudcontrolv1beta1.NfsInstanceStatus{
+			State: "Ready",
+			Id:    "gcp-filestore-1",
+			Conditions: []v1.Condition{
+				{
+					Type:               "Ready",
+					Status:             "True",
+					LastTransitionTime: v1.Time{Time: time.Now()},
+					Reason:             "Ready",
+					Message:            "NFS is instance is ready",
+				},
+			},
+			Hosts:      []string{"10.0.0.2"},
+			CapacityGb: 1024,
+		},
+	}
+}
+
+func getInstanceWithoutStatus() *cloudcontrolv1beta1.NfsInstance {
+	var gcpNfsInstance2 = getGcpNfsInstance().DeepCopy()
+	gcpNfsInstance2.Name = "test-gcp-nfs-instance-2"
+	gcpNfsInstance2.Labels[cloudcontrolv1beta1.LabelRemoteName] = "test-gcp-nfs-volume-2"
+	gcpNfsInstance2.Spec.RemoteRef.Name = "test-gcp-nfs-volume-2"
+	gcpNfsInstance2.Status = cloudcontrolv1beta1.NfsInstanceStatus{}
+	return gcpNfsInstance2
+}
+
+type testStateFactory struct {
+	factory                StateFactory
+	kcpCluster             composed.StateCluster
+	nfsInstance            *cloudcontrolv1beta1.NfsInstance
+	nfsInstanceNoCondition *cloudcontrolv1beta1.NfsInstance
+	deletedNfsInstance     *cloudcontrolv1beta1.NfsInstance
+	fakeHttpServer         *httptest.Server
+}
+
+func newTestStateFactory() (*testStateFactory, error) {
+
+	kcpScheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(kcpScheme))
+	utilruntime.Must(cloudcontrolv1beta1.AddToScheme(kcpScheme))
+
+	kcpClient := fake.NewClientBuilder().
+		WithScheme(kcpScheme).
+		WithObjects(getGcpNfsInstance()).
+		WithObjects(getInstanceWithoutStatus()).
+		WithObjects(getDeletedGcpNfsInstance()).
+		Build()
+	kcpCluster := composed.NewStateCluster(kcpClient, nil, kcpScheme)
+	fakeFileStoreClientProvider, fakeHttpServer := NewFakeFilestoreClientProvider()
+	factory := NewStateFactory(fakeFileStoreClientProvider, abstractions.NewMockedEnvironment(map[string]string{"GCP_SA_JSON_KEY_PATH": "test"}))
+
+	return &testStateFactory{
+		factory:                factory,
+		kcpCluster:             kcpCluster,
+		nfsInstance:            getGcpNfsInstance(),
+		nfsInstanceNoCondition: getInstanceWithoutStatus(),
+		deletedNfsInstance:     getDeletedGcpNfsInstance(),
+		fakeHttpServer:         fakeHttpServer,
+	}, nil
+
+}
+
+type TestState struct {
+	*State
+	FakeHttpServer *httptest.Server
+}
+
+func (f *testStateFactory) newState(ctx context.Context) (*TestState, error) {
+	return f.newStateWith(ctx, getGcpNfsInstance())
+}
+
+func (f *testStateFactory) newStateWith(ctx context.Context, nfsInstance *cloudcontrolv1beta1.NfsInstance) (*TestState, error) {
+	focalState := focal.NewStateFactory().NewState(composed.NewStateFactory(f.kcpCluster).NewState(
+		types.NamespacedName{
+			Name:      nfsInstance.Name,
+			Namespace: nfsInstance.Namespace,
+		}, nfsInstance))
+	typesState := newTypesState(focalState)
+
+	state, err := f.factory.NewState(ctx, typesState)
+	if err != nil {
+		return nil, err
+	} else {
+		return &TestState{
+			State:          state,
+			FakeHttpServer: f.fakeHttpServer,
+		}, nil
+	}
+}
+
+func NewFakeFilestoreClientProvider() (client.ClientProvider[client2.FilestoreClient], *httptest.Server) {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var opResp *file.Operation
+		switch r.Method {
+		case http.MethodGet:
+			if r.URL.Path == "/projects/test-project/locations/us-west1/instances/test-gcp-nfs-volume" {
+
+			}
+			if r.URL.Path == "/projects/test-project/locations/us-west1/instances/test-gcp-nfs-volume-2" {
+
+			}
+			//Check if url path is for operation
+			if r.URL.Path == "/projects/test-project/locations/us-west1/operations/create-operation" {
+				// check if operation name is create-operation
+			}
+
+		case http.MethodPost:
+			opResp = &file.Operation{
+				Name: "create-operation",
+				Done: false,
+			}
+		case http.MethodPatch:
+			opResp = &file.Operation{
+				Name: "patch-operation",
+				Done: false,
+			}
+		case http.MethodDelete:
+			opResp = &file.Operation{
+				Name: "delete-operation",
+				Done: false,
+			}
+		}
+		b, err := json.Marshal(opResp)
+		if err != nil {
+			http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			http.Error(w, "unable to write to provided ResponseWriter: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}))
+	return client.NewCachedClientProvider(
+		func(ctx context.Context, saJsonKeyPath string) (client2.FilestoreClient, error) {
+			fsClient, err := file.NewService(ctx, option.WithoutAuthentication(), option.WithEndpoint(fakeHttpServer.URL))
+			if err != nil {
+				return nil, err
+			}
+			return client2.NewFilestoreClient(fsClient), nil
+		},
+	), fakeHttpServer
+}
+
+type typesState struct {
+	focal.State
+
+	ipRange *cloudcontrolv1beta1.IpRange
+}
+
+func (s *typesState) ObjAsNfsInstance() *cloudcontrolv1beta1.NfsInstance {
+	return s.Obj().(*cloudcontrolv1beta1.NfsInstance)
+}
+
+func (s *typesState) IpRange() *cloudcontrolv1beta1.IpRange {
+	return s.ipRange
+}
+
+func (s *typesState) SetIpRange(r *cloudcontrolv1beta1.IpRange) {
+	s.ipRange = r
+}
+
+func newTypesState(focalState focal.State) nfsTypes.State {
+	return &typesState{State: focalState}
+}

--- a/pkg/kcp/provider/gcp/nfsinstance/validateAlways_test.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/validateAlways_test.go
@@ -1,0 +1,63 @@
+package nfsinstance
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+type validateAlwaysSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *validateAlwaysSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *validateAlwaysSuite) TestValidateAlwaysHappy() {
+	factory, err := newTestStateFactory()
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	testState, err := factory.newStateWith(ctx, getInstanceWithoutStatus())
+	assert.Nil(suite.T(), err)
+	defer testState.FakeHttpServer.Close()
+	err, _ = validateAlways(ctx, testState.State)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), 0, len(testState.State.ObjAsNfsInstance().Status.Conditions))
+}
+
+func (suite *validateAlwaysSuite) TestValidateAlwaysInvalidCapacity() {
+	factory, err := newTestStateFactory()
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	instance := getInstanceWithoutStatus()
+	instance.Spec.Instance.Gcp.CapacityGb = 100
+	testState, err := factory.newStateWith(ctx, instance)
+	assert.Nil(suite.T(), err)
+	defer testState.FakeHttpServer.Close()
+	err, _ = validateAlways(ctx, testState.State)
+	assert.Error(suite.T(), err)
+	assert.Len(suite.T(), testState.State.ObjAsNfsInstance().Status.Conditions, 1)
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, testState.State.ObjAsNfsInstance().Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, testState.State.ObjAsNfsInstance().Status.Conditions[0].Status)
+	assert.Equal(suite.T(), v1beta1.ReasonValidationFailed, testState.State.ObjAsNfsInstance().Status.Conditions[0].Reason)
+	assert.Equal(suite.T(), 1, len(testState.State.validations))
+}
+
+func TestValidateAlways(t *testing.T) {
+	suite.Run(t, new(validateAlwaysSuite))
+}


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- state_test which initializes state with fake kcp k8s and fake gcp http server
- unit test for validateAlways action

**Related issue(s)**
https://jira.tools.sap/browse/PHX-55