### PR TITLE
fix: aws cached client

### DIFF
--- a/pkg/kcp/provider/aws/client/provider.go
+++ b/pkg/kcp/provider/aws/client/provider.go
@@ -2,41 +2,8 @@ package client
 
 import (
 	"context"
-	"sync"
 )
 
 type GardenClientProvider[T any] func(ctx context.Context, region, key, secret string) (T, error)
 
 type SkrClientProvider[T any] func(ctx context.Context, region, key, secret, role string) (T, error)
-
-func NewCachedGardenClientProvider[T comparable](p GardenClientProvider[T]) GardenClientProvider[T] {
-	var result T
-	var nilT T
-	var m sync.Mutex
-	return func(ctx context.Context, region, key, secret string) (T, error) {
-		m.Lock()
-		defer m.Unlock()
-
-		var err error
-		if result == nilT {
-			result, err = p(ctx, region, key, secret)
-		}
-		return result, err
-	}
-}
-
-func NewCachedSkrClientProvider[T comparable](p SkrClientProvider[T]) SkrClientProvider[T] {
-	var result T
-	var nilT T
-	var m sync.Mutex
-	return func(ctx context.Context, region, key, secret, role string) (T, error) {
-		m.Lock()
-		defer m.Unlock()
-
-		var err error
-		if result == nilT {
-			result, err = p(ctx, region, key, secret, role)
-		}
-		return result, err
-	}
-}

--- a/pkg/kcp/provider/aws/iprange/client/client.go
+++ b/pkg/kcp/provider/aws/iprange/client/client.go
@@ -19,15 +19,13 @@ type Client interface {
 }
 
 func NewClientProvider() client2.SkrClientProvider[Client] {
-	return client2.NewCachedSkrClientProvider(
-		func(ctx context.Context, region, key, secret, role string) (Client, error) {
-			cfg, err := client2.NewSkrConfig(ctx, region, key, secret, role)
-			if err != nil {
-				return nil, err
-			}
-			return newClient(ec2.NewFromConfig(cfg)), nil
-		},
-	)
+	return func(ctx context.Context, region, key, secret, role string) (Client, error) {
+		cfg, err := client2.NewSkrConfig(ctx, region, key, secret, role)
+		if err != nil {
+			return nil, err
+		}
+		return newClient(ec2.NewFromConfig(cfg)), nil
+	}
 }
 
 func newClient(svc *ec2.Client) Client {

--- a/pkg/kcp/provider/aws/nfsinstance/client/client.go
+++ b/pkg/kcp/provider/aws/nfsinstance/client/client.go
@@ -17,18 +17,16 @@ const (
 )
 
 func NewClientProvider() client2.SkrClientProvider[Client] {
-	return client2.NewCachedSkrClientProvider(
-		func(ctx context.Context, region, key, secret, role string) (Client, error) {
-			cfg, err := client2.NewSkrConfig(ctx, region, key, secret, role)
-			if err != nil {
-				return nil, err
-			}
-			return newClient(
-				ec2.NewFromConfig(cfg),
-				efs.NewFromConfig(cfg),
-			), nil
-		},
-	)
+	return func(ctx context.Context, region, key, secret, role string) (Client, error) {
+		cfg, err := client2.NewSkrConfig(ctx, region, key, secret, role)
+		if err != nil {
+			return nil, err
+		}
+		return newClient(
+			ec2.NewFromConfig(cfg),
+			efs.NewFromConfig(cfg),
+		), nil
+	}
 }
 
 type Client interface {

--- a/pkg/kcp/scope/client/awsStsClient.go
+++ b/pkg/kcp/scope/client/awsStsClient.go
@@ -7,15 +7,13 @@ import (
 )
 
 func NewAwsStsGardenClientProvider() client.GardenClientProvider[AwsStsClient] {
-	return client.NewCachedGardenClientProvider(
-		func(ctx context.Context, region, key, secret string) (AwsStsClient, error) {
-			cfg, err := client.NewGardenConfig(ctx, region, key, secret)
-			if err != nil {
-				return nil, err
-			}
-			return newAwsStsClient(sts.NewFromConfig(cfg)), nil
-		},
-	)
+	return func(ctx context.Context, region, key, secret string) (AwsStsClient, error) {
+		cfg, err := client.NewGardenConfig(ctx, region, key, secret)
+		if err != nil {
+			return nil, err
+		}
+		return newAwsStsClient(sts.NewFromConfig(cfg)), nil
+	}
 }
 
 type AwsStsClient interface {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- fixes aws cached client - single cached instance can not be used due to different assumed roles and regions, so each reconcile loop must instantiate it's own

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
