### PR TITLE
fix: rc-tag is missing from security scans config

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,4 +1,5 @@
 module-name: cloud-manager
+rc-tag: 0.1.2
 protecode:
   - europe-docker.pkg.dev/kyma-project/prod/cloud-manager:v20240311-5cf288e9
 whitesource:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Adds rc-tag to security scans config
