### PR TITLE
gcp nfsInstance unit test for validatePostCreate and validations

### DIFF
--- a/pkg/kcp/provider/gcp/nfsinstance/checkGcpOperation_test.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/checkGcpOperation_test.go
@@ -32,7 +32,8 @@ func (suite *checkGcpOperationSuite) TestCheckGcpOperationNoOperation() {
 		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
 		return
 	}))
-	factory, err := newTestStateFactory(fakeHttpServer)
+	gcpNfsInstance := getGcpNfsInstance()
+	factory, err := newTestStateFactory(fakeHttpServer, gcpNfsInstance)
 	assert.Nil(suite.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -40,7 +41,7 @@ func (suite *checkGcpOperationSuite) TestCheckGcpOperationNoOperation() {
 
 	//Get state object with GcpNfsVolume
 
-	testState, err := factory.newStateWith(ctx, getGcpNfsInstance(), "")
+	testState, err := factory.newStateWith(ctx, gcpNfsInstance, "")
 	assert.Nil(suite.T(), err)
 	defer testState.FakeHttpServer.Close()
 	err, resCtx := checkGcpOperation(ctx, testState.State)
@@ -78,7 +79,8 @@ func (suite *checkGcpOperationSuite) TestCheckGcpOperationFailedOperation() {
 		}
 		return
 	}))
-	factory, err := newTestStateFactory(fakeHttpServer)
+	gcpNfsInstance := getGcpNfsInstance()
+	factory, err := newTestStateFactory(fakeHttpServer, gcpNfsInstance)
 	assert.Nil(suite.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -86,7 +88,7 @@ func (suite *checkGcpOperationSuite) TestCheckGcpOperationFailedOperation() {
 
 	//Get state object with GcpNfsVolume
 
-	testState, err := factory.newStateWith(ctx, getGcpNfsInstance(), "/projects/test-project/locations/us-west1/operations/create-operation")
+	testState, err := factory.newStateWith(ctx, gcpNfsInstance, "/projects/test-project/locations/us-west1/operations/create-operation")
 	assert.Nil(suite.T(), err)
 	defer testState.FakeHttpServer.Close()
 	err, _ = checkGcpOperation(ctx, testState.State)
@@ -124,7 +126,8 @@ func (suite *checkGcpOperationSuite) TestCheckGcpOperationNotDoneOperation() {
 		}
 		return
 	}))
-	factory, err := newTestStateFactory(fakeHttpServer)
+	gcpNfsInstance := getGcpNfsInstance()
+	factory, err := newTestStateFactory(fakeHttpServer, gcpNfsInstance)
 	assert.Nil(suite.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -132,7 +135,7 @@ func (suite *checkGcpOperationSuite) TestCheckGcpOperationNotDoneOperation() {
 
 	//Get state object with GcpNfsVolume
 
-	testState, err := factory.newStateWith(ctx, getGcpNfsInstance(), "/projects/test-project/locations/us-west1/operations/create-operation")
+	testState, err := factory.newStateWith(ctx, gcpNfsInstance, "/projects/test-project/locations/us-west1/operations/create-operation")
 	assert.Nil(suite.T(), err)
 	defer testState.FakeHttpServer.Close()
 	err, resCtx := checkGcpOperation(ctx, testState.State)
@@ -166,7 +169,8 @@ func (suite *checkGcpOperationSuite) TestCheckGcpOperationSuccessfulOperation() 
 		}
 		return
 	}))
-	factory, err := newTestStateFactory(fakeHttpServer)
+	gcpNfsInstance := getGcpNfsInstance()
+	factory, err := newTestStateFactory(fakeHttpServer, gcpNfsInstance)
 	assert.Nil(suite.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -174,7 +178,7 @@ func (suite *checkGcpOperationSuite) TestCheckGcpOperationSuccessfulOperation() 
 
 	//Get state object with GcpNfsVolume
 
-	testState, err := factory.newStateWith(ctx, getGcpNfsInstance(), "/projects/test-project/locations/us-west1/operations/create-operation")
+	testState, err := factory.newStateWith(ctx, gcpNfsInstance, "/projects/test-project/locations/us-west1/operations/create-operation")
 	assert.Nil(suite.T(), err)
 	defer testState.FakeHttpServer.Close()
 	err, resCtx := checkGcpOperation(ctx, testState.State)

--- a/pkg/kcp/provider/gcp/nfsinstance/loadNfsInstance_test.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/loadNfsInstance_test.go
@@ -38,7 +38,8 @@ func (suite *loadNfsInstanceSuite) TestLoadNfsInstanceNotFound() {
 			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
 		}
 	}))
-	factory, err := newTestStateFactory(fakeHttpServer)
+	gcpNfsInstance := getGcpNfsInstance()
+	factory, err := newTestStateFactory(fakeHttpServer, gcpNfsInstance)
 	assert.Nil(suite.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -46,7 +47,7 @@ func (suite *loadNfsInstanceSuite) TestLoadNfsInstanceNotFound() {
 
 	//Get state object with GcpNfsVolume
 
-	testState, err := factory.newStateWith(ctx, getGcpNfsInstance(), "")
+	testState, err := factory.newStateWith(ctx, gcpNfsInstance, "")
 	assert.Nil(suite.T(), err)
 	defer testState.FakeHttpServer.Close()
 	err, resCtx := loadNfsInstance(ctx, testState.State)
@@ -68,15 +69,15 @@ func (suite *loadNfsInstanceSuite) TestLoadNfsInstanceOtherErrors() {
 			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
 		}
 	}))
-	factory, err := newTestStateFactory(fakeHttpServer)
+	gcpNfsInstance := getGcpNfsInstance()
+	factory, err := newTestStateFactory(fakeHttpServer, gcpNfsInstance)
 	assert.Nil(suite.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	//Get state object with GcpNfsVolume
-
-	testState, err := factory.newStateWith(ctx, getGcpNfsInstance(), "")
+	testState, err := factory.newStateWith(ctx, gcpNfsInstance, "")
 	assert.Nil(suite.T(), err)
 	defer testState.FakeHttpServer.Close()
 	err, _ = loadNfsInstance(ctx, testState.State)
@@ -102,7 +103,8 @@ func (suite *loadNfsInstanceSuite) TestLoadNfsInstanceSuccess() {
 			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
 		}
 	}))
-	factory, err := newTestStateFactory(fakeHttpServer)
+	gcpNfsInstance := getGcpNfsInstance()
+	factory, err := newTestStateFactory(fakeHttpServer, gcpNfsInstance)
 	assert.Nil(suite.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -110,7 +112,7 @@ func (suite *loadNfsInstanceSuite) TestLoadNfsInstanceSuccess() {
 
 	//Get state object with GcpNfsVolume
 
-	testState, err := factory.newStateWith(ctx, getGcpNfsInstance(), "")
+	testState, err := factory.newStateWith(ctx, gcpNfsInstance, "")
 	assert.Nil(suite.T(), err)
 	defer testState.FakeHttpServer.Close()
 	err, resCtx := loadNfsInstance(ctx, testState.State)

--- a/pkg/kcp/provider/gcp/nfsinstance/validateAlways_test.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/validateAlways_test.go
@@ -26,15 +26,15 @@ func (suite *validateAlwaysSuite) TestValidateAlwaysHappy() {
 	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		return // no-op
 	}))
-
-	factory, err := newTestStateFactory(fakeHttpServer)
+	gcpNfsInstanceWithoutStatus := getGcpNfsInstanceWithoutStatus()
+	factory, err := newTestStateFactory(fakeHttpServer, gcpNfsInstanceWithoutStatus)
 	assert.Nil(suite.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	//Get state object with GcpNfsVolume
-	testState, err := factory.newStateWith(ctx, getGcpNfsInstanceWithoutStatus(), "")
+	testState, err := factory.newStateWith(ctx, gcpNfsInstanceWithoutStatus, "")
 	assert.Nil(suite.T(), err)
 	defer testState.FakeHttpServer.Close()
 	err, _ = validateAlways(ctx, testState.State)
@@ -46,16 +46,16 @@ func (suite *validateAlwaysSuite) TestValidateAlwaysInvalidCapacity() {
 	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		return // no-op
 	}))
-	factory, err := newTestStateFactory(fakeHttpServer)
+	gcpNfsInstanceWithoutStatus := getGcpNfsInstanceWithoutStatus()
+	gcpNfsInstanceWithoutStatus.Spec.Instance.Gcp.CapacityGb = 100
+	factory, err := newTestStateFactory(fakeHttpServer, gcpNfsInstanceWithoutStatus)
 	assert.Nil(suite.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	//Get state object with GcpNfsVolume
-	instance := getGcpNfsInstanceWithoutStatus()
-	instance.Spec.Instance.Gcp.CapacityGb = 100
-	testState, err := factory.newStateWith(ctx, instance, "")
+	testState, err := factory.newStateWith(ctx, gcpNfsInstanceWithoutStatus, "")
 	assert.Nil(suite.T(), err)
 	defer testState.FakeHttpServer.Close()
 	err, _ = validateAlways(ctx, testState.State)

--- a/pkg/kcp/provider/gcp/nfsinstance/validatePostCreate_test.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/validatePostCreate_test.go
@@ -1,0 +1,105 @@
+package nfsinstance
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/file/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+type validatePostCreateSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *validatePostCreateSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *validatePostCreateSuite) TestValidatePostCreateScaleDownFail() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+	}))
+	gcpNfsInstance := getGcpNfsInstance()
+	factory, err := newTestStateFactory(fakeHttpServer, gcpNfsInstance)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+
+	testState, err := factory.newStateWith(ctx, gcpNfsInstance, "")
+	testState.fsInstance = &file.Instance{
+		Name: "test-gcp-nfs-volume",
+		FileShares: []*file.FileShareConfig{
+			{
+				CapacityGb: 5000,
+			},
+		},
+	}
+	assert.Nil(suite.T(), err)
+	defer testState.FakeHttpServer.Close()
+	err, resCtx := validatePostCreate(ctx, testState.State)
+	assert.Nil(suite.T(), resCtx)
+	assert.NotNil(suite.T(), err)
+	// validate status conditions error
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, testState.State.ObjAsNfsInstance().Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, testState.State.ObjAsNfsInstance().Status.Conditions[0].Status)
+	assert.Equal(suite.T(), v1beta1.ReasonValidationFailed, testState.State.ObjAsNfsInstance().Status.Conditions[0].Reason)
+	updatedObject := &v1beta1.NfsInstance{}
+	err = factory.kcpCluster.K8sClient().Get(ctx, types.NamespacedName{Name: gcpNfsInstance.Name, Namespace: gcpNfsInstance.Namespace}, updatedObject)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, updatedObject.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, updatedObject.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), v1beta1.ReasonValidationFailed, updatedObject.Status.Conditions[0].Reason)
+}
+
+func (suite *validatePostCreateSuite) TestValidatePostCreateSuccess() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+	}))
+	gcpNfsInstance := getGcpNfsInstance()
+	gcpNfsInstance.Spec.Instance.Gcp.Tier = v1beta1.ZONAL
+	factory, err := newTestStateFactory(fakeHttpServer, gcpNfsInstance)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+
+	testState, err := factory.newStateWith(ctx, gcpNfsInstance, "")
+	testState.fsInstance = &file.Instance{
+		Name: "test-gcp-nfs-volume",
+		FileShares: []*file.FileShareConfig{
+			{
+				CapacityGb: 5000,
+			},
+		},
+	}
+	assert.Nil(suite.T(), err)
+	defer testState.FakeHttpServer.Close()
+	updatedObject := &v1beta1.NfsInstance{}
+	err = factory.kcpCluster.K8sClient().Get(ctx, types.NamespacedName{Name: gcpNfsInstance.Name, Namespace: gcpNfsInstance.Namespace}, updatedObject)
+	assert.Nil(suite.T(), err)
+	err, resCtx := validatePostCreate(ctx, testState.State)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+	updatedObject2 := &v1beta1.NfsInstance{}
+	err = factory.kcpCluster.K8sClient().Get(ctx, types.NamespacedName{Name: gcpNfsInstance.Name, Namespace: gcpNfsInstance.Namespace}, updatedObject2)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), updatedObject.ObjectMeta.ResourceVersion, updatedObject2.ObjectMeta.ResourceVersion)
+}
+
+func TestValidatePostCreate(t *testing.T) {
+	suite.Run(t, new(validatePostCreateSuite))
+}

--- a/pkg/kcp/provider/gcp/nfsinstance/validations_test.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/validations_test.go
@@ -1,0 +1,60 @@
+package nfsinstance
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+type validationsSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *validationsSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *validationsSuite) TestIsValidCapacity() {
+	testMinMax(suite, v1beta1.BASIC_HDD, 1023, 66000, 1024, 65000)
+	testMinMax(suite, v1beta1.STANDARD, 1023, 66000, 1024, 65000)
+	testMinMax(suite, v1beta1.BASIC_SSD, 2559, 66000, 2560, 65000)
+	testMinMax(suite, v1beta1.PREMIUM, 2559, 66000, 2560, 65000)
+	testMinMax(suite, v1beta1.ZONAL, 1023, 10241, 1024, 10240)
+	testMinMax(suite, v1beta1.ENTERPRISE, 1023, 10241, 1024, 10240)
+	testMinMax(suite, v1beta1.REGIONAL, 1023, 10241, 1024, 10240)
+	testMinMax(suite, v1beta1.HIGH_SCALE_SSD, 10239, 102401, 10240, 102400)
+}
+
+func testMinMax(suite *validationsSuite, tier v1beta1.GcpFileTier, minErr, maxErr, minOk, maxOk int) {
+	valid, err := IsValidCapacity(tier, minErr)
+	assert.False(suite.T(), valid)
+	assert.NotNil(suite.T(), err)
+	valid, err = IsValidCapacity(tier, maxErr)
+	assert.False(suite.T(), valid)
+	assert.NotNil(suite.T(), err)
+	valid, err = IsValidCapacity(tier, minOk)
+	assert.True(suite.T(), valid)
+	assert.Nil(suite.T(), err)
+	valid, err = IsValidCapacity(tier, maxOk)
+	assert.True(suite.T(), valid)
+	assert.Nil(suite.T(), err)
+}
+
+func (suite *validationsSuite) TestCanScaleDown() {
+	assert.False(suite.T(), CanScaleDown(v1beta1.BASIC_HDD))
+	assert.False(suite.T(), CanScaleDown(v1beta1.STANDARD))
+	assert.False(suite.T(), CanScaleDown(v1beta1.BASIC_SSD))
+	assert.False(suite.T(), CanScaleDown(v1beta1.PREMIUM))
+	assert.True(suite.T(), CanScaleDown(v1beta1.ZONAL))
+	assert.True(suite.T(), CanScaleDown(v1beta1.ENTERPRISE))
+	assert.True(suite.T(), CanScaleDown(v1beta1.REGIONAL))
+	assert.True(suite.T(), CanScaleDown(v1beta1.HIGH_SCALE_SSD))
+}
+func TestValidations(t *testing.T) {
+	suite.Run(t, new(validationsSuite))
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- updating state_test so updateStatus works with fake k8s client
- unit test for validatePostCreate
- unit test for validations.go methods

**Related issue(s)**
https://jira.tools.sap/browse/PHX-55