### PR TITLE
awsnfsvolume to show Ready/Error status on kubectl get

### DIFF
--- a/api/cloud-resources/v1beta1/awsnfsvolume_types.go
+++ b/api/cloud-resources/v1beta1/awsnfsvolume_types.go
@@ -71,6 +71,9 @@ type AwsNfsVolumeStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status"
+// +kubebuilder:printcolumn:name="Error",type="string",JSONPath=".status.conditions[?(@.type==\"Error\")].status"
 
 // AwsNfsVolume is the Schema for the awsnfsvolumes API
 type AwsNfsVolume struct {

--- a/config/crd/bases/cloud-resources.kyma-project.io_awsnfsvolumes.yaml
+++ b/config/crd/bases/cloud-resources.kyma-project.io_awsnfsvolumes.yaml
@@ -14,7 +14,17 @@ spec:
     singular: awsnfsvolume
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Error")].status
+      name: Error
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: AwsNfsVolume is the Schema for the awsnfsvolumes API


### PR DESCRIPTION
Description

Changes proposed in this pull request:

adding "READY" and "ERROR" column to "kubectl get" result of cloud-resources awsNfsVolume

For the details please visit: https://jira.tools.sap/browse/PHX-59
Related issue(s)
https://jira.tools.sap/browse/PHX-61