### PR TITLE
gcp nfsInstance unit test for checkGcpOperation and loadNfsInstance actions

### DIFF
--- a/pkg/kcp/provider/gcp/nfsinstance/checkGcpOperation_test.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/checkGcpOperation_test.go
@@ -1,0 +1,186 @@
+package nfsinstance
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/file/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
+	"testing"
+)
+
+type checkGcpOperationSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *checkGcpOperationSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *checkGcpOperationSuite) TestCheckGcpOperationNoOperation() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+
+	testState, err := factory.newStateWith(ctx, getGcpNfsInstance(), "")
+	assert.Nil(suite.T(), err)
+	defer testState.FakeHttpServer.Close()
+	err, resCtx := checkGcpOperation(ctx, testState.State)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+}
+
+func (suite *checkGcpOperationSuite) TestCheckGcpOperationFailedOperation() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var opResp *file.Operation
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/operations/create-operation") {
+				opResp = &file.Operation{
+					Name: "create-operation",
+					Done: true,
+					Error: &file.Status{
+						Code:    500,
+						Message: "Operation failed",
+					},
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(opResp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+
+	testState, err := factory.newStateWith(ctx, getGcpNfsInstance(), "/projects/test-project/locations/us-west1/operations/create-operation")
+	assert.Nil(suite.T(), err)
+	defer testState.FakeHttpServer.Close()
+	err, _ = checkGcpOperation(ctx, testState.State)
+	assert.Error(suite.T(), err)
+	assert.Len(suite.T(), testState.State.ObjAsNfsInstance().Status.Conditions, 1)
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, testState.State.ObjAsNfsInstance().Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, testState.State.ObjAsNfsInstance().Status.Conditions[0].Status)
+	assert.Equal(suite.T(), v1beta1.ReasonGcpError, testState.State.ObjAsNfsInstance().Status.Conditions[0].Reason)
+	assert.Equal(suite.T(), "", testState.State.ObjAsNfsInstance().Status.OpIdentifier)
+}
+
+func (suite *checkGcpOperationSuite) TestCheckGcpOperationNotDoneOperation() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var opResp *file.Operation
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/operations/create-operation") {
+				opResp = &file.Operation{
+					Name: "create-operation",
+					Done: false,
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(opResp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+
+	testState, err := factory.newStateWith(ctx, getGcpNfsInstance(), "/projects/test-project/locations/us-west1/operations/create-operation")
+	assert.Nil(suite.T(), err)
+	defer testState.FakeHttpServer.Close()
+	err, resCtx := checkGcpOperation(ctx, testState.State)
+	assert.Nil(suite.T(), resCtx)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+}
+
+func (suite *checkGcpOperationSuite) TestCheckGcpOperationSuccessfulOperation() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var opResp *file.Operation
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/operations/create-operation") {
+				opResp = &file.Operation{
+					Name: "create-operation",
+					Done: true,
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(opResp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+
+	testState, err := factory.newStateWith(ctx, getGcpNfsInstance(), "/projects/test-project/locations/us-west1/operations/create-operation")
+	assert.Nil(suite.T(), err)
+	defer testState.FakeHttpServer.Close()
+	err, resCtx := checkGcpOperation(ctx, testState.State)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+}
+func TestCheckGcpOperation(t *testing.T) {
+	suite.Run(t, new(checkGcpOperationSuite))
+}

--- a/pkg/kcp/provider/gcp/nfsinstance/loadNfsInstance_test.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/loadNfsInstance_test.go
@@ -1,0 +1,123 @@
+package nfsinstance
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
+	"testing"
+)
+
+type loadNfsInstanceSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *loadNfsInstanceSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *loadNfsInstanceSuite) TestLoadNfsInstanceNotFound() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/test-gcp-nfs-volume") {
+				//Return 404
+				http.Error(w, "Not Found", http.StatusNotFound)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+	}))
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+
+	testState, err := factory.newStateWith(ctx, getGcpNfsInstance(), "")
+	assert.Nil(suite.T(), err)
+	defer testState.FakeHttpServer.Close()
+	err, resCtx := loadNfsInstance(ctx, testState.State)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+}
+
+func (suite *loadNfsInstanceSuite) TestLoadNfsInstanceOtherErrors() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/test-gcp-nfs-volume") {
+				//Return 500
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+	}))
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+
+	testState, err := factory.newStateWith(ctx, getGcpNfsInstance(), "")
+	assert.Nil(suite.T(), err)
+	defer testState.FakeHttpServer.Close()
+	err, _ = loadNfsInstance(ctx, testState.State)
+	assert.NotNil(suite.T(), err)
+	// check error condition in status
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, testState.State.ObjAsNfsInstance().Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, testState.State.ObjAsNfsInstance().Status.Conditions[0].Status)
+	assert.Equal(suite.T(), v1beta1.ReasonGcpError, testState.State.ObjAsNfsInstance().Status.Conditions[0].Reason)
+}
+
+func (suite *loadNfsInstanceSuite) TestLoadNfsInstanceSuccess() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/test-gcp-nfs-volume") {
+				//Return 200
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"name":"test-gcp-nfs-volume"}`))
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+	}))
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+
+	testState, err := factory.newStateWith(ctx, getGcpNfsInstance(), "")
+	assert.Nil(suite.T(), err)
+	defer testState.FakeHttpServer.Close()
+	err, resCtx := loadNfsInstance(ctx, testState.State)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+	assert.NotNil(suite.T(), testState.State.fsInstance)
+}
+func TestLoadNfsInstance(t *testing.T) {
+	suite.Run(t, new(loadNfsInstanceSuite))
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- updating state_test so fake http server can be injected for each test
- unit test for CheckGcpOperation action
- unit test for LoadNfsInstance action

**Related issue(s)**
https://jira.tools.sap/browse/PHX-55