### PR TITLE
fix: ctx must be supplied to LogErrorAndReturn()

### DIFF
--- a/pkg/common/actions/removeFinalizer.go
+++ b/pkg/common/actions/removeFinalizer.go
@@ -23,7 +23,7 @@ func RemoveFinalizer(ctx context.Context, state composed.State) (error, context.
 	//Remove finalizer
 	controllerutil.RemoveFinalizer(state.Obj(), cloudresourcesv1beta1.FinalizerName)
 	if err := state.UpdateObj(ctx); err != nil {
-		return composed.LogErrorAndReturn(err, "Error removing Finalizer", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error removing Finalizer", composed.StopWithRequeue, ctx)
 	}
 
 	//stop reconciling loop.

--- a/pkg/composed/logger.go
+++ b/pkg/composed/logger.go
@@ -2,6 +2,7 @@ package composed
 
 import (
 	"context"
+	"errors"
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -18,6 +19,9 @@ func LoggerIntoCtx(ctx context.Context, logger logr.Logger) context.Context {
 
 func LogErrorAndReturn(err error, msg string, result error, ctx context.Context) (error, context.Context) {
 	logger := LoggerFromCtx(ctx)
+	if ctx == nil {
+		logger.Error(errors.New("the ctx is not supplied to LogErrorAndReturn"), "Logical error")
+	}
 	logger.Error(err, msg)
 	return result, ctx
 }

--- a/pkg/kcp/nfsinstance/loadIpRange.go
+++ b/pkg/kcp/nfsinstance/loadIpRange.go
@@ -25,7 +25,7 @@ func loadIpRange(ctx context.Context, st composed.State) (error, context.Context
 	}, ipRange)
 
 	if client.IgnoreNotFound(err) != nil {
-		return composed.LogErrorAndReturn(err, "Error loading referred IpRange", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error loading referred IpRange", composed.StopWithRequeue, ctx)
 	}
 
 	if apierrors.IsNotFound(err) {
@@ -41,7 +41,7 @@ func loadIpRange(ctx context.Context, st composed.State) (error, context.Context
 		state.ObjAsNfsInstance().Status.State = cloudresourcesv1beta1.ErrorState
 		err = state.UpdateObjStatus(ctx)
 		if err != nil {
-			return composed.LogErrorAndReturn(err, "Error updating NfsInstance status after referred IpRange not found", composed.StopWithRequeue, nil)
+			return composed.LogErrorAndReturn(err, "Error updating NfsInstance status after referred IpRange not found", composed.StopWithRequeue, ctx)
 		}
 
 		return composed.StopAndForget, nil

--- a/pkg/kcp/provider/aws/iprange/checkCidrBlockStatus.go
+++ b/pkg/kcp/provider/aws/iprange/checkCidrBlockStatus.go
@@ -70,7 +70,7 @@ func checkCidrBlockStatus(ctx context.Context, st composed.State) (error, contex
 	})
 	err := state.UpdateObjStatus(ctx)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Failed updating CidrAssociationFailed status", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Failed updating CidrAssociationFailed status", composed.StopWithRequeue, ctx)
 	}
 
 	return composed.StopAndForget, nil

--- a/pkg/kcp/provider/aws/iprange/checkCidrOverlap.go
+++ b/pkg/kcp/provider/aws/iprange/checkCidrOverlap.go
@@ -37,7 +37,7 @@ func checkCidrOverlap(ctx context.Context, st composed.State) (error, context.Co
 			})
 			err := state.UpdateObjStatus(ctx)
 			if err != nil {
-				return composed.LogErrorAndReturn(err, "Error updating IpRange status due to cidr overlap", composed.StopWithRequeue, nil)
+				return composed.LogErrorAndReturn(err, "Error updating IpRange status due to cidr overlap", composed.StopWithRequeue, ctx)
 			}
 
 			return composed.StopAndForget, nil

--- a/pkg/kcp/provider/aws/iprange/ensureShootZonesAndRangeSubnetsMatch.go
+++ b/pkg/kcp/provider/aws/iprange/ensureShootZonesAndRangeSubnetsMatch.go
@@ -32,7 +32,7 @@ func ensureShootZonesAndRangeSubnetsMatch(ctx context.Context, st composed.State
 
 		err := state.UpdateObjStatus(ctx)
 		if err != nil {
-			return composed.LogErrorAndReturn(err, "Error updating IpRange status on shoot and vpc mismatch", composed.StopWithRequeue, nil)
+			return composed.LogErrorAndReturn(err, "Error updating IpRange status on shoot and vpc mismatch", composed.StopWithRequeue, ctx)
 		}
 
 		return composed.StopAndForget, nil

--- a/pkg/kcp/provider/aws/iprange/extendVpcAddressSpace.go
+++ b/pkg/kcp/provider/aws/iprange/extendVpcAddressSpace.go
@@ -31,7 +31,7 @@ func extendVpcAddressSpace(ctx context.Context, st composed.State) (error, conte
 		})
 		err = state.UpdateObjStatus(ctx)
 		if err != nil {
-			return composed.LogErrorAndReturn(err, "Error updating status due to failed extending vpc address space", composed.StopWithRequeue, nil)
+			return composed.LogErrorAndReturn(err, "Error updating status due to failed extending vpc address space", composed.StopWithRequeue, ctx)
 		}
 
 		return composed.StopAndForget, nil

--- a/pkg/kcp/provider/aws/iprange/loadSubnets.go
+++ b/pkg/kcp/provider/aws/iprange/loadSubnets.go
@@ -11,7 +11,7 @@ func loadSubnets(ctx context.Context, st composed.State) (error, context.Context
 
 	subnetList, err := state.client.DescribeSubnets(ctx, pointer.StringDeref(state.vpc.VpcId, ""))
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error loading subnets", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error loading subnets", composed.StopWithRequeue, ctx)
 	}
 
 	state.allSubnets = subnetList

--- a/pkg/kcp/provider/aws/iprange/splitRangeByZones.go
+++ b/pkg/kcp/provider/aws/iprange/splitRangeByZones.go
@@ -72,7 +72,7 @@ func splitRangeByZones(ctx context.Context, st composed.State) (error, context.C
 	err = state.UpdateObjStatus(ctx)
 	if err != nil {
 		err = fmt.Errorf("error updating IpRange status: %w", err)
-		return composed.LogErrorAndReturn(err, "Error splitting IpRange CIDR", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error splitting IpRange CIDR", composed.StopWithRequeue, ctx)
 	}
 
 	return composed.StopWithRequeue, nil

--- a/pkg/kcp/provider/aws/iprange/updateSuccessStatus.go
+++ b/pkg/kcp/provider/aws/iprange/updateSuccessStatus.go
@@ -22,7 +22,7 @@ func updateSuccessStatus(ctx context.Context, st composed.State) (error, context
 
 	err := state.UpdateObjStatus(ctx)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error updating IpRange success status", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error updating IpRange success status", composed.StopWithRequeue, ctx)
 	}
 
 	return nil, nil

--- a/pkg/kcp/provider/aws/nfsinstance/createEfs.go
+++ b/pkg/kcp/provider/aws/nfsinstance/createEfs.go
@@ -56,7 +56,7 @@ func createEfs(ctx context.Context, st composed.State) (error, context.Context) 
 		})
 		err = state.UpdateObjStatus(ctx)
 		if err != nil {
-			return composed.LogErrorAndReturn(err, "Error updating NfsInstance status due failed creating efs", composed.StopWithRequeue, nil)
+			return composed.LogErrorAndReturn(err, "Error updating NfsInstance status due failed creating efs", composed.StopWithRequeue, ctx)
 		}
 
 		return composed.StopWithRequeueDelay(time.Minute), nil

--- a/pkg/kcp/provider/aws/nfsinstance/createMountTargets.go
+++ b/pkg/kcp/provider/aws/nfsinstance/createMountTargets.go
@@ -35,7 +35,7 @@ func createMountTargets(ctx context.Context, st composed.State) (error, context.
 			[]string{state.securityGroupId},
 		)
 		if err != nil {
-			return composed.LogErrorAndReturn(err, "Error creating Mount point", composed.StopWithRequeue, nil)
+			return composed.LogErrorAndReturn(err, "Error creating Mount point", composed.StopWithRequeue, ctx)
 		}
 	}
 

--- a/pkg/kcp/provider/aws/nfsinstance/createSecurityGroup.go
+++ b/pkg/kcp/provider/aws/nfsinstance/createSecurityGroup.go
@@ -35,7 +35,7 @@ func createSecurityGroup(ctx context.Context, st composed.State) (error, context
 		},
 	})
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error creating security group", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error creating security group", composed.StopWithRequeue, ctx)
 	}
 
 	state.securityGroupId = sgId

--- a/pkg/kcp/provider/aws/nfsinstance/findSecurityGroup.go
+++ b/pkg/kcp/provider/aws/nfsinstance/findSecurityGroup.go
@@ -32,7 +32,7 @@ func findSecurityGroup(ctx context.Context, st composed.State) (error, context.C
 		},
 	}, nil)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error listing security groups", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error listing security groups", composed.StopWithRequeue, ctx)
 	}
 
 	if len(list) > 0 {

--- a/pkg/kcp/provider/aws/nfsinstance/loadEfs.go
+++ b/pkg/kcp/provider/aws/nfsinstance/loadEfs.go
@@ -12,7 +12,7 @@ func loadEfs(ctx context.Context, st composed.State) (error, context.Context) {
 
 	list, err := state.awsClient.DescribeFileSystems(ctx)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error listing AWS file systems", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error listing AWS file systems", composed.StopWithRequeue, ctx)
 	}
 
 	for _, fs := range list {

--- a/pkg/kcp/provider/aws/nfsinstance/loadMountTargets.go
+++ b/pkg/kcp/provider/aws/nfsinstance/loadMountTargets.go
@@ -19,7 +19,7 @@ func loadMountTargets(ctx context.Context, st composed.State) (error, context.Co
 
 	mtList, err := state.awsClient.DescribeMountTargets(ctx, pointer.StringDeref(state.efs.FileSystemId, ""))
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error loading mount targets", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error loading mount targets", composed.StopWithRequeue, ctx)
 	}
 
 	state.mountTargets = mtList
@@ -29,7 +29,7 @@ func loadMountTargets(ctx context.Context, st composed.State) (error, context.Co
 		mtID := pointer.StringDeref(mt.MountTargetId, "")
 		sgList, err := state.awsClient.DescribeMountTargetSecurityGroups(ctx, mtID)
 		if err != nil {
-			return composed.LogErrorAndReturn(err, "Error loading mount target security groups", composed.StopWithRequeue, nil)
+			return composed.LogErrorAndReturn(err, "Error loading mount target security groups", composed.StopWithRequeue, ctx)
 		}
 		state.mountTargetSecurityGroups[mtID] = sgList
 	}

--- a/pkg/kcp/provider/aws/nfsinstance/loadSecurityGroup.go
+++ b/pkg/kcp/provider/aws/nfsinstance/loadSecurityGroup.go
@@ -28,7 +28,7 @@ func loadSecurityGroup(ctx context.Context, st composed.State) (error, context.C
 		state.ObjAsNfsInstance().Status.State = cloudresourcesv1beta1.ErrorState
 		err := state.UpdateObjStatus(ctx)
 		if err != nil {
-			return composed.LogErrorAndReturn(err, "Error updating NfsInstance status after missing security group id", composed.StopWithRequeue, nil)
+			return composed.LogErrorAndReturn(err, "Error updating NfsInstance status after missing security group id", composed.StopWithRequeue, ctx)
 		}
 		return composed.StopAndForget, nil
 	}
@@ -44,7 +44,7 @@ func loadSecurityGroup(ctx context.Context, st composed.State) (error, context.C
 		[]string{state.securityGroupId},
 	)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error loading security group", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error loading security group", composed.StopWithRequeue, ctx)
 	}
 	if len(sg) < 1 {
 		logger.Info("Security group with id not found!!!")
@@ -57,7 +57,7 @@ func loadSecurityGroup(ctx context.Context, st composed.State) (error, context.C
 		state.ObjAsNfsInstance().Status.State = cloudresourcesv1beta1.ErrorState
 		err := state.UpdateObjStatus(ctx)
 		if err != nil {
-			return composed.LogErrorAndReturn(err, "Error updating NfsInstance status after missing created security group", composed.StopWithRequeue, nil)
+			return composed.LogErrorAndReturn(err, "Error updating NfsInstance status after missing created security group", composed.StopWithRequeue, ctx)
 		}
 		return composed.StopAndForget, nil
 	}

--- a/pkg/kcp/provider/aws/nfsinstance/validateExistingMountTargets.go
+++ b/pkg/kcp/provider/aws/nfsinstance/validateExistingMountTargets.go
@@ -63,13 +63,13 @@ func validateExistingMountTargets(ctx context.Context, st composed.State) (error
 	})
 	err := state.UpdateObjStatus(ctx)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error updating NfsInstance status conditions after invalid mount targets found", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error updating NfsInstance status conditions after invalid mount targets found", composed.StopWithRequeue, ctx)
 	}
 
 	state.ObjAsNfsInstance().Status.State = cloudresourcesv1beta1.ErrorState
 	err = state.UpdateObj(ctx)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error updating NfsInstance status state after invalid mount targets found", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error updating NfsInstance status state after invalid mount targets found", composed.StopWithRequeue, ctx)
 	}
 
 	return composed.StopAndForget, nil

--- a/pkg/skr/awsnfsvolume/addFinalizer.go
+++ b/pkg/skr/awsnfsvolume/addFinalizer.go
@@ -23,7 +23,7 @@ func addFinalizer(ctx context.Context, st composed.State) (error, context.Contex
 
 	err := state.UpdateObj(ctx)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error saving AwsNfsVolume after finalizer added", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error saving AwsNfsVolume after finalizer added", composed.StopWithRequeue, ctx)
 	}
 
 	logger.Info("Added finalizer to SKR IpRange, requeue")

--- a/pkg/skr/cloudresources/addFinalizer.go
+++ b/pkg/skr/cloudresources/addFinalizer.go
@@ -25,7 +25,7 @@ func addFinalizer(ctx context.Context, st composed.State) (error, context.Contex
 
 	err := state.UpdateObj(ctx)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error saving object after finalizer added", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error saving object after finalizer added", composed.StopWithRequeue, ctx)
 	}
 
 	return composed.StopWithRequeue, nil

--- a/pkg/skr/gcpnfsvolume/addFinalizer.go
+++ b/pkg/skr/gcpnfsvolume/addFinalizer.go
@@ -20,7 +20,7 @@ func addFinalizer(ctx context.Context, st composed.State) (error, context.Contex
 
 	err := st.UpdateObj(ctx)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error saving object after finalizer added", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error saving object after finalizer added", composed.StopWithRequeue, ctx)
 	}
 
 	return nil, nil

--- a/pkg/skr/gcpnfsvolume/createPersistenceVolume.go
+++ b/pkg/skr/gcpnfsvolume/createPersistenceVolume.go
@@ -75,7 +75,7 @@ func createPersistenceVolume(ctx context.Context, st composed.State) (error, con
 	//Create PV
 	err := state.SkrCluster.K8sClient().Create(ctx, state.PV)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error creating PersistentVolume", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error creating PersistentVolume", composed.StopWithRequeue, ctx)
 	}
 
 	//continue

--- a/pkg/skr/gcpnfsvolume/deleteKcpNfsInstance.go
+++ b/pkg/skr/gcpnfsvolume/deleteKcpNfsInstance.go
@@ -21,7 +21,7 @@ func deleteKcpNfsInstance(ctx context.Context, st composed.State) (error, contex
 
 	err := state.KcpCluster.K8sClient().Delete(ctx, state.KcpNfsInstance)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error deleting KCP NfsInstance", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error deleting KCP NfsInstance", composed.StopWithRequeue, ctx)
 	}
 
 	// give some time to cloud-control and cloud providers to delete it, and then run again

--- a/pkg/skr/gcpnfsvolume/deletePersistenceVolume.go
+++ b/pkg/skr/gcpnfsvolume/deletePersistenceVolume.go
@@ -55,7 +55,7 @@ func deletePersistenceVolume(ctx context.Context, st composed.State) (error, con
 	//Delete PV
 	err := state.SkrCluster.K8sClient().Delete(ctx, state.PV)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error deleting PersistentVolume", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error deleting PersistentVolume", composed.StopWithRequeue, ctx)
 	}
 
 	// give some time, and then run again

--- a/pkg/skr/gcpnfsvolume/loadKcpIpRange.go
+++ b/pkg/skr/gcpnfsvolume/loadKcpIpRange.go
@@ -27,7 +27,7 @@ func loadKcpIpRange(ctx context.Context, st composed.State) (error, context.Cont
 		client.InNamespace(state.KymaRef.Namespace),
 	)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error loading KCP IpRange", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error loading KCP IpRange", composed.StopWithRequeue, ctx)
 	}
 
 	if len(list.Items) == 0 {

--- a/pkg/skr/gcpnfsvolume/loadKcpNfsInstance.go
+++ b/pkg/skr/gcpnfsvolume/loadKcpNfsInstance.go
@@ -23,7 +23,7 @@ func loadKcpNfsInstance(ctx context.Context, st composed.State) (error, context.
 		client.InNamespace(state.KymaRef.Namespace),
 	)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error loading KCP NfsInstance", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error loading KCP NfsInstance", composed.StopWithRequeue, ctx)
 	}
 
 	if len(list.Items) == 0 {

--- a/pkg/skr/gcpnfsvolume/loadPersistenceVolume.go
+++ b/pkg/skr/gcpnfsvolume/loadPersistenceVolume.go
@@ -22,7 +22,7 @@ func loadPersistenceVolume(ctx context.Context, st composed.State) (error, conte
 		},
 	)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error loading Persistent Volume", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error loading Persistent Volume", composed.StopWithRequeue, ctx)
 	}
 
 	if len(list.Items) == 0 {

--- a/pkg/skr/gcpnfsvolume/modifyPersistenceVolume.go
+++ b/pkg/skr/gcpnfsvolume/modifyPersistenceVolume.go
@@ -47,7 +47,7 @@ func modifyPersistenceVolume(ctx context.Context, st composed.State) (error, con
 	err := state.SkrCluster.K8sClient().Update(ctx, state.PV)
 
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error updating PersistentVolume", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error updating PersistentVolume", composed.StopWithRequeue, ctx)
 	}
 
 	//continue

--- a/pkg/skr/gcpnfsvolume/removeFinalizer.go
+++ b/pkg/skr/gcpnfsvolume/removeFinalizer.go
@@ -23,7 +23,7 @@ func removeFinalizer(ctx context.Context, st composed.State) (error, context.Con
 	controllerutil.RemoveFinalizer(state.Obj(), cloudresourcesv1beta1.Finalizer)
 	err := state.UpdateObj(ctx)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error saving SKR GcpNfsVolume after finalizer remove", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error saving SKR GcpNfsVolume after finalizer remove", composed.StopWithRequeue, ctx)
 	}
 
 	// bye, bye SKR GcpNfsVolume

--- a/pkg/skr/gcpnfsvolume/removePersistenceVolumeFinalizer.go
+++ b/pkg/skr/gcpnfsvolume/removePersistenceVolumeFinalizer.go
@@ -24,7 +24,7 @@ func removePersistenceVolumeFinalizer(ctx context.Context, st composed.State) (e
 	controllerutil.RemoveFinalizer(state.PV, v1beta1.Finalizer)
 	err := state.SkrCluster.K8sClient().Update(ctx, state.PV)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error saving SKR PersistentVolume after finalizer removal", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error saving SKR PersistentVolume after finalizer removal", composed.StopWithRequeue, ctx)
 	}
 
 	// bye, bye SKR PersistentVolume

--- a/pkg/skr/gcpnfsvolume/validateSpec.go
+++ b/pkg/skr/gcpnfsvolume/validateSpec.go
@@ -81,7 +81,7 @@ func validateIpRange(ctx context.Context, st composed.State) (error, context.Con
 			Name:      ipRangeName.Name},
 		ipRange)
 	if client.IgnoreNotFound(err) != nil {
-		return composed.LogErrorAndReturn(err, "Error loading referred IpRange", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error loading referred IpRange", composed.StopWithRequeue, ctx)
 	}
 	if err != nil {
 		logger.

--- a/pkg/skr/iprange/addFinalizer.go
+++ b/pkg/skr/iprange/addFinalizer.go
@@ -25,7 +25,7 @@ func addFinalizer(ctx context.Context, st composed.State) (error, context.Contex
 
 	err := state.UpdateObj(ctx)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error saving object after finalizer added", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error saving object after finalizer added", composed.StopWithRequeue, ctx)
 	}
 
 	return composed.StopWithRequeue, nil

--- a/pkg/skr/iprange/deleteKcpIpRange.go
+++ b/pkg/skr/iprange/deleteKcpIpRange.go
@@ -24,7 +24,7 @@ func deleteKcpIpRange(ctx context.Context, st composed.State) (error, context.Co
 
 	err := state.KcpCluster.K8sClient().Delete(ctx, state.KcpIpRange)
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error deleting KCP IpRange", composed.StopWithRequeue, nil)
+		return composed.LogErrorAndReturn(err, "Error deleting KCP IpRange", composed.StopWithRequeue, ctx)
 	}
 
 	// give some time to cloud-control and cloud providers to delete it, and then run again


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- the `ctx` must be supplied to LogErrorAndReturn() otherwise whole loggining context is lost and not logged, like controller,   group, kind, resource name, and everything else put into it that's helping going trough logs and tracing a single reconcilation loop

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
