### PR TITLE
Gcp IpRange Reconciler unit tests

### DIFF
--- a/pkg/kcp/provider/gcp/client/provider.go
+++ b/pkg/kcp/provider/gcp/client/provider.go
@@ -53,15 +53,11 @@ var projectNumbers map[string]int64 = make(map[string]int64)
 var projectNumbersMutex sync.Mutex
 
 // GetCachedProjectNumber get project number from cloud resources manager for a given project id
-func GetCachedProjectNumber(ctx context.Context, projectId string, httpClient *http.Client) (int64, error) {
+func GetCachedProjectNumber(ctx context.Context, projectId string, crmService *cloudresourcemanager.Service) (int64, error) {
 	projectNumbersMutex.Lock()
 	defer projectNumbersMutex.Unlock()
 	projectNumber, ok := projectNumbers[projectId]
 	if !ok {
-		crmService, err := cloudresourcemanager.NewService(ctx, option.WithHTTPClient(httpClient))
-		if err != nil {
-			return 0, err
-		}
 		project, err := crmService.Projects.Get(projectId).Do()
 		if err != nil {
 			return 0, err

--- a/pkg/kcp/provider/gcp/iprange/checkGcpOperation_test.go
+++ b/pkg/kcp/provider/gcp/iprange/checkGcpOperation_test.go
@@ -24,8 +24,6 @@ type checkGcpOperationSuite struct {
 	ctx context.Context
 }
 
-var opIdentifier = "/projects/test-project/locations/us-west1/operations/create-operation"
-
 func (suite *checkGcpOperationSuite) SetupTest() {
 	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
 }
@@ -48,7 +46,7 @@ func (suite *checkGcpOperationSuite) TestWhenOpIdentifierIsNil() {
 	state, err := factory.newStateWith(ctx, ipRange)
 	assert.Nil(suite.T(), err)
 
-	//Call checkGcpOperation
+	//Invoke the function under test
 	err, resCtx := checkGcpOperation(ctx, state)
 	assert.Nil(suite.T(), err)
 	assert.Nil(suite.T(), resCtx)
@@ -76,7 +74,7 @@ func (suite *checkGcpOperationSuite) TestWhenSvcNwGetOperationFailed() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	//Get state object with GcpNfsVolume
+	//Get state object with IpRange
 	ipRange := gcpIpRange.DeepCopy()
 	ipRange.Status.State = client.DeletePsaConnection
 	ipRange.Status.OpIdentifier = opIdentifier
@@ -86,6 +84,7 @@ func (suite *checkGcpOperationSuite) TestWhenSvcNwGetOperationFailed() {
 	state, err := factory.newStateWith(ctx, ipRange)
 	assert.Nil(suite.T(), err)
 
+	//Invoke the function under test
 	err, _ = checkGcpOperation(ctx, state)
 	assert.Equal(suite.T(), composed.StopWithRequeue, err)
 
@@ -138,7 +137,7 @@ func (suite *checkGcpOperationSuite) TestWhenSvcNwOperationFailed() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	//Get state object with GcpNfsVolume
+	//Get state object with IpRange
 	ipRange := gcpIpRange.DeepCopy()
 	ipRange.Status.State = client.DeletePsaConnection
 	ipRange.Status.OpIdentifier = opIdentifier
@@ -148,6 +147,7 @@ func (suite *checkGcpOperationSuite) TestWhenSvcNwOperationFailed() {
 	state, err := factory.newStateWith(ctx, ipRange)
 	assert.Nil(suite.T(), err)
 
+	//Invoke the function under test
 	err, _ = checkGcpOperation(ctx, state)
 	assert.Equal(suite.T(), composed.StopWithRequeue, err)
 
@@ -206,6 +206,7 @@ func (suite *checkGcpOperationSuite) TestWhenSvcNwOperationNotComplete() {
 	state, err := factory.newStateWith(ctx, ipRange)
 	assert.Nil(suite.T(), err)
 
+	//Invoke the function under test
 	err, resCtx := checkGcpOperation(ctx, state)
 	assert.Nil(suite.T(), resCtx)
 	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
@@ -255,6 +256,7 @@ func (suite *checkGcpOperationSuite) TestWhenSvcNwOperationSuccessful() {
 	state, err := factory.newStateWith(ctx, ipRange)
 	assert.Nil(suite.T(), err)
 
+	//Invoke the function under test
 	err, resCtx := checkGcpOperation(ctx, state)
 	assert.Nil(suite.T(), err)
 	assert.Nil(suite.T(), resCtx)
@@ -282,7 +284,7 @@ func (suite *checkGcpOperationSuite) TestWhenComputeGetOperationFailed() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	//Get state object with GcpNfsVolume
+	//Get state object with IpRange
 	ipRange := gcpIpRange.DeepCopy()
 	ipRange.Status.State = client.DeleteAddress
 	ipRange.Status.OpIdentifier = opIdentifier
@@ -292,6 +294,7 @@ func (suite *checkGcpOperationSuite) TestWhenComputeGetOperationFailed() {
 	state, err := factory.newStateWith(ctx, ipRange)
 	assert.Nil(suite.T(), err)
 
+	//Invoke the function under test
 	err, _ = checkGcpOperation(ctx, state)
 	assert.Equal(suite.T(), composed.StopWithRequeue, err)
 
@@ -347,7 +350,7 @@ func (suite *checkGcpOperationSuite) TestWhenComputeOperationFailed() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	//Get state object with GcpNfsVolume
+	//Get state object with IpRange
 	ipRange := gcpIpRange.DeepCopy()
 	ipRange.Status.State = client.DeleteAddress
 	ipRange.Status.OpIdentifier = opIdentifier
@@ -357,6 +360,7 @@ func (suite *checkGcpOperationSuite) TestWhenComputeOperationFailed() {
 	state, err := factory.newStateWith(ctx, ipRange)
 	assert.Nil(suite.T(), err)
 
+	//Invoke the function under test
 	err, _ = checkGcpOperation(ctx, state)
 	assert.Equal(suite.T(), composed.StopWithRequeue, err)
 
@@ -415,6 +419,7 @@ func (suite *checkGcpOperationSuite) TestWhenComputeOperationNotComplete() {
 	state, err := factory.newStateWith(ctx, ipRange)
 	assert.Nil(suite.T(), err)
 
+	//Invoke the function under test
 	err, resCtx := checkGcpOperation(ctx, state)
 	assert.Nil(suite.T(), resCtx)
 	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
@@ -464,6 +469,7 @@ func (suite *checkGcpOperationSuite) TestWhenComputeOperationSuccessful() {
 	state, err := factory.newStateWith(ctx, ipRange)
 	assert.Nil(suite.T(), err)
 
+	//Invoke the function under test
 	err, resCtx := checkGcpOperation(ctx, state)
 	assert.Nil(suite.T(), err)
 	assert.Nil(suite.T(), resCtx)

--- a/pkg/kcp/provider/gcp/iprange/checkGcpOperation_test.go
+++ b/pkg/kcp/provider/gcp/iprange/checkGcpOperation_test.go
@@ -1,0 +1,474 @@
+package iprange
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/go-logr/logr"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/servicenetworking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
+	"testing"
+)
+
+type checkGcpOperationSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+var opIdentifier = "/projects/test-project/locations/us-west1/operations/create-operation"
+
+func (suite *checkGcpOperationSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *checkGcpOperationSuite) TestWhenOpIdentifierIsNil() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Call checkGcpOperation
+	err, resCtx := checkGcpOperation(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+}
+
+func (suite *checkGcpOperationSuite) TestWhenSvcNwGetOperationFailed() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, opIdentifier) {
+				http.Error(w, "Operation failed", http.StatusInternalServerError)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	ipRange := gcpIpRange.DeepCopy()
+	ipRange.Status.State = client.DeletePsaConnection
+	ipRange.Status.OpIdentifier = opIdentifier
+	err = factory.kcpCluster.K8sClient().Status().Update(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	err, _ = checkGcpOperation(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeue, err)
+
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	assert.Len(suite.T(), ipRange.Status.Conditions, 1)
+	assert.Equal(suite.T(), cloudcontrolv1beta1.ConditionTypeError, ipRange.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, ipRange.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), cloudcontrolv1beta1.ReasonGcpError, ipRange.Status.Conditions[0].Reason)
+	assert.Equal(suite.T(), opIdentifier, ipRange.Status.OpIdentifier)
+}
+
+func (suite *checkGcpOperationSuite) TestWhenSvcNwOperationFailed() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var opResp *servicenetworking.Operation
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, opIdentifier) {
+				opResp = &servicenetworking.Operation{
+					Name: "create-operation",
+					Done: true,
+					Error: &servicenetworking.Status{
+						Code:    500,
+						Message: "Operation failed",
+					},
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(opResp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	ipRange := gcpIpRange.DeepCopy()
+	ipRange.Status.State = client.DeletePsaConnection
+	ipRange.Status.OpIdentifier = opIdentifier
+	err = factory.kcpCluster.K8sClient().Status().Update(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	err, _ = checkGcpOperation(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeue, err)
+
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	assert.Len(suite.T(), ipRange.Status.Conditions, 1)
+	assert.Equal(suite.T(), cloudcontrolv1beta1.ConditionTypeError, ipRange.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, ipRange.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), cloudcontrolv1beta1.ReasonGcpError, ipRange.Status.Conditions[0].Reason)
+	assert.Equal(suite.T(), "", ipRange.Status.OpIdentifier)
+}
+
+func (suite *checkGcpOperationSuite) TestWhenSvcNwOperationNotComplete() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var opResp *servicenetworking.Operation
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, opIdentifier) {
+				opResp = &servicenetworking.Operation{
+					Name: "create-operation",
+					Done: false,
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(opResp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with IpRange
+	ipRange := gcpIpRange.DeepCopy()
+	ipRange.Status.State = client.DeletePsaConnection
+	ipRange.Status.OpIdentifier = opIdentifier
+	err = factory.kcpCluster.K8sClient().Status().Update(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	err, resCtx := checkGcpOperation(ctx, state)
+	assert.Nil(suite.T(), resCtx)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+}
+
+func (suite *checkGcpOperationSuite) TestWhenSvcNwOperationSuccessful() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var opResp *servicenetworking.Operation
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, opIdentifier) {
+				opResp = &servicenetworking.Operation{
+					Name: "create-operation",
+					Done: true,
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(opResp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with IpRange
+	ipRange := gcpIpRange.DeepCopy()
+	ipRange.Status.State = client.DeletePsaConnection
+	ipRange.Status.OpIdentifier = opIdentifier
+	err = factory.kcpCluster.K8sClient().Status().Update(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	err, resCtx := checkGcpOperation(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+}
+
+func (suite *checkGcpOperationSuite) TestWhenComputeGetOperationFailed() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, opIdentifier) {
+				http.Error(w, "Operation failed", http.StatusInternalServerError)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	ipRange := gcpIpRange.DeepCopy()
+	ipRange.Status.State = client.DeleteAddress
+	ipRange.Status.OpIdentifier = opIdentifier
+	err = factory.kcpCluster.K8sClient().Status().Update(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	err, _ = checkGcpOperation(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeue, err)
+
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	assert.Len(suite.T(), ipRange.Status.Conditions, 1)
+	assert.Equal(suite.T(), cloudcontrolv1beta1.ConditionTypeError, ipRange.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, ipRange.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), cloudcontrolv1beta1.ReasonGcpError, ipRange.Status.Conditions[0].Reason)
+	assert.Equal(suite.T(), opIdentifier, ipRange.Status.OpIdentifier)
+}
+
+func (suite *checkGcpOperationSuite) TestWhenComputeOperationFailed() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var opResp *compute.Operation
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, opIdentifier) {
+				opResp = &compute.Operation{
+					Error: &compute.OperationError{
+						Errors: []*compute.OperationErrorErrors{{
+							Code:    "500",
+							Message: "Operation Failed",
+						}},
+					},
+					Name:   opIdentifier,
+					Status: "DONE",
+				}
+
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(opResp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	ipRange := gcpIpRange.DeepCopy()
+	ipRange.Status.State = client.DeleteAddress
+	ipRange.Status.OpIdentifier = opIdentifier
+	err = factory.kcpCluster.K8sClient().Status().Update(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	err, _ = checkGcpOperation(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeue, err)
+
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	assert.Len(suite.T(), ipRange.Status.Conditions, 1)
+	assert.Equal(suite.T(), cloudcontrolv1beta1.ConditionTypeError, ipRange.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, ipRange.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), cloudcontrolv1beta1.ReasonGcpError, ipRange.Status.Conditions[0].Reason)
+	assert.Equal(suite.T(), "", ipRange.Status.OpIdentifier)
+}
+
+func (suite *checkGcpOperationSuite) TestWhenComputeOperationNotComplete() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var opResp *compute.Operation
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, opIdentifier) {
+				opResp = &compute.Operation{
+					Name:   opIdentifier,
+					Status: "PENDING",
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(opResp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with IpRange
+	ipRange := gcpIpRange.DeepCopy()
+	ipRange.Status.State = client.DeleteAddress
+	ipRange.Status.OpIdentifier = opIdentifier
+	err = factory.kcpCluster.K8sClient().Status().Update(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	err, resCtx := checkGcpOperation(ctx, state)
+	assert.Nil(suite.T(), resCtx)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+}
+
+func (suite *checkGcpOperationSuite) TestWhenComputeOperationSuccessful() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var opResp *compute.Operation
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, opIdentifier) {
+				opResp = &compute.Operation{
+					Name:   opIdentifier,
+					Status: "DONE",
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(opResp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with IpRange
+	ipRange := gcpIpRange.DeepCopy()
+	ipRange.Status.State = client.DeleteAddress
+	ipRange.Status.OpIdentifier = opIdentifier
+	err = factory.kcpCluster.K8sClient().Status().Update(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	err, resCtx := checkGcpOperation(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+}
+
+func TestCheckGcpOperation(t *testing.T) {
+	suite.Run(t, new(checkGcpOperationSuite))
+}

--- a/pkg/kcp/provider/gcp/iprange/compareStates_test.go
+++ b/pkg/kcp/provider/gcp/iprange/compareStates_test.go
@@ -1,0 +1,442 @@
+package iprange
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/servicenetworking/v1"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+type compareStatesSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *compareStatesSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *compareStatesSuite) TestWhenDeletingAndNoAddressOrConnectionExists() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+	err = factory.kcpCluster.K8sClient().Delete(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Get the updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	////Invoke the function under test
+	err, resCtx := compareStates(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Validate state attributes
+	assert.Equal(suite.T(), client.Deleted, state.curState)
+	assert.Equal(suite.T(), client.NONE, state.connectionOp)
+	assert.Equal(suite.T(), client.NONE, state.addressOp)
+	assert.True(suite.T(), state.inSync)
+}
+
+func (suite *compareStatesSuite) TestWhenDeletingAndAddressExistsAndNoConnectionExists() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+	err = factory.kcpCluster.K8sClient().Delete(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Get the updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	//Set Address
+	address := &compute.Address{
+		Address: ipAddr,
+		Name:    gcpIpRange.Spec.RemoteRef.Name,
+	}
+	state.address = address
+
+	////Invoke the function under test
+	err, resCtx := compareStates(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Validate state attributes
+	assert.Equal(suite.T(), client.DeleteAddress, state.curState)
+	assert.Equal(suite.T(), client.NONE, state.connectionOp)
+	assert.Equal(suite.T(), client.DELETE, state.addressOp)
+	assert.False(suite.T(), state.inSync)
+}
+
+func (suite *compareStatesSuite) TestWhenDeletingAndNoAddressExistsAndConnectionExists() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+	err = factory.kcpCluster.K8sClient().Delete(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Get the updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	//Set Connection
+	connection := &servicenetworking.Connection{
+		ReservedPeeringRanges: []string{ipRange.Spec.RemoteRef.Name},
+	}
+	state.serviceConnection = connection
+
+	////Invoke the function under test
+	err, resCtx := compareStates(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Validate state attributes
+	assert.Equal(suite.T(), client.DeletePsaConnection, state.curState)
+	assert.Equal(suite.T(), client.DELETE, state.connectionOp)
+	assert.Equal(suite.T(), client.NONE, state.addressOp)
+	assert.False(suite.T(), state.inSync)
+}
+
+func (suite *compareStatesSuite) TestWhenDeletingAndBothAddressAndConnectionExists() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+	err = factory.kcpCluster.K8sClient().Delete(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Get the updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	//Set Address
+	address := &compute.Address{
+		Address: ipAddr,
+		Name:    gcpIpRange.Spec.RemoteRef.Name,
+	}
+	state.address = address
+
+	//Set Connection
+	connection := &servicenetworking.Connection{
+		ReservedPeeringRanges: []string{ipRange.Spec.RemoteRef.Name, "test"},
+	}
+	state.serviceConnection = connection
+
+	////Invoke the function under test
+	err, resCtx := compareStates(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Validate state attributes
+	assert.Equal(suite.T(), client.DeletePsaConnection, state.curState)
+	assert.Equal(suite.T(), client.MODIFY, state.connectionOp)
+	assert.Equal(suite.T(), client.DELETE, state.addressOp)
+	assert.False(suite.T(), state.inSync)
+}
+
+func (suite *compareStatesSuite) TestWhenNotDeleting_NoAddressOrConnectionExists() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Get the updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	////Invoke the function under test
+	err, resCtx := compareStates(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Validate state attributes
+	assert.Equal(suite.T(), client.SyncAddress, state.curState)
+	assert.Equal(suite.T(), client.ADD, state.connectionOp)
+	assert.Equal(suite.T(), client.ADD, state.addressOp)
+	assert.False(suite.T(), state.inSync)
+}
+
+func (suite *compareStatesSuite) TestWhenNotDeleting_AddressExistsAndNoConnectionExists() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Get the updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	//Set Address
+	address := &compute.Address{
+		Address:      ipAddr,
+		PrefixLength: int64(prefix),
+		Name:         gcpIpRange.Spec.RemoteRef.Name,
+		Network:      state.Scope().Spec.Scope.Gcp.VpcNetwork,
+	}
+	state.address = address
+	state.ipAddress = ipAddr
+	state.prefix = prefix
+
+	////Invoke the function under test
+	err, resCtx := compareStates(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Validate state attributes
+	assert.Equal(suite.T(), client.SyncPsaConnection, state.curState)
+	assert.Equal(suite.T(), client.ADD, state.connectionOp)
+	assert.Equal(suite.T(), client.NONE, state.addressOp)
+	assert.False(suite.T(), state.inSync)
+}
+
+func (suite *compareStatesSuite) TestWhenNotDeleting_AddressNotMatches() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Get the updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	//Set Address
+	address := &compute.Address{
+		Address:      ipAddr,
+		PrefixLength: int64(prefix),
+		Name:         gcpIpRange.Spec.RemoteRef.Name,
+	}
+	state.address = address
+	state.ipAddress = ipAddr
+	state.prefix = prefix + 1
+
+	////Invoke the function under test
+	err, resCtx := compareStates(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Validate state attributes
+	assert.Equal(suite.T(), client.SyncAddress, state.curState)
+	assert.Equal(suite.T(), client.ADD, state.connectionOp)
+	assert.Equal(suite.T(), client.MODIFY, state.addressOp)
+	assert.False(suite.T(), state.inSync)
+}
+
+func (suite *compareStatesSuite) TestWhenNotDeleting_AddressExistsAndConnectionNotInclusive() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Get the updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	//Set Address
+	address := &compute.Address{
+		Address:      ipAddr,
+		PrefixLength: int64(prefix),
+		Name:         gcpIpRange.Spec.RemoteRef.Name,
+		Network:      state.Scope().Spec.Scope.Gcp.VpcNetwork,
+	}
+	state.address = address
+	state.ipAddress = ipAddr
+	state.prefix = prefix
+
+	//Set Connection
+	connection := &servicenetworking.Connection{
+		ReservedPeeringRanges: []string{"test"},
+	}
+	state.serviceConnection = connection
+
+	//Invoke the function under test
+	err, resCtx := compareStates(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Validate state attributes
+	assert.Equal(suite.T(), client.SyncPsaConnection, state.curState)
+	assert.Equal(suite.T(), client.MODIFY, state.connectionOp)
+	assert.Equal(suite.T(), client.NONE, state.addressOp)
+	assert.False(suite.T(), state.inSync)
+}
+
+func (suite *compareStatesSuite) TestWhenNotDeleting_BothAddressAndConnectionExists() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Get the updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	//Set Address
+	address := &compute.Address{
+		Address:      ipAddr,
+		PrefixLength: int64(prefix),
+		Name:         gcpIpRange.Spec.RemoteRef.Name,
+		Network:      state.Scope().Spec.Scope.Gcp.VpcNetwork,
+	}
+	state.address = address
+	state.ipAddress = ipAddr
+	state.prefix = prefix
+
+	//Set Connection
+	connection := &servicenetworking.Connection{
+		ReservedPeeringRanges: []string{gcpIpRange.Spec.RemoteRef.Name},
+	}
+	state.serviceConnection = connection
+
+	////Invoke the function under test
+	err, resCtx := compareStates(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Validate state attributes
+	assert.Equal(suite.T(), cloudcontrolv1beta1.ReadyState, state.curState)
+	assert.Equal(suite.T(), client.NONE, state.connectionOp)
+	assert.Equal(suite.T(), client.NONE, state.addressOp)
+	assert.True(suite.T(), state.inSync)
+}
+
+func TestCompareStates(t *testing.T) {
+	suite.Run(t, new(compareStatesSuite))
+}

--- a/pkg/kcp/provider/gcp/iprange/loadAddress_test.go
+++ b/pkg/kcp/provider/gcp/iprange/loadAddress_test.go
@@ -1,0 +1,232 @@
+package iprange
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/compute/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
+	"testing"
+)
+
+type loadAddressSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *loadAddressSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *loadAddressSuite) TestWhenNotFound() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, getUrlCompute) {
+				//Return 404
+				http.Error(w, "Not Found", http.StatusNotFound)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Invoke the function under test
+	err, resCtx := loadAddress(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error condition in status
+	assert.Len(suite.T(), ipRange.Status.Conditions, 0)
+}
+
+func (suite *loadAddressSuite) TestWhenErrorResponse() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, getUrlCompute) {
+				//Return 404
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Invoke the function under test
+	err, resCtx := loadAddress(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeue, err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error condition in status
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, ipRange.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, ipRange.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), v1beta1.ReasonGcpError, ipRange.Status.Conditions[0].Reason)
+}
+
+func (suite *loadAddressSuite) TestWhenGcpAddressHasWrongVPC() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var resp *compute.Address
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, getUrlCompute) {
+				resp = &compute.Address{
+					Address:      ipAddr,
+					Name:         gcpIpRange.Spec.RemoteRef.Name,
+					Network:      "not-matching-vpc",
+					PrefixLength: int64(prefix),
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(resp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Invoke the function under test
+	err, resCtx := loadAddress(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeue, err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error condition in status
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, ipRange.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, ipRange.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), v1beta1.ReasonGcpError, ipRange.Status.Conditions[0].Reason)
+}
+
+func (suite *loadAddressSuite) TestWhenGcpAddressHasCorrectVPC() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var resp *compute.Address
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, getUrlCompute) {
+				resp = &compute.Address{
+					Address:      ipAddr,
+					Name:         gcpIpRange.Spec.RemoteRef.Name,
+					Network:      "test-vpc",
+					PrefixLength: int64(prefix),
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(resp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Invoke the function under test
+	err, resCtx := loadAddress(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error condition in status
+	assert.Len(suite.T(), ipRange.Status.Conditions, 0)
+	assert.NotNil(suite.T(), state.address)
+}
+
+func TestLoadAddress(t *testing.T) {
+	suite.Run(t, new(loadAddressSuite))
+}

--- a/pkg/kcp/provider/gcp/iprange/loadPsaConnection_test.go
+++ b/pkg/kcp/provider/gcp/iprange/loadPsaConnection_test.go
@@ -1,0 +1,247 @@
+package iprange
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/servicenetworking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
+	"testing"
+)
+
+type loadPsaConnectionSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *loadPsaConnectionSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *loadPsaConnectionSuite) TestWhenIpRangePurposeIsNotPSA() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var resp *servicenetworking.ListConnectionsResponse
+
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, urlSvcNetworking) {
+				resp = &servicenetworking.ListConnectionsResponse{
+					Connections: nil,
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(resp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+	ipRange.Spec.Options.Gcp.Purpose = v1beta1.GcpPurposePSC
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Invoke the function under test
+	err, resCtx := loadPsaConnection(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error condition in status
+	assert.Len(suite.T(), ipRange.Status.Conditions, 0)
+}
+
+func (suite *loadPsaConnectionSuite) TestWhenSvcConnectionNotFound() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var resp *servicenetworking.ListConnectionsResponse
+
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, urlSvcNetworking) {
+				resp = &servicenetworking.ListConnectionsResponse{
+					Connections: nil,
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(resp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Invoke the function under test
+	err, resCtx := loadPsaConnection(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error condition in status
+	assert.Len(suite.T(), ipRange.Status.Conditions, 0)
+}
+
+func (suite *loadPsaConnectionSuite) TestWhenErrorResponse() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, urlSvcNetworking) {
+				//Return 404
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Invoke the function under test
+	err, resCtx := loadPsaConnection(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeue, err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error condition in status
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, ipRange.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, ipRange.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), v1beta1.ReasonGcpError, ipRange.Status.Conditions[0].Reason)
+}
+
+func (suite *loadPsaConnectionSuite) TestWhenMatchingConnectionFound() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var resp *servicenetworking.ListConnectionsResponse
+
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, urlSvcNetworking) {
+				resp = &servicenetworking.ListConnectionsResponse{
+					Connections: []*servicenetworking.Connection{
+						{
+							Network:               "test-vpc",
+							Peering:               client.PsaPeeringName,
+							ReservedPeeringRanges: nil,
+							Service:               client.ServiceNetworkingServiceConnectionName,
+						},
+					},
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(resp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+
+	//Invoke the function under test
+	err, resCtx := loadPsaConnection(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error condition in status
+	assert.NotNil(suite.T(), state.serviceConnection)
+	assert.Len(suite.T(), ipRange.Status.Conditions, 0)
+}
+
+func TestLoadPsaConnection(t *testing.T) {
+	suite.Run(t, new(loadPsaConnectionSuite))
+}

--- a/pkg/kcp/provider/gcp/iprange/state_test.go
+++ b/pkg/kcp/provider/gcp/iprange/state_test.go
@@ -93,14 +93,31 @@ func (f *testStateFactory) newStateWith(ctx context.Context, ipRange *cloudcontr
 	snc, _ := f.serviceNetworkingClientProvider(ctx, "test")
 	cc, _ := f.computeClientProvider(ctx, "test")
 
-	return newState(newTypesState(
-		focal.NewStateFactory().NewState(
-			composed.NewStateFactory(f.kcpCluster).NewState(
-				types.NamespacedName{
-					Name:      ipRange.Name,
-					Namespace: ipRange.Namespace,
+	focalState := focal.NewStateFactory().NewState(
+		composed.NewStateFactory(f.kcpCluster).NewState(
+			types.NamespacedName{
+				Name:      ipRange.Name,
+				Namespace: ipRange.Namespace,
+			},
+			ipRange))
+
+	focalState.SetScope(&cloudcontrolv1beta1.Scope{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kymaRef.Name,
+			Namespace: kymaRef.Namespace,
+		},
+		Spec: cloudcontrolv1beta1.ScopeSpec{
+			Region: "us-west1",
+			Scope: cloudcontrolv1beta1.ScopeInfo{
+				Gcp: &cloudcontrolv1beta1.GcpScope{
+					Project:    "test-project",
+					VpcNetwork: "test-vpc",
 				},
-				ipRange))), snc, cc), nil
+			},
+		},
+	})
+
+	return newState(newTypesState(focalState), snc, cc), nil
 
 }
 

--- a/pkg/kcp/provider/gcp/iprange/syncAddress_test.go
+++ b/pkg/kcp/provider/gcp/iprange/syncAddress_test.go
@@ -1,0 +1,266 @@
+package iprange
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/compute/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
+	"testing"
+)
+
+type syncAddressSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *syncAddressSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *syncAddressSuite) TestCreateSuccess() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var resp *compute.Operation
+		switch r.Method {
+		case http.MethodPost:
+			if strings.HasSuffix(r.URL.Path, urlGlobalAddress) {
+				resp = &compute.Operation{
+					Name: opIdentifier,
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(resp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+	state.addressOp = client.ADD
+
+	//Invoke the function under test
+	err, resCtx := syncAddress(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpOperationWaitTime), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error operationId  in status
+	assert.Equal(suite.T(), opIdentifier, ipRange.Status.OpIdentifier)
+}
+
+func (suite *syncAddressSuite) TestCreateFailure() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			if strings.HasSuffix(r.URL.Path, urlGlobalAddress) {
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+	state.addressOp = client.ADD
+
+	//Invoke the function under test
+	err, resCtx := syncAddress(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error condition in status
+	assert.Len(suite.T(), ipRange.Status.Conditions, 1)
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, ipRange.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, ipRange.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), v1beta1.ReasonGcpError, ipRange.Status.Conditions[0].Reason)
+}
+func (suite *syncAddressSuite) TestUpdate() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+	state.addressOp = client.MODIFY
+
+	//Invoke the function under test
+	err, resCtx := syncAddress(ctx, state)
+	assert.Equal(suite.T(), composed.StopAndForget, err)
+	assert.Nil(suite.T(), resCtx)
+}
+
+func (suite *syncAddressSuite) TestDeleteSuccess() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var resp *compute.Operation
+		switch r.Method {
+		case http.MethodDelete:
+			if strings.HasSuffix(r.URL.Path, getUrlCompute) {
+				resp = &compute.Operation{
+					Name: opIdentifier,
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(resp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+	state.addressOp = client.DELETE
+
+	//Invoke the function under test
+	err, resCtx := syncAddress(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpOperationWaitTime), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error operationId  in status
+	assert.Equal(suite.T(), opIdentifier, ipRange.Status.OpIdentifier)
+}
+
+func (suite *syncAddressSuite) TestDeleteFailure() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var resp *compute.Operation
+		switch r.Method {
+		case http.MethodDelete:
+			if strings.HasSuffix(r.URL.Path, getUrlCompute) {
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(resp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+	state.addressOp = client.DELETE
+
+	//Invoke the function under test
+	err, resCtx := syncAddress(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error condition in status
+	assert.Len(suite.T(), ipRange.Status.Conditions, 1)
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, ipRange.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, ipRange.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), v1beta1.ReasonGcpError, ipRange.Status.Conditions[0].Reason)
+}
+
+func TestSyncAddress(t *testing.T) {
+	suite.Run(t, new(syncAddressSuite))
+}

--- a/pkg/kcp/provider/gcp/iprange/syncPsaConnection_test.go
+++ b/pkg/kcp/provider/gcp/iprange/syncPsaConnection_test.go
@@ -1,0 +1,319 @@
+package iprange
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/servicenetworking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
+	"testing"
+)
+
+type syncPsaConnectionSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *syncPsaConnectionSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *syncPsaConnectionSuite) TestCreateSuccess() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var resp *compute.Operation
+		switch r.Method {
+		case http.MethodPost:
+			if strings.HasSuffix(r.URL.Path, urlSvcNetworking) {
+				resp = &compute.Operation{
+					Name: opIdentifier,
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(resp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+	state.connectionOp = client.ADD
+
+	//Invoke the function under test
+	err, resCtx := syncPsaConnection(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpOperationWaitTime), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error operationId  in status
+	assert.Equal(suite.T(), opIdentifier, ipRange.Status.OpIdentifier)
+}
+
+func (suite *syncPsaConnectionSuite) TestCreateFailure() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var resp *compute.Operation
+		switch r.Method {
+		case http.MethodPost:
+			if strings.HasSuffix(r.URL.Path, urlSvcNetworking) {
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		b, err := json.Marshal(resp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+	state.connectionOp = client.ADD
+
+	//Invoke the function under test
+	err, resCtx := syncPsaConnection(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error condition in status
+	assert.Len(suite.T(), ipRange.Status.Conditions, 1)
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, ipRange.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, ipRange.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), v1beta1.ReasonGcpError, ipRange.Status.Conditions[0].Reason)
+}
+func (suite *syncPsaConnectionSuite) TestUpdate() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPatch:
+			if strings.HasSuffix(r.URL.Path, getUrlSvcNw) {
+				resp := &servicenetworking.Operation{
+					Done: true,
+					Name: opIdentifier,
+				}
+				b, err := json.Marshal(resp)
+				if err != nil {
+					assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+				}
+				_, err = w.Write(b)
+				if err != nil {
+					assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+	state.connectionOp = client.MODIFY
+
+	//Invoke the function under test
+	err, resCtx := syncPsaConnection(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpOperationWaitTime), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error operationId  in status
+	assert.Equal(suite.T(), opIdentifier, ipRange.Status.OpIdentifier)
+}
+
+func (suite *syncPsaConnectionSuite) TestDeleteSuccess() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, getUrlCrmSvc) {
+				resp := &cloudresourcemanager.Project{
+					Name:          "test-project",
+					ProjectId:     "test-project",
+					ProjectNumber: 12345,
+				}
+				b, err := json.Marshal(resp)
+				if err != nil {
+					assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+				}
+				_, err = w.Write(b)
+				if err != nil {
+					assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		case http.MethodPost:
+			if strings.HasSuffix(r.URL.Path, getUrlSvcNw) {
+				resp := &servicenetworking.Operation{
+					Done: true,
+					Name: opIdentifier,
+				}
+				b, err := json.Marshal(resp)
+				if err != nil {
+					assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
+				}
+				_, err = w.Write(b)
+				if err != nil {
+					assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+				}
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+	state.connectionOp = client.DELETE
+
+	//Invoke the function under test
+	err, resCtx := syncPsaConnection(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpOperationWaitTime), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error operationId  in status
+	assert.Equal(suite.T(), opIdentifier, ipRange.Status.OpIdentifier)
+}
+
+func (suite *syncPsaConnectionSuite) TestDeleteFailure() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, getUrlCrmSvc) {
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		case http.MethodPost:
+			if strings.HasSuffix(r.URL.Path, getUrlSvcNw) {
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+	state.connectionOp = client.DELETE
+
+	//Invoke the function under test
+	err, resCtx := syncPsaConnection(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check error condition in status
+	assert.Len(suite.T(), ipRange.Status.Conditions, 1)
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, ipRange.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, ipRange.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), v1beta1.ReasonGcpError, ipRange.Status.Conditions[0].Reason)
+}
+
+func TestSyncPsaConnection(t *testing.T) {
+	suite.Run(t, new(syncPsaConnectionSuite))
+}

--- a/pkg/kcp/provider/gcp/iprange/updateState_test.go
+++ b/pkg/kcp/provider/gcp/iprange/updateState_test.go
@@ -1,0 +1,104 @@
+package iprange
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+type updateStateSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *updateStateSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *updateStateSuite) TestStateChangeToReady() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+	state.curState = v1beta1.ReadyState
+
+	//Invoke the function under test
+	err, resCtx := updateState(ctx, state)
+	assert.Equal(suite.T(), composed.StopAndForget, err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check ready condition in status
+	assert.Equal(suite.T(), v1beta1.ReadyState, ipRange.Status.State)
+	assert.Equal(suite.T(), gcpIpRange.Spec.Cidr, ipRange.Status.Cidr)
+	assert.Len(suite.T(), ipRange.Status.Conditions, 1)
+	assert.Equal(suite.T(), v1beta1.ConditionTypeReady, ipRange.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), metav1.ConditionTrue, ipRange.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), v1beta1.ReasonReady, ipRange.Status.Conditions[0].Reason)
+}
+
+func (suite *updateStateSuite) TestStateChangeToOther() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	factory, err := newTestStateFactory(fakeHttpServer)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with ipRange
+	ipRange := gcpIpRange.DeepCopy()
+
+	state, err := factory.newStateWith(ctx, ipRange)
+	assert.Nil(suite.T(), err)
+	state.curState = client.SyncPsaConnection
+
+	//Invoke the function under test
+	err, resCtx := updateState(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeue, err)
+	assert.Nil(suite.T(), resCtx)
+
+	//Load updated object
+	err = state.LoadObj(ctx)
+	assert.Nil(suite.T(), err)
+	ipRange = state.ObjAsIpRange()
+
+	// check state in status
+	assert.Equal(suite.T(), client.SyncPsaConnection, ipRange.Status.State)
+	assert.Equal(suite.T(), "", ipRange.Status.Cidr)
+	assert.Len(suite.T(), ipRange.Status.Conditions, 0)
+}
+
+func TestUpdateState(t *testing.T) {
+	suite.Run(t, new(updateStateSuite))
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
Gcp IpRange Reconciler unit tests for 
- CheckGcpOperation
- CompareStates
- LoadAddress
- LoadPsaConnection
- SyncAddress
- SyncPsaConnection
- UpdateState

**Related issue(s)**

https://jira.tools.sap/browse/PHX-56
