### PR TITLE
fix: Separate timer values for test and actual GCP provider calls

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"github.com/elliotchance/pie/v2"
+	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
 	awsiprangeclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/iprange/client"
 	awsnfsinstanceclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/nfsinstance/client"
 	awsvpcpeeringclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/vpcpeering/client"
@@ -151,6 +152,7 @@ func main() {
 	}
 
 	// KCP Controllers
+	env := abstractions.NewOSEnvironment()
 	if err = cloudcontrolcontroller.SetupScopeReconciler(mgr, scopeclient.NewAwsStsGardenClientProvider(), skrLoop, gcpclient.NewServiceUsageClientProvider()); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Scope")
 		os.Exit(1)
@@ -159,6 +161,7 @@ func main() {
 		mgr,
 		awsnfsinstanceclient.NewClientProvider(),
 		gcpFilestoreClient.NewFilestoreClientProvider(),
+		env,
 	); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "NfsInstance")
 		os.Exit(1)
@@ -175,6 +178,7 @@ func main() {
 		awsiprangeclient.NewClientProvider(),
 		gcpiprangeclient.NewServiceNetworkingClient(),
 		gcpiprangeclient.NewComputeClient(),
+		env,
 	); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "IpRange")
 		os.Exit(1)

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -10,6 +10,8 @@ configMapGenerator:
   - GARDENER_NAMESPACE=garden-spm-test01
   - SKR_PROVIDERS=/var/kyma/cloud-manager/skr/providers/
   - GCP_CLIENT_RENEW_DURATION=5m
+  - GCP_RETRY_WAIT_DURATION=5s
+  - GCP_OPERATION_WAIT_DURATION=5s
   name: manager-env
 
 secretGenerator:

--- a/internal/controller/cloud-control/iprange_controller.go
+++ b/internal/controller/cloud-control/iprange_controller.go
@@ -39,14 +39,18 @@ func SetupIpRangeReconciler(
 	awsProvider awsclient.SkrClientProvider[iprangeclient.Client],
 	gcpSvcNetProvider gcpclient.ClientProvider[client.ServiceNetworkingClient],
 	gcpComputeProvider gcpclient.ClientProvider[client.ComputeClient],
+	env abstractions.Environment,
 ) error {
+	if env == nil {
+		env = abstractions.NewOSEnvironment()
+	}
 	return NewIpRangeReconciler(
 		iprange.NewIPRangeReconciler(
 			composed.NewStateFactory(composed.NewStateClusterFromCluster(kcpManager)),
 			focal.NewStateFactory(),
-			awsiprange.NewStateFactory(awsProvider, abstractions.NewOSEnvironment()),
+			awsiprange.NewStateFactory(awsProvider, env),
 			azureiprange.NewStateFactory(nil),
-			gcpiprange.NewStateFactory(gcpSvcNetProvider, gcpComputeProvider, abstractions.NewOSEnvironment()),
+			gcpiprange.NewStateFactory(gcpSvcNetProvider, gcpComputeProvider, env),
 		),
 	).SetupWithManager(kcpManager)
 }

--- a/internal/controller/cloud-control/nfsinstance_controller.go
+++ b/internal/controller/cloud-control/nfsinstance_controller.go
@@ -38,14 +38,18 @@ func SetupNfsInstanceReconciler(
 	kcpManager manager.Manager,
 	awsSkrProvider awsclient.SkrClientProvider[awsnfsinstanceclient.Client],
 	filestoreClientProvider gcpclient.ClientProvider[gcpnfsinstanceclient.FilestoreClient],
+	env abstractions.Environment,
 ) error {
+	if env == nil {
+		env = abstractions.NewOSEnvironment()
+	}
 	return NewNfsInstanceReconciler(
 		nfsinstance.NewNfsInstanceReconciler(
 			composed.NewStateFactory(composed.NewStateClusterFromCluster(kcpManager)),
 			focal.NewStateFactory(),
-			awsnfsinstance.NewStateFactory(awsSkrProvider, abstractions.NewOSEnvironment()),
+			awsnfsinstance.NewStateFactory(awsSkrProvider, env),
 			azurenfsinstance.NewStateFactory(),
-			gcpnfsinstance.NewStateFactory(filestoreClientProvider, abstractions.NewOSEnvironment()),
+			gcpnfsinstance.NewStateFactory(filestoreClientProvider, env),
 		),
 	).SetupWithManager(kcpManager)
 }

--- a/internal/controller/cloud-control/suite_test.go
+++ b/internal/controller/cloud-control/suite_test.go
@@ -18,6 +18,7 @@ package cloudcontrol
 
 import (
 	"context"
+	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
 	"github.com/kyma-project/cloud-manager/pkg/testinfra"
 	"go.uber.org/zap/zapcore"
 	"os"
@@ -64,6 +65,13 @@ var _ = BeforeSuite(func() {
 	Expect(infra.Garden().GivenNamespaceExists(infra.Garden().Namespace())).
 		NotTo(HaveOccurred(), "failed creating namespace %s in Garden", infra.Garden().Namespace())
 
+	// Setup environment variables
+	env := abstractions.NewMockedEnvironment(map[string]string{
+		"GCP_SA_JSON_KEY_PATH":        "test",
+		"GCP_RETRY_WAIT_DURATION":     "300ms",
+		"GCP_OPERATION_WAIT_DURATION": "300ms",
+	})
+
 	// Setup controllers
 	// Scope
 	Expect(SetupScopeReconciler(
@@ -78,12 +86,14 @@ var _ = BeforeSuite(func() {
 		infra.AwsMock().IpRangeSkrProvider(),
 		infra.GcpMock().ServiceNetworkingClientProvider(),
 		infra.GcpMock().ComputeClientProvider(),
+		env,
 	))
 	// NfsInstance
 	Expect(SetupNfsInstanceReconciler(
 		infra.KcpManager(),
 		infra.AwsMock().NfsInstanceSkrProvider(),
 		infra.GcpMock().FilestoreClientProvider(),
+		env,
 	))
 	//VpcPeering
 	Expect(SetupVpcPeeringReconciler(

--- a/internal/controller/cloud-resources/gcpnfsvolume_test.go
+++ b/internal/controller/cloud-resources/gcpnfsvolume_test.go
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var _ = SkipDescribe("Feature: SKR GcpNfsVolume", func() {
+var _ = Describe("Feature: SKR GcpNfsVolume", func() {
 
 	const (
 		interval = time.Millisecond * 250

--- a/pkg/kcp/provider/gcp/client/gcpConstants.go
+++ b/pkg/kcp/provider/gcp/client/gcpConstants.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
 	"regexp"
 	"time"
 
@@ -18,6 +19,26 @@ const filestoreParentPattern = "projects/%s/locations/%s"
 
 const GcpRetryWaitTime = time.Second * 3
 const GcpOperationWaitTime = time.Second * 5
+
+type GcpConfig struct {
+	GcpRetryWaitTime     time.Duration
+	GcpOperationWaitTime time.Duration
+}
+
+func GetGcpConfig(env abstractions.Environment) *GcpConfig {
+	return &GcpConfig{
+		GcpRetryWaitTime:     GetConfigDuration(env, "GCP_RETRY_WAIT_DURATION", GcpRetryWaitTime),
+		GcpOperationWaitTime: GetConfigDuration(env, "GCP_OPERATION_WAIT_DURATION", GcpOperationWaitTime),
+	}
+}
+
+func GetConfigDuration(env abstractions.Environment, key string, defaultValue time.Duration) time.Duration {
+	duration, err := time.ParseDuration(env.Get(key))
+	if err != nil {
+		return defaultValue
+	}
+	return duration
+}
 
 var FilestoreInstanceRegEx *regexp.Regexp = regexp.MustCompile(`^projects\/([^/]+)\/locations\/([^/]+)\/instances\/([^/]+)$`)
 

--- a/pkg/kcp/provider/gcp/iprange/checkGcpOperation.go
+++ b/pkg/kcp/provider/gcp/iprange/checkGcpOperation.go
@@ -41,7 +41,7 @@ func checkGcpOperation(ctx context.Context, st composed.State) (error, context.C
 
 		//Operation not completed yet.. requeue again.
 		if op != nil && !op.Done {
-			return composed.StopWithRequeueDelay(client.GcpRetryWaitTime), nil
+			return composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), nil
 		}
 
 		//If not able to find the operation or it is completed, reset OpIdentifier.
@@ -81,7 +81,7 @@ func checkGcpOperation(ctx context.Context, st composed.State) (error, context.C
 
 		//Operation not completed yet.. requeue again.
 		if op != nil && op.Status != "DONE" {
-			return composed.StopWithRequeueDelay(client.GcpRetryWaitTime), nil
+			return composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), nil
 		}
 
 		//If not able to find the operation or it is completed, reset OpIdentifier.

--- a/pkg/kcp/provider/gcp/iprange/checkGcpOperation_test.go
+++ b/pkg/kcp/provider/gcp/iprange/checkGcpOperation_test.go
@@ -209,7 +209,7 @@ func (suite *checkGcpOperationSuite) TestWhenSvcNwOperationNotComplete() {
 	//Invoke the function under test
 	err, resCtx := checkGcpOperation(ctx, state)
 	assert.Nil(suite.T(), resCtx)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), err)
 }
 
 func (suite *checkGcpOperationSuite) TestWhenSvcNwOperationSuccessful() {
@@ -422,7 +422,7 @@ func (suite *checkGcpOperationSuite) TestWhenComputeOperationNotComplete() {
 	//Invoke the function under test
 	err, resCtx := checkGcpOperation(ctx, state)
 	assert.Nil(suite.T(), resCtx)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), err)
 }
 
 func (suite *checkGcpOperationSuite) TestWhenComputeOperationSuccessful() {

--- a/pkg/kcp/provider/gcp/iprange/syncAddress.go
+++ b/pkg/kcp/provider/gcp/iprange/syncAddress.go
@@ -45,15 +45,15 @@ func syncAddress(ctx context.Context, st composed.State) (error, context.Context
 				Reason:  v1beta1.ReasonGcpError,
 				Message: err.Error(),
 			}).
-			SuccessError(composed.StopWithRequeueDelay(client.GcpRetryWaitTime)).
+			SuccessError(composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime)).
 			SuccessLogMsg(fmt.Sprintf("Error creating/deleting Address object in GCP :%s", err)).
 			Run(ctx, state)
 	}
 	if operation != nil {
 		ipRange.Status.OpIdentifier = operation.Name
 		return composed.UpdateStatus(ipRange).
-			SuccessError(composed.StopWithRequeueDelay(client.GcpOperationWaitTime)).
+			SuccessError(composed.StopWithRequeueDelay(state.gcpConfig.GcpOperationWaitTime)).
 			Run(ctx, state)
 	}
-	return composed.StopWithRequeueDelay(client.GcpOperationWaitTime), nil
+	return composed.StopWithRequeueDelay(state.gcpConfig.GcpOperationWaitTime), nil
 }

--- a/pkg/kcp/provider/gcp/iprange/syncAddress_test.go
+++ b/pkg/kcp/provider/gcp/iprange/syncAddress_test.go
@@ -69,7 +69,7 @@ func (suite *syncAddressSuite) TestCreateSuccess() {
 
 	//Invoke the function under test
 	err, _ = syncAddress(ctx, state)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpOperationWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(state.gcpConfig.GcpOperationWaitTime), err)
 
 	//Load updated object
 	err = state.LoadObj(ctx)
@@ -111,7 +111,7 @@ func (suite *syncAddressSuite) TestCreateFailure() {
 
 	//Invoke the function under test
 	err, _ = syncAddress(ctx, state)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), err)
 
 	//Load updated object
 	err = state.LoadObj(ctx)
@@ -192,7 +192,7 @@ func (suite *syncAddressSuite) TestDeleteSuccess() {
 
 	//Invoke the function under test
 	err, _ = syncAddress(ctx, state)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpOperationWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(state.gcpConfig.GcpOperationWaitTime), err)
 
 	//Load updated object
 	err = state.LoadObj(ctx)
@@ -243,7 +243,7 @@ func (suite *syncAddressSuite) TestDeleteFailure() {
 
 	//Invoke the function under test
 	err, _ = syncAddress(ctx, state)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), err)
 
 	//Load updated object
 	err = state.LoadObj(ctx)

--- a/pkg/kcp/provider/gcp/iprange/syncPsaConnection.go
+++ b/pkg/kcp/provider/gcp/iprange/syncPsaConnection.go
@@ -42,15 +42,15 @@ func syncPsaConnection(ctx context.Context, st composed.State) (error, context.C
 				Reason:  v1beta1.ReasonGcpError,
 				Message: err.Error(),
 			}).
-			SuccessError(composed.StopWithRequeueDelay(client.GcpRetryWaitTime)).
+			SuccessError(composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime)).
 			SuccessLogMsg(fmt.Sprintf("Error creating/deleting Service Connection object in GCP :%s", err)).
 			Run(ctx, state)
 	}
 	if operation != nil {
 		ipRange.Status.OpIdentifier = operation.Name
 		return composed.UpdateStatus(ipRange).
-			SuccessError(composed.StopWithRequeueDelay(client.GcpOperationWaitTime)).
+			SuccessError(composed.StopWithRequeueDelay(state.gcpConfig.GcpOperationWaitTime)).
 			Run(ctx, state)
 	}
-	return composed.StopWithRequeueDelay(client.GcpOperationWaitTime), nil
+	return composed.StopWithRequeueDelay(state.gcpConfig.GcpOperationWaitTime), nil
 }

--- a/pkg/kcp/provider/gcp/iprange/syncPsaConnection_test.go
+++ b/pkg/kcp/provider/gcp/iprange/syncPsaConnection_test.go
@@ -71,7 +71,7 @@ func (suite *syncPsaConnectionSuite) TestCreateSuccess() {
 
 	//Invoke the function under test
 	err, _ = syncPsaConnection(ctx, state)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpOperationWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(state.gcpConfig.GcpOperationWaitTime), err)
 
 	//Load updated object
 	err = state.LoadObj(ctx)
@@ -122,7 +122,7 @@ func (suite *syncPsaConnectionSuite) TestCreateFailure() {
 
 	//Invoke the function under test
 	err, _ = syncPsaConnection(ctx, state)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), err)
 
 	//Load updated object
 	err = state.LoadObj(ctx)
@@ -177,7 +177,7 @@ func (suite *syncPsaConnectionSuite) TestUpdate() {
 
 	//Invoke the function under test
 	err, _ = syncPsaConnection(ctx, state)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpOperationWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(state.gcpConfig.GcpOperationWaitTime), err)
 
 	//Load updated object
 	err = state.LoadObj(ctx)
@@ -248,7 +248,7 @@ func (suite *syncPsaConnectionSuite) TestDeleteSuccess() {
 
 	//Invoke the function under test
 	err, _ = syncPsaConnection(ctx, state)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpOperationWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(state.gcpConfig.GcpOperationWaitTime), err)
 
 	//Load updated object
 	err = state.LoadObj(ctx)
@@ -295,7 +295,7 @@ func (suite *syncPsaConnectionSuite) TestDeleteFailure() {
 
 	//Invoke the function under test
 	err, _ = syncPsaConnection(ctx, state)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), err)
 
 	//Load updated object
 	err = state.LoadObj(ctx)

--- a/pkg/kcp/provider/gcp/nfsinstance/checkGcpOperation.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/checkGcpOperation.go
@@ -3,7 +3,6 @@ package nfsinstance
 import (
 	"context"
 	"fmt"
-	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
@@ -40,7 +39,7 @@ func checkGcpOperation(ctx context.Context, st composed.State) (error, context.C
 
 	//Operation not completed yet.. requeue again.
 	if op != nil && !op.Done {
-		return composed.StopWithRequeueDelay(client.GcpRetryWaitTime), nil
+		return composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), nil
 	}
 
 	//If not able to find the operation or it is completed, reset OpIdentifier.

--- a/pkg/kcp/provider/gcp/nfsinstance/checkGcpOperation_test.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/checkGcpOperation_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/api/file/v1"
@@ -140,7 +139,7 @@ func (suite *checkGcpOperationSuite) TestCheckGcpOperationNotDoneOperation() {
 	defer testState.FakeHttpServer.Close()
 	err, resCtx := checkGcpOperation(ctx, testState.State)
 	assert.Nil(suite.T(), resCtx)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(testState.gcpConfig.GcpRetryWaitTime), err)
 }
 
 func (suite *checkGcpOperationSuite) TestCheckGcpOperationSuccessfulOperation() {

--- a/pkg/kcp/provider/gcp/nfsinstance/loadNfsInstance.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/loadNfsInstance.go
@@ -3,7 +3,6 @@ package nfsinstance
 import (
 	"context"
 	"errors"
-	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
@@ -41,7 +40,7 @@ func loadNfsInstance(ctx context.Context, st composed.State) (error, context.Con
 				Reason:  v1beta1.ReasonGcpError,
 				Message: "Error getting Filestore Instance from GCP",
 			}).
-			SuccessError(composed.StopWithRequeueDelay(client.GcpRetryWaitTime)).
+			SuccessError(composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime)).
 			SuccessLogMsg("Error getting Filestore Instance from GCP").
 			Run(ctx, state)
 	}

--- a/pkg/kcp/provider/gcp/nfsinstance/syncNfsInstance.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/syncNfsInstance.go
@@ -46,7 +46,7 @@ func syncNfsInstance(ctx context.Context, st composed.State) (error, context.Con
 				Reason:  v1beta1.ReasonGcpError,
 				Message: err.Error(),
 			}).
-			SuccessError(composed.StopWithRequeueDelay(client.GcpRetryWaitTime)).
+			SuccessError(composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime)).
 			SuccessLogMsg(fmt.Sprintf("Error updating Filestore object in GCP :%s", err)).
 			Run(ctx, state)
 	}
@@ -57,7 +57,7 @@ func syncNfsInstance(ctx context.Context, st composed.State) (error, context.Con
 		}
 		nfsInstance.Status.OpIdentifier = operation.Name
 		return composed.UpdateStatus(nfsInstance).
-			SuccessError(composed.StopWithRequeueDelay(client.GcpOperationWaitTime)).
+			SuccessError(composed.StopWithRequeueDelay(state.gcpConfig.GcpOperationWaitTime)).
 			Run(ctx, state)
 	}
 	return nil, nil

--- a/pkg/kcp/provider/gcp/nfsinstance/syncNfsInstance_test.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/syncNfsInstance_test.go
@@ -66,7 +66,7 @@ func (suite *syncNfsInstanceSuite) TestSyncNfsInstanceAddSuccess() {
 	defer testState.FakeHttpServer.Close()
 	testState.operation = client.ADD
 	err, _ = syncNfsInstance(ctx, testState.State)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpOperationWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(testState.gcpConfig.GcpOperationWaitTime), err)
 	assert.NotNil(suite.T(), testState.State.ObjAsNfsInstance().Status.Id)
 	assert.Equal(suite.T(), "create-instance-operation", testState.State.ObjAsNfsInstance().Status.OpIdentifier)
 
@@ -113,7 +113,7 @@ func (suite *syncNfsInstanceSuite) TestSyncNfsInstanceAddError() {
 	defer testState.FakeHttpServer.Close()
 	testState.operation = client.ADD
 	err, _ = syncNfsInstance(ctx, testState.State)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(testState.gcpConfig.GcpRetryWaitTime), err)
 	assert.Equal(suite.T(), "", testState.State.ObjAsNfsInstance().Status.Id)
 	// check conditions
 	assert.Len(suite.T(), testState.State.ObjAsNfsInstance().Status.Conditions, 1)
@@ -169,7 +169,7 @@ func (suite *syncNfsInstanceSuite) TestSyncNfsInstancePatchSuccess() {
 	testState.operation = client.MODIFY
 	testState.updateMask = []string{"description"}
 	err, _ = syncNfsInstance(ctx, testState.State)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpOperationWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(testState.gcpConfig.GcpOperationWaitTime), err)
 	assert.NotNil(suite.T(), testState.State.ObjAsNfsInstance().Status.Id)
 	assert.Equal(suite.T(), "patch-instance-operation", testState.State.ObjAsNfsInstance().Status.OpIdentifier)
 
@@ -217,7 +217,7 @@ func (suite *syncNfsInstanceSuite) TestSyncNfsInstancePatchError() {
 	testState.operation = client.MODIFY
 	testState.updateMask = []string{"description"}
 	err, _ = syncNfsInstance(ctx, testState.State)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(testState.gcpConfig.GcpRetryWaitTime), err)
 	assert.Equal(suite.T(), "", testState.State.ObjAsNfsInstance().Status.Id)
 	// check conditions
 	assert.Len(suite.T(), testState.State.ObjAsNfsInstance().Status.Conditions, 1)
@@ -264,7 +264,7 @@ func (suite *syncNfsInstanceSuite) TestSyncNfsInstanceDeleteSuccess() {
 	defer testState.FakeHttpServer.Close()
 	testState.operation = client.DELETE
 	err, _ = syncNfsInstance(ctx, testState.State)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpOperationWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(testState.gcpConfig.GcpOperationWaitTime), err)
 	assert.Equal(suite.T(), "delete-instance-operation", testState.State.ObjAsNfsInstance().Status.OpIdentifier)
 
 	updatedObject := &v1beta1.NfsInstance{}
@@ -303,7 +303,7 @@ func (suite *syncNfsInstanceSuite) TestSyncNfsInstanceDeleteError() {
 	defer testState.FakeHttpServer.Close()
 	testState.operation = client.DELETE
 	err, _ = syncNfsInstance(ctx, testState.State)
-	assert.Equal(suite.T(), composed.StopWithRequeueDelay(client.GcpRetryWaitTime), err)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(testState.gcpConfig.GcpRetryWaitTime), err)
 	// check conditions
 	assert.Len(suite.T(), testState.State.ObjAsNfsInstance().Status.Conditions, 1)
 	assert.Equal(suite.T(), v1beta1.ConditionTypeError, testState.State.ObjAsNfsInstance().Status.Conditions[0].Type)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Configurable reconciliation delays for GCP access
- Separate delays for actual GCP calls and testing.

**Related issue(s)**
https://jira.tools.sap/browse/PHX-87