### PR TITLE
fix: let LM delete cloudresources CRD

### DIFF
--- a/pkg/skr/cloudresources/deleteCrds.go
+++ b/pkg/skr/cloudresources/deleteCrds.go
@@ -26,8 +26,12 @@ func deleteCrds(ctx context.Context, st composed.State) (error, context.Context)
 	logger.Info("Checking CRDs to uninstall")
 
 	suffix := ".cloud-resources.kyma-project.io"
+	skip := "cloudresources.cloud-resources.kyma-project.io"
 	for _, crd := range crdList.Items {
 		if !strings.HasSuffix(crd.GetName(), suffix) {
+			continue
+		}
+		if crd.GetName() == skip {
 			continue
 		}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- do not delete cloudresources.cloud-resources.kyma-project.io crd since LifecycleManager will do it

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
