### PR TITLE
scope fix upon deployment - in Kyma CR module first appears in the st…

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -65,7 +65,7 @@ rules:
 - apiGroups:
   - cloud-control.kyma-project.io
   resources:
-  - scope
+  - scopes
   verbs:
   - create
   - delete
@@ -77,13 +77,13 @@ rules:
 - apiGroups:
   - cloud-control.kyma-project.io
   resources:
-  - scope/finalizers
+  - scopes/finalizers
   verbs:
   - update
 - apiGroups:
   - cloud-control.kyma-project.io
   resources:
-  - scope/status
+  - scopes/status
   verbs:
   - get
   - patch

--- a/internal/controller/cloud-control/scope_aws_test.go
+++ b/internal/controller/cloud-control/scope_aws_test.go
@@ -27,7 +27,7 @@ var _ = Describe("KCP Scope", func() {
 		kymaCR := util.NewKymaUnstructured()
 		By("And Given Kyma CR exists", func() {
 			Eventually(CreateKymaCR).
-				WithArguments(infra.Ctx(), infra, kymaCR, WithName(kymaName)).
+				WithArguments(infra.Ctx(), infra, kymaCR, WithName(kymaName), WithKymaSpecChannel("dev")).
 				Should(Succeed(), "failed creating kyma cr")
 		})
 
@@ -41,10 +41,10 @@ var _ = Describe("KCP Scope", func() {
 				Should(Not(Succeed()), "expected Scope not to exist")
 		})
 
-		By("When Kyma Module is listed in spec", func() {
-			Eventually(UpdateObj).
-				WithArguments(infra.Ctx(), infra.KCP().Client(), kymaCR, WithKymaModuleState(util.KymaModuleStateProcessing), WithKymaModuleChannelInSpec("dev")).
-				Should(Succeed(), "failed updating KymaCR module to Ready state")
+		By("When Kyma Module is listed in status in Processing state", func() {
+			Eventually(UpdateStatus).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), kymaCR, WithKymaStatusModuleState(util.KymaModuleStateProcessing)).
+				Should(Succeed(), "failed updating KymaCR module to Processing state")
 
 			Eventually(LoadAndCheck).
 				WithArguments(infra.Ctx(), infra.KCP().Client(), scope, NewObjActions(WithName(kymaName))).

--- a/internal/controller/cloud-control/scope_aws_test.go
+++ b/internal/controller/cloud-control/scope_aws_test.go
@@ -43,7 +43,7 @@ var _ = Describe("KCP Scope", func() {
 
 		By("When Kyma Module is listed in spec", func() {
 			Eventually(UpdateObj).
-				WithArguments(infra.Ctx(), infra.KCP().Client(), kymaCR, WithKymaModuleListedInSpec(), WithKymaModuleChannelInSpec("dev")).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), kymaCR, WithKymaModuleState(util.KymaModuleStateProcessing), WithKymaModuleChannelInSpec("dev")).
 				Should(Succeed(), "failed updating KymaCR module to Ready state")
 
 			Eventually(LoadAndCheck).

--- a/internal/controller/cloud-control/scope_aws_test.go
+++ b/internal/controller/cloud-control/scope_aws_test.go
@@ -41,11 +41,13 @@ var _ = Describe("KCP Scope", func() {
 				Should(Not(Succeed()), "expected Scope not to exist")
 		})
 
-		By("When Kyma Module is listed in status in Processing state", func() {
+		By("When Kyma Module is listed in status", func() {
 			Eventually(UpdateStatus).
 				WithArguments(infra.Ctx(), infra.KCP().Client(), kymaCR, WithKymaStatusModuleState(util.KymaModuleStateProcessing)).
 				Should(Succeed(), "failed updating KymaCR module to Processing state")
+		})
 
+		By("Then Scope is created", func() {
 			Eventually(LoadAndCheck).
 				WithArguments(infra.Ctx(), infra.KCP().Client(), scope, NewObjActions(WithName(kymaName))).
 				Should(Succeed(), "expected Scope to be created")

--- a/internal/controller/cloud-control/scope_controller.go
+++ b/internal/controller/cloud-control/scope_controller.go
@@ -44,9 +44,9 @@ type ScopeReconciler struct {
 	Reconciler kcpscope.ScopeReconciler
 }
 
-//+kubebuilder:rbac:groups=cloud-control.kyma-project.io,resources=scope,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=cloud-control.kyma-project.io,resources=scope/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=cloud-control.kyma-project.io,resources=scope/finalizers,verbs=update
+//+kubebuilder:rbac:groups=cloud-control.kyma-project.io,resources=scopes,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=cloud-control.kyma-project.io,resources=scopes/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=cloud-control.kyma-project.io,resources=scopes/finalizers,verbs=update
 // +kubebuilder:rbac:groups=operator.kyma-project.io,resources=kymas,verbs=get;list;watch
 // +kubebuilder:rbac:groups=operator.kyma-project.io,resources=kymas/status,verbs=get
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get

--- a/pkg/kcp/scope/findKymaModuleState.go
+++ b/pkg/kcp/scope/findKymaModuleState.go
@@ -9,8 +9,12 @@ import (
 func findKymaModuleState(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
 
-	isListed := util.IsKymaModuleListedInSpec(state.kyma, "cloud-manager")
-
+	// Once module is added to the SKR Kyma CR, in KCP it first appears in the status field
+	// with state: Processing, and it does not appear in the spec
+	moduleState := util.GetKymaModuleStateFromStatus(state.kyma, "cloud-manager")
+	//isListed := util.IsKymaModuleListedInSpec(state.kyma, "cloud-manager")
+	isListed := moduleState != util.KymaModuleStateNotPresent
+	
 	if !isListed {
 		return composed.StopAndForget, nil
 	}

--- a/pkg/kcp/scope/findKymaModuleState.go
+++ b/pkg/kcp/scope/findKymaModuleState.go
@@ -14,7 +14,7 @@ func findKymaModuleState(ctx context.Context, st composed.State) (error, context
 	moduleState := util.GetKymaModuleStateFromStatus(state.kyma, "cloud-manager")
 	//isListed := util.IsKymaModuleListedInSpec(state.kyma, "cloud-manager")
 	isListed := moduleState != util.KymaModuleStateNotPresent
-	
+
 	if !isListed {
 		return composed.StopAndForget, nil
 	}

--- a/pkg/testinfra/dsl/kyma.go
+++ b/pkg/testinfra/dsl/kyma.go
@@ -17,7 +17,7 @@ const (
 	DefaultModuleName = "cloud-manager"
 )
 
-func WithKymaModuleChannelInSpec(channel string) ObjAction {
+func WithKymaSpecChannel(channel string) ObjAction {
 	return &objAction{
 		f: func(obj client.Object) {
 			if channel == "" {
@@ -69,7 +69,7 @@ func WithKymaModuleRemovedInSpec() ObjAction {
 	}
 }
 
-func WithKymaModuleState(state util.KymaModuleState) ObjStatusAction {
+func WithKymaStatusModuleState(state util.KymaModuleState) ObjStatusAction {
 	return &objStatusAction{
 		f: func(obj client.Object) {
 			x, ok := obj.(*unstructured.Unstructured)

--- a/pkg/testinfra/gherkin.go
+++ b/pkg/testinfra/gherkin.go
@@ -36,9 +36,15 @@ type node struct {
 }
 
 func (n *node) prepare() {
+	addChildrenDurations := false
+	if n.duration == 0 {
+		addChildrenDurations = true
+	}
 	for _, child := range n.items {
 		child.prepare()
-		//n.duration = n.duration + child.duration
+		if addChildrenDurations {
+			n.duration = n.duration + child.duration
+		}
 	}
 }
 
@@ -46,7 +52,7 @@ func (n *node) print() {
 	color.NoColor = false
 	fmt.Println()
 	n.prepare()
-	n.printInternal(0, n.maxNameLen()+14) // 14 estimated max indent
+	n.printInternal(0, n.maxNameLen()+24) // 14 estimated max indent
 }
 
 func (n *node) maxNameLen() int {


### PR DESCRIPTION
…atus and not in spec

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- changed Scope reconciler to look for activated module in the Kyma CR status, instead of spec as it did so far
- fixed RBAC, ranamed scope to scopes

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
