### PR TITLE
ipRange and gcpNfsVolume to show Ready/Error status on kubectl get

### DIFF
--- a/api/cloud-resources/v1beta1/gcpnfsvolume_types.go
+++ b/api/cloud-resources/v1beta1/gcpnfsvolume_types.go
@@ -74,6 +74,9 @@ type GcpNfsVolumeStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status"
+// +kubebuilder:printcolumn:name="Error",type="string",JSONPath=".status.conditions[?(@.type==\"Error\")].status"
 
 // GcpNfsVolume is the Schema for the gcpnfsvolumes API
 type GcpNfsVolume struct {

--- a/api/cloud-resources/v1beta1/iprange_types.go
+++ b/api/cloud-resources/v1beta1/iprange_types.go
@@ -47,8 +47,12 @@ type IpRangeStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="cidr",type="string",JSONPath=".spec.cidr"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status"
+// +kubebuilder:printcolumn:name="Error",type="string",JSONPath=".status.conditions[?(@.type==\"Error\")].status"
 
 // IpRange is the Schema for the ipranges API
 type IpRange struct {

--- a/config/crd/bases/cloud-resources.kyma-project.io_gcpnfsvolumes.yaml
+++ b/config/crd/bases/cloud-resources.kyma-project.io_gcpnfsvolumes.yaml
@@ -14,7 +14,17 @@ spec:
     singular: gcpnfsvolume
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Error")].status
+      name: Error
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: GcpNfsVolume is the Schema for the gcpnfsvolumes API

--- a/config/crd/bases/cloud-resources.kyma-project.io_ipranges.yaml
+++ b/config/crd/bases/cloud-resources.kyma-project.io_ipranges.yaml
@@ -14,7 +14,20 @@ spec:
     singular: iprange
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.cidr
+      name: cidr
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Error")].status
+      name: Error
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: IpRange is the Schema for the ipranges API

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,20 +5,26 @@ resources:
 - secret-gcp.yaml
 
 configMapGenerator:
-  - name: manager-env
-    behavior: merge
-    literals:
-      - GARDENER_NAMESPACE=garden-spm-test01
-      - SKR_PROVIDERS=/var/kyma/cloud-manager/skr/providers/
+- behavior: merge
+  literals:
+  - GARDENER_NAMESPACE=garden-spm-test01
+  - SKR_PROVIDERS=/var/kyma/cloud-manager/skr/providers/
+  name: manager-env
 
 secretGenerator:
-  - name: manager-env-aws
-    behavior: merge
-    literals:
-      - AWS_ROLE_NAME=CrossAccountPowerUser
-      - AWS_ACCESS_KEY_ID=xxx
-      - AWS_SECRET_ACCESS_KEY=xxx
-  - name: manager-env-gcp
-    behavior: merge
-    literals:
-      - credentials.json=xxx
+- behavior: merge
+  literals:
+  - AWS_ROLE_NAME=CrossAccountPowerUser
+  - AWS_ACCESS_KEY_ID=xxx
+  - AWS_SECRET_ACCESS_KEY=xxx
+  name: manager-env-aws
+- behavior: merge
+  literals:
+  - credentials.json=xxx
+  name: manager-env-gcp
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: controller
+  newTag: latest


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- adding "READY" and "ERROR" column to "kubectl get" result of cloud-resources gcpNfsVolume
- adding "READY" and "ERROR" column to "kubectl get" result of cloud-resources ipRange
For the details please visit: https://jira.tools.sap/browse/PHX-59

**Related issue(s)**
https://jira.tools.sap/browse/PHX-59
https://jira.tools.sap/browse/PHX-60