### PR TITLE
feat: KCP AWS VpcPeering mock

### DIFF
--- a/api/cloud-control/v1beta1/vpcpeering_types.go
+++ b/api/cloud-control/v1beta1/vpcpeering_types.go
@@ -20,6 +20,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	ReasonFailedCreatingVpcPeeringConnection = "FailedCreatingVpcPeeringConnection"
+)
+
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 

--- a/internal/controller/cloud-control/vpcpeering_aws_test.go
+++ b/internal/controller/cloud-control/vpcpeering_aws_test.go
@@ -62,6 +62,12 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 				awsutil.Ec2Tags("Name", "Remote Network Name"),
 				nil,
 			)
+			infra.AwsMock().AddVpc(
+				"wrong3",
+				"10.200.0.0/16",
+				awsutil.Ec2Tags("Name", "wrong3"),
+				nil,
+			)
 		})
 
 		vpcpeeringName := "b76ff161-c288-44fa-a295-8df2076af6a5"
@@ -99,6 +105,9 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 				connection = p
 			}
 		}
+		By("And Then found VpcPeeringConnection has AccepterVpcInfo.VpcId equals remote vpc id", func() {
+			Expect(*connection.AccepterVpcInfo.VpcId).To(Equal(remoteVpcId))
+		})
 
 		By("And Then KCP VpcPeering has status.ConnectionId equal to existing AWS Connection id", func() {
 			Expect(vpcpeering.Status.ConnectionId).To(Equal(pointer.StringDeref(connection.VpcPeeringConnectionId, "xxx")))

--- a/internal/controller/cloud-control/vpcpeering_aws_test.go
+++ b/internal/controller/cloud-control/vpcpeering_aws_test.go
@@ -1,6 +1,7 @@
 package cloudcontrol
 
 import (
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	awsmock "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/mock"
 	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
@@ -8,6 +9,7 @@ import (
 	. "github.com/kyma-project/cloud-manager/pkg/testinfra/dsl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("Feature: KCP VpcPeering", func() {
@@ -17,9 +19,9 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 			kymaName        = "09bdb13e-8a51-4920-852d-b170433d1236"
 			vpcId           = "26ce833e-07d1-4493-98ee-f9d6f11a6987"
 			remoteVpcId     = "6e6d1748-9912-4957-9075-b97a6fac8ac1"
-			remoteAccountId = "123"
+			remoteAccountId = "444455556666"
 			remoteRegion    = "eu-west1"
-			connectionId    = "26ce833e-07d1-4493-98ee-f9d6f11a6987->6e6d1748-9912-4957-9075-b97a6fac8ac1"
+			connectionId    = "pcx-111aaa111"
 		)
 
 		scope := &cloudcontrolv1beta1.Scope{}
@@ -63,6 +65,9 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 			)
 		})
 
+		var connection *ec2Types.VpcPeeringConnection
+		connection = infra.AwsMock().AddVpcPeering(connectionId, vpcId, remoteVpcId, remoteRegion, remoteAccountId)
+
 		vpcpeeringName := "b76ff161-c288-44fa-a295-8df2076af6a5"
 		vpcpeering := &cloudcontrolv1beta1.VpcPeering{}
 
@@ -91,7 +96,7 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 		})
 
 		By("And Then KCP VpcPeering has status.ConnectionId equal to existing AWS Connection id", func() {
-			Expect(vpcpeering.Status.ConnectionId).To(Equal(connectionId))
+			Expect(vpcpeering.Status.ConnectionId).To(Equal(pointer.StringDeref(connection.VpcPeeringConnectionId, "xxx")))
 		})
 	})
 

--- a/internal/controller/cloud-control/vpcpeering_aws_test.go
+++ b/internal/controller/cloud-control/vpcpeering_aws_test.go
@@ -21,7 +21,6 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 			remoteVpcId     = "6e6d1748-9912-4957-9075-b97a6fac8ac1"
 			remoteAccountId = "444455556666"
 			remoteRegion    = "eu-west1"
-			connectionId    = "pcx-111aaa111"
 		)
 
 		scope := &cloudcontrolv1beta1.Scope{}
@@ -65,9 +64,6 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 			)
 		})
 
-		var connection *ec2Types.VpcPeeringConnection
-		connection = infra.AwsMock().AddVpcPeering(connectionId, vpcId, remoteVpcId, remoteRegion, remoteAccountId)
-
 		vpcpeeringName := "b76ff161-c288-44fa-a295-8df2076af6a5"
 		vpcpeering := &cloudcontrolv1beta1.VpcPeering{}
 
@@ -94,6 +90,15 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 		By("And Then KCP VpcPeering has status.vpcId equal to existing AWS VPC id", func() {
 			Expect(vpcpeering.Status.VpcId).To(Equal(vpcId))
 		})
+
+		list, _ := infra.AwsMock().DescribeVpcPeeringConnections(infra.Ctx())
+
+		var connection ec2Types.VpcPeeringConnection
+		for _, p := range list {
+			if vpcpeering.Status.ConnectionId == pointer.StringDeref(p.VpcPeeringConnectionId, "") {
+				connection = p
+			}
+		}
 
 		By("And Then KCP VpcPeering has status.ConnectionId equal to existing AWS Connection id", func() {
 			Expect(vpcpeering.Status.ConnectionId).To(Equal(pointer.StringDeref(connection.VpcPeeringConnectionId, "xxx")))

--- a/pkg/kcp/provider/aws/mock/type.go
+++ b/pkg/kcp/provider/aws/mock/type.go
@@ -48,4 +48,5 @@ type Server interface {
 	VpcConfig
 	NfsConfig
 	ScopeConfig
+	VpcPeeringConfig
 }

--- a/pkg/kcp/provider/aws/mock/vpcPeeringStore.go
+++ b/pkg/kcp/provider/aws/mock/vpcPeeringStore.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/elliotchance/pie/v2"
+	"github.com/google/uuid"
 	"k8s.io/utils/pointer"
 	"sync"
 )
 
 type VpcPeeringConfig interface {
-	AddVpcPeering(PeeringConnectionId, vpcId, remoteVpcId, remoteRegion, remoteAccountId string) *ec2types.VpcPeeringConnection
 }
 
 type vpcPeeringEntry struct {
@@ -20,33 +20,34 @@ type vpcPeeringStore struct {
 	items []*vpcPeeringEntry
 }
 
-func (s *vpcPeeringStore) AddVpcPeering(id, vpcId, remoteVpcId, remoteRegion, remoteAccountId string) *ec2types.VpcPeeringConnection {
+func (s *vpcPeeringStore) CreateVpcPeeringConnection(ctx context.Context, vpcId, remoteVpcId, remoteRegion, remoteAccountId *string) (*ec2types.VpcPeeringConnection, error) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
 	item := &vpcPeeringEntry{
 		peering: ec2types.VpcPeeringConnection{
-			VpcPeeringConnectionId: pointer.String(id),
+			VpcPeeringConnectionId: pointer.String("pcx-" + uuid.NewString()[:8]),
 			RequesterVpcInfo: &ec2types.VpcPeeringConnectionVpcInfo{
-				VpcId: pointer.String(vpcId),
+				VpcId: vpcId,
 			},
 			AccepterVpcInfo: &ec2types.VpcPeeringConnectionVpcInfo{
-				VpcId:   pointer.String(remoteVpcId),
-				Region:  pointer.String(remoteRegion),
-				OwnerId: pointer.String(remoteAccountId),
+				VpcId:   remoteVpcId,
+				Region:  remoteRegion,
+				OwnerId: remoteAccountId,
 			},
 		},
 	}
 
 	s.items = append(s.items, item)
-	return &item.peering
+
+	return &item.peering, nil
 }
 
-func (s *vpcPeeringStore) CreateVpcPeeringConnection(ctx context.Context, vpcId, remoteVpcId, remoteRegion, remoteAccountId *string) (*ec2types.VpcPeeringConnection, error) {
+func (s *vpcPeeringStore) DescribeVpcPeeringConnections(ctx context.Context) ([]ec2types.VpcPeeringConnection, error) {
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	idx := pie.FindFirstUsing(s.items, func(e *vpcPeeringEntry) bool {
-		return pointer.StringEqual(e.peering.RequesterVpcInfo.VpcId, vpcId) &&
-			pointer.StringEqual(e.peering.AccepterVpcInfo.VpcId, remoteVpcId)
-	})
-
-	return &s.items[idx].peering, nil
+	return pie.Map(s.items, func(e *vpcPeeringEntry) ec2types.VpcPeeringConnection {
+		return e.peering
+	}), nil
 }

--- a/pkg/kcp/provider/aws/vpcpeering/client/client.go
+++ b/pkg/kcp/provider/aws/vpcpeering/client/client.go
@@ -10,6 +10,7 @@ import (
 type Client interface {
 	DescribeVpcs(ctx context.Context) ([]types.Vpc, error)
 	CreateVpcPeeringConnection(ctx context.Context, vpcId, remoteVpcId, remoteRegion, remoteAccountId *string) (*types.VpcPeeringConnection, error)
+	DescribeVpcPeeringConnections(ctx context.Context) ([]types.VpcPeeringConnection, error)
 }
 
 func NewClientProvider() awsclient.SkrClientProvider[Client] {
@@ -51,4 +52,12 @@ func (c *client) CreateVpcPeeringConnection(ctx context.Context, vpcId, remoteVp
 	//return out.VpcPeeringConnection, nil
 
 	return nil, nil
+}
+
+func (c *client) DescribeVpcPeeringConnections(ctx context.Context) ([]types.VpcPeeringConnection, error) {
+	out, err := c.svc.DescribeVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{})
+	if err != nil {
+		return nil, err
+	}
+	return out.VpcPeeringConnections, err
 }

--- a/pkg/kcp/provider/aws/vpcpeering/createVpcPeeringConnection.go
+++ b/pkg/kcp/provider/aws/vpcpeering/createVpcPeeringConnection.go
@@ -2,27 +2,79 @@ package vpcpeering
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+	"time"
 )
 
 func createVpcPeeringConnection(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
 	logger := composed.LoggerFromCtx(ctx)
 
-	con, err := state.client.CreateVpcPeeringConnection(ctx, state.vpc.VpcId, state.remoteVpc.VpcId, pointer.String(state.remoteRegion), state.remoteVpc.OwnerId)
+	if state.vpcPeeringConnection != nil {
+		return nil, nil
+	}
+
+	con, err := state.client.CreateVpcPeeringConnection(
+		ctx,
+		state.vpc.VpcId,
+		state.remoteVpc.VpcId,
+		pointer.String(state.remoteRegion),
+		state.remoteVpc.OwnerId)
+
+	if err != nil {
+		logger.Error(err, "Error creating VPC Peering")
+
+		composed.UpdateStatus(state.ObjAsVpcPeering()).
+			SetCondition(metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  "True",
+				Reason:  cloudcontrolv1beta1.ReasonFailedCreatingVpcPeeringConnection,
+				Message: fmt.Sprintf("Failed creating VpcPeerings %s", err),
+			}).
+			ErrorLogMessage("Error updating VpcPeering status due to failed creating vpc peering connection").
+			FailedError(composed.StopWithRequeue).
+			SuccessError(composed.StopWithRequeueDelay(time.Minute)).
+			Run(ctx, state)
+	}
 
 	if err != nil {
 		return composed.LogErrorAndReturn(err, "Error creating AWS VPC Peering Connection", composed.StopWithRequeue, ctx)
 	}
 
-	state.vpcPeeringConnection = con
-
-	state.ObjAsVpcPeering().Status.ConnectionId = pointer.StringDeref(con.VpcPeeringConnectionId, "")
-
-	logger = logger.WithValues("connectionId", pointer.StringDeref(state.vpcPeeringConnection.VpcPeeringConnectionId, ""))
+	logger = logger.WithValues("connectionId", pointer.StringDeref(con.VpcPeeringConnectionId, ""))
 
 	ctx = composed.LoggerIntoCtx(ctx, logger)
+
+	logger.Info("AWS VPC Peering Connection created")
+
+	state.vpcPeeringConnection = con
+
+	state.ObjAsVpcPeering().Status.ConnectionId = *state.vpcPeeringConnection.VpcPeeringConnectionId
+
+	err = state.UpdateObjStatus(ctx)
+
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error updating VPC Peering status with connection id", composed.StopWithRequeue, ctx)
+	}
+
+	if state.vpcPeeringConnection == nil {
+		logger.Error(errors.New("unable to load just created VPC Peering Connection"), "Logical error!!!")
+
+		return composed.UpdateStatus(state.ObjAsVpcPeering()).
+			SetExclusiveConditions(metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  cloudcontrolv1beta1.ReasonUnknown,
+				Message: "Failed creating EFS",
+			}).
+			ErrorLogMessage("Error updating KCP VPC Peering status after failed loading of just created VPC Peering Connection").
+			Run(ctx, state)
+	}
 
 	return nil, ctx
 }

--- a/pkg/kcp/provider/aws/vpcpeering/createVpcPeeringConnection.go
+++ b/pkg/kcp/provider/aws/vpcpeering/createVpcPeeringConnection.go
@@ -70,7 +70,7 @@ func createVpcPeeringConnection(ctx context.Context, st composed.State) (error, 
 				Type:    cloudcontrolv1beta1.ConditionTypeError,
 				Status:  metav1.ConditionTrue,
 				Reason:  cloudcontrolv1beta1.ReasonUnknown,
-				Message: "Failed creating EFS",
+				Message: "Failed creating VPC Peering",
 			}).
 			ErrorLogMessage("Error updating KCP VPC Peering status after failed loading of just created VPC Peering Connection").
 			Run(ctx, state)

--- a/pkg/kcp/provider/aws/vpcpeering/loadRemoteVpc.go
+++ b/pkg/kcp/provider/aws/vpcpeering/loadRemoteVpc.go
@@ -53,7 +53,8 @@ func loadRemoteVpc(ctx context.Context, st composed.State) (error, context.Conte
 	var allLoadedVpcs []string
 	// TODO refactor as it is more or less the same as in loadVpc
 
-	for _, v := range vpcList {
+	for _, vv := range vpcList {
+		v := vv
 		var sb strings.Builder
 		for _, t := range v.Tags {
 			sb.WriteString(pointer.StringDeref(t.Key, ""))

--- a/pkg/kcp/provider/aws/vpcpeering/loadVpcPeeringConnection.go
+++ b/pkg/kcp/provider/aws/vpcpeering/loadVpcPeeringConnection.go
@@ -1,0 +1,49 @@
+package vpcpeering
+
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"k8s.io/utils/pointer"
+)
+
+func loadVpcPeeringConnection(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	list, err := state.client.DescribeVpcPeeringConnections(ctx)
+
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error listing AWS peering connections", composed.StopWithRequeue, ctx)
+	}
+
+	// TODO use Status.ConnectionId
+	for _, c := range list {
+		if state.ObjAsVpcPeering().Status.ConnectionId == pointer.StringDeref(c.VpcPeeringConnectionId, "") {
+			state.vpcPeeringConnection = &c
+			break
+		}
+	}
+
+	if state.vpcPeeringConnection == nil {
+		return nil, nil
+	}
+
+	logger = logger.WithValues(
+		"vpcConnectionId", pointer.StringDeref(state.vpcPeeringConnection.VpcPeeringConnectionId, ""))
+
+	ctx = composed.LoggerIntoCtx(ctx, logger)
+
+	if len(state.ObjAsVpcPeering().Status.ConnectionId) > 0 {
+		return nil, ctx
+	}
+
+	state.ObjAsVpcPeering().Status.ConnectionId = *state.vpcPeeringConnection.VpcPeeringConnectionId
+
+	err = state.UpdateObjStatus(ctx)
+
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error updating VPC Peering status with connection id", composed.StopWithRequeue, ctx)
+	}
+
+	return composed.StopWithRequeue, ctx
+}

--- a/pkg/kcp/provider/aws/vpcpeering/new.go
+++ b/pkg/kcp/provider/aws/vpcpeering/new.go
@@ -27,6 +27,7 @@ func New(stateFactory StateFactory) composed.Action {
 					addFinalizer,
 					loadVpc,
 					loadRemoteVpc,
+					loadVpcPeeringConnection,
 					createVpcPeeringConnection,
 					updateSuccessStatus,
 					composed.StopAndForgetAction),

--- a/pkg/kcp/provider/aws/vpcpeering/updateSuccessStatus.go
+++ b/pkg/kcp/provider/aws/vpcpeering/updateSuccessStatus.go
@@ -17,6 +17,8 @@ func updateSuccessStatus(ctx context.Context, st composed.State) (error, context
 			Reason:  cloudcontrol1beta1.ReasonReady,
 			Message: "Additional VpcPeerings(s) are provisioned",
 		}).
-		ErrorLogMessage("Error updating VpcPeering success status").
+		ErrorLogMessage("Error updating VpcPeering success status after setting Ready condition").
+		SuccessLogMsg("KPC VpcPeering is ready").
+		SuccessError(composed.StopAndForget).
 		Run(ctx, state)
 }

--- a/pkg/kcp/vpcpeering/reconciler.go
+++ b/pkg/kcp/vpcpeering/reconciler.go
@@ -57,7 +57,6 @@ func (r *vpcPeeringReconciler) newAction() composed.Action {
 					"providerSwitch",
 					nil,
 					composed.NewCase(focal.AwsProviderPredicate, vpcpeering.New(r.awsStateFactory)),
-					composed.NewCase(focal.AwsProviderPredicate, vpcpeering.New(r.awsStateFactory)),
 				),
 			)(ctx, newState(st.(focal.State)))
 		},


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use vpc peering connection id returned by the mock instead of using hard coded value
