### PR TITLE
use api reader to get secrets

### DIFF
--- a/pkg/composed/state.go
+++ b/pkg/composed/state.go
@@ -10,15 +10,18 @@ import (
 )
 
 func NewStateClusterFromCluster(cluster cluster.Cluster) StateCluster {
-	return NewStateCluster(cluster.GetClient(), cluster.GetEventRecorderFor("cloud-manager"), cluster.GetScheme())
+	return NewStateCluster(cluster.GetClient(), cluster.GetAPIReader(), cluster.GetEventRecorderFor("cloud-manager"), cluster.GetScheme())
 }
 
-func NewStateCluster(client client.Client,
+func NewStateCluster(
+	client client.Client,
+	reader client.Reader,
 	eventRecorder record.EventRecorder,
 	scheme *runtime.Scheme,
 ) StateCluster {
 	return &stateCluster{
 		client:        client,
+		reader:        reader,
 		eventRecorder: eventRecorder,
 		scheme:        scheme,
 	}
@@ -26,18 +29,24 @@ func NewStateCluster(client client.Client,
 
 type StateCluster interface {
 	K8sClient() client.Client
+	ApiReader() client.Reader
 	EventRecorder() record.EventRecorder
 	Scheme() *runtime.Scheme
 }
 
 type stateCluster struct {
 	client        client.Client
+	reader        client.Reader
 	eventRecorder record.EventRecorder
 	scheme        *runtime.Scheme
 }
 
 func (c *stateCluster) K8sClient() client.Client {
 	return c.client
+}
+
+func (c *stateCluster) ApiReader() client.Reader {
+	return c.reader
 }
 
 func (c *stateCluster) EventRecorder() record.EventRecorder {

--- a/pkg/kcp/provider/gcp/iprange/state_test.go
+++ b/pkg/kcp/provider/gcp/iprange/state_test.go
@@ -71,7 +71,7 @@ func newTestStateFactory(fakeHttpServer *httptest.Server) (*testStateFactory, er
 		WithObjects(&gcpIpRange).
 		WithStatusSubresource(&gcpIpRange).
 		Build()
-	kcpCluster := composed.NewStateCluster(kcpClient, nil, kcpScheme)
+	kcpCluster := composed.NewStateCluster(kcpClient, kcpClient, nil, kcpScheme)
 
 	computeClientProvider := newFakeComputeClientProvider(fakeHttpServer)
 	svcNwClientProvider := newFakeServiceNetworkingProvider(fakeHttpServer)

--- a/pkg/kcp/provider/gcp/nfsinstance/state_test.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/state_test.go
@@ -122,7 +122,7 @@ func newTestStateFactory(fakeHttpServer *httptest.Server, objects ...*cloudcontr
 	}
 	kcpClient := kcpClientBuilder.
 		Build()
-	kcpCluster := composed.NewStateCluster(kcpClient, nil, kcpScheme)
+	kcpCluster := composed.NewStateCluster(kcpClient, kcpClient, nil, kcpScheme)
 	fakeFileStoreClientProvider := NewFakeFilestoreClientProvider(fakeHttpServer)
 	factory := NewStateFactory(fakeFileStoreClientProvider, abstractions.NewMockedEnvironment(map[string]string{"GCP_SA_JSON_KEY_PATH": "test"}))
 

--- a/pkg/kcp/scope/createGardenerClient.go
+++ b/pkg/kcp/scope/createGardenerClient.go
@@ -19,7 +19,7 @@ func createGardenerClient(ctx context.Context, st composed.State) (error, contex
 	logger.Info("Loading gardener credentials")
 
 	secret := &corev1.Secret{}
-	err := state.Cluster().K8sClient().Get(ctx, types.NamespacedName{
+	err := state.Cluster().ApiReader().Get(ctx, types.NamespacedName{
 		Namespace: "kcp-system",
 		Name:      "gardener-credentials",
 	}, secret)

--- a/pkg/skr/gcpnfsvolume/reconciler.go
+++ b/pkg/skr/gcpnfsvolume/reconciler.go
@@ -52,8 +52,8 @@ func (r *Reconciler) newAction() composed.Action {
 }
 
 func NewReconciler(kymaRef klog.ObjectRef, kcpCluster cluster.Cluster, skrCluster cluster.Cluster) Reconciler {
-	compSkrCluster := composed.NewStateCluster(skrCluster.GetClient(), skrCluster.GetEventRecorderFor("cloud-resources"), skrCluster.GetScheme())
-	compKcpCluster := composed.NewStateCluster(kcpCluster.GetClient(), kcpCluster.GetEventRecorderFor("cloud-control"), kcpCluster.GetScheme())
+	compSkrCluster := composed.NewStateCluster(skrCluster.GetClient(), skrCluster.GetAPIReader(), skrCluster.GetEventRecorderFor("cloud-resources"), skrCluster.GetScheme())
+	compKcpCluster := composed.NewStateCluster(kcpCluster.GetClient(), kcpCluster.GetAPIReader(), kcpCluster.GetEventRecorderFor("cloud-control"), kcpCluster.GetScheme())
 	composedStateFactory := composed.NewStateFactory(compSkrCluster)
 	stateFactory := NewStateFactory(kymaRef, compKcpCluster, compSkrCluster)
 	return Reconciler{

--- a/pkg/skr/gcpnfsvolume/state_test.go
+++ b/pkg/skr/gcpnfsvolume/state_test.go
@@ -251,7 +251,7 @@ func newTestStateFactory() (*testStateFactory, error) {
 		WithObjects(&gcpNfsInstanceToDelete).
 		WithStatusSubresource(&gcpNfsInstanceToDelete).
 		Build()
-	kcpCluster := composed.NewStateCluster(kcpClient, nil, kcpScheme)
+	kcpCluster := composed.NewStateCluster(kcpClient, kcpClient, nil, kcpScheme)
 
 	skrScheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(skrScheme))
@@ -264,7 +264,7 @@ func newTestStateFactory() (*testStateFactory, error) {
 		WithObjects(&deletedGcpNfsVolume).
 		WithStatusSubresource(&deletedGcpNfsVolume).
 		Build()
-	skrCluster := composed.NewStateCluster(skrClient, nil, skrScheme)
+	skrCluster := composed.NewStateCluster(skrClient, skrClient, nil, skrScheme)
 
 	factory := NewStateFactory(kymaRef, kcpCluster, skrCluster)
 

--- a/pkg/testinfra/run.go
+++ b/pkg/testinfra/run.go
@@ -111,6 +111,10 @@ func Start() (Infra, error) {
 			},
 		},
 	})
+	reader := kcpMgr.GetAPIReader()
+	if reader == nil {
+		return nil, errors.New("KCP Manager API Reader is nil")
+	}
 	if err != nil {
 		return nil, fmt.Errorf("error creating KCP manager: %w", err)
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- changed get Gardener secret to use API Reader and not the caching client as so far to avoid necessary list/watch permissions on secerets
- added `ApiReader() client.Reader` to `composed.State`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
