### PR TITLE
fix: verify no gcpNfsVolume has a ref to ipRange while deleting

### DIFF
--- a/api/cloud-resources/v1beta1/awsnfsvolume_types.go
+++ b/api/cloud-resources/v1beta1/awsnfsvolume_types.go
@@ -39,10 +39,6 @@ const (
 	AwsThroughputModeElastic  = AwsThroughputMode("elastic")
 )
 
-const (
-	IpRangeField = ".spec.ipRange"
-)
-
 // AwsNfsVolumeSpec defines the desired state of AwsNfsVolume
 type AwsNfsVolumeSpec struct {
 

--- a/api/cloud-resources/v1beta1/iprange_ref.go
+++ b/api/cloud-resources/v1beta1/iprange_ref.go
@@ -11,6 +11,10 @@ type IpRangeRef struct {
 	Namespace string `json:"namespace"`
 }
 
+const (
+	IpRangeField = ".spec.ipRange"
+)
+
 func (in *IpRangeRef) ObjKey() types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: in.Namespace,

--- a/internal/controller/cloud-resources/iprange_controller.go
+++ b/internal/controller/cloud-resources/iprange_controller.go
@@ -78,6 +78,17 @@ func SetupIpRangeReconciler(reg skrruntime.SkrRegistry) error {
 		}
 		return []string{fmt.Sprintf("%s/%s", ns, nfsVol.Spec.IpRange.Name)}
 	})
+	reg.IndexField(&cloudresourcesv1beta1.GcpNfsVolume{}, cloudresourcesv1beta1.IpRangeField, func(object client.Object) []string {
+		nfsVol := object.(*cloudresourcesv1beta1.GcpNfsVolume)
+		if nfsVol.Spec.IpRange.Name == "" {
+			return nil
+		}
+		ns := nfsVol.Spec.IpRange.Namespace
+		if len(ns) == 0 {
+			ns = nfsVol.Namespace
+		}
+		return []string{fmt.Sprintf("%s/%s", ns, nfsVol.Spec.IpRange.Name)}
+	})
 
 	return reg.Register().
 		WithFactory(&IpRangeReconcilerFactory{}).

--- a/pkg/skr/gcpnfsvolume/validateSpec.go
+++ b/pkg/skr/gcpnfsvolume/validateSpec.go
@@ -14,6 +14,9 @@ import (
 
 func validateCapacity(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
+	if composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
 	// Capacity hasn't changed. No need to validate
 	if state.ObjAsGcpNfsVolume().Spec.CapacityGb == state.ObjAsGcpNfsVolume().Status.CapacityGb {
 		return nil, nil
@@ -71,7 +74,11 @@ func validateCapacityForTier(ctx context.Context, st composed.State, min, max, c
 }
 
 func validateIpRange(ctx context.Context, st composed.State) (error, context.Context) {
+	if composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
 	logger := composed.LoggerFromCtx(ctx)
+
 	state := st.(*State)
 	ipRangeName := state.ObjAsGcpNfsVolume().Spec.IpRange
 	ipRange := &cloudresourcesv1beta1.IpRange{}
@@ -130,6 +137,9 @@ func validateIpRange(ctx context.Context, st composed.State) (error, context.Con
 
 func validateFileShareName(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
+	if composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
 	tier := state.ObjAsGcpNfsVolume().Spec.Tier
 	fileShareName := state.ObjAsGcpNfsVolume().Spec.FileShareName
 	switch tier {

--- a/pkg/skr/iprange/preventDeleteOnGcpNfsVolumeUsage.go
+++ b/pkg/skr/iprange/preventDeleteOnGcpNfsVolumeUsage.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func preventDeleteOnAwsNfsVolumeUsage(ctx context.Context, st composed.State) (error, context.Context) {
+func preventDeleteOnGcpNfsVolumeUsage(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
 	logger := composed.LoggerFromCtx(ctx)
 
@@ -22,32 +22,32 @@ func preventDeleteOnAwsNfsVolumeUsage(ctx context.Context, st composed.State) (e
 		return nil, nil
 	}
 
-	awsNfsVolumesUsingThisIpRange := &cloudresourcesv1beta1.AwsNfsVolumeList{}
+	gcpNfsVolumesUsingThisIpRange := &cloudresourcesv1beta1.GcpNfsVolumeList{}
 	listOps := &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(cloudresourcesv1beta1.IpRangeField, st.Name().String()),
 	}
-	err := state.Cluster().K8sClient().List(ctx, awsNfsVolumesUsingThisIpRange, listOps)
+	err := state.Cluster().K8sClient().List(ctx, gcpNfsVolumesUsingThisIpRange, listOps)
 	if err != nil {
 		var noKindMatchError *meta.NoKindMatchError
 		if errors.As(err, &noKindMatchError) {
 			logger.
-				Info("AwsNfsVolume CR not found. Skipping check for AwsNfsVolume usage of IpRange.")
+				Info("GcpNfsVolume CR not found. Skipping check for GcpNfsVolume usage of IpRange.")
 			return nil, nil
 		}
-		return composed.LogErrorAndReturn(err, "Error listing AwsNfsVolumes using IpRange", composed.StopWithRequeue, ctx)
+		return composed.LogErrorAndReturn(err, "Error listing GcpNfsVolumes using IpRange", composed.StopWithRequeue, ctx)
 	}
 
-	if len(awsNfsVolumesUsingThisIpRange.Items) == 0 {
+	if len(gcpNfsVolumesUsingThisIpRange.Items) == 0 {
 		return nil, nil
 	}
 
-	usedByAwsNfsVolumes := fmt.Sprintf("%v", pie.Map(awsNfsVolumesUsingThisIpRange.Items, func(x cloudresourcesv1beta1.AwsNfsVolume) string {
+	usedByGcpNfsVolumes := fmt.Sprintf("%v", pie.Map(gcpNfsVolumesUsingThisIpRange.Items, func(x cloudresourcesv1beta1.GcpNfsVolume) string {
 		return fmt.Sprintf("%s/%s", x.Namespace, x.Name)
 	}))
 
 	logger.
-		WithValues("usedByAwsNfsVolumes", usedByAwsNfsVolumes).
-		Info("IpRange marked for deleting used by AwsNfsVolume")
+		WithValues("usedByGcpNfsVolumes", usedByGcpNfsVolumes).
+		Info("IpRange marked for deleting used by GcpNfsVolume")
 
 	state.ObjAsIpRange().Status.State = cloudresourcesv1beta1.StateWarning
 	return composed.UpdateStatus(state.ObjAsIpRange()).
@@ -55,7 +55,7 @@ func preventDeleteOnAwsNfsVolumeUsage(ctx context.Context, st composed.State) (e
 			Type:    cloudresourcesv1beta1.ConditionTypeWarning,
 			Status:  metav1.ConditionTrue,
 			Reason:  cloudresourcesv1beta1.ConditionTypeDeleteWhileUsed,
-			Message: fmt.Sprintf("Can not be deleted while used by: %s", usedByAwsNfsVolumes),
+			Message: fmt.Sprintf("Can not be deleted while used by: %s", usedByGcpNfsVolumes),
 		}).
 		ErrorLogMessage("Error updating IpRange status with Warning condition for delete while in use").
 		SuccessLogMsg("Forgetting SKR IpRange marked for deleting that is in use").

--- a/pkg/skr/iprange/reconciler.go
+++ b/pkg/skr/iprange/reconciler.go
@@ -53,6 +53,7 @@ func (r *reconciler) newAction() composed.Action {
 		addFinalizer,
 		createKcpIpRange,
 		preventDeleteOnAwsNfsVolumeUsage,
+		preventDeleteOnGcpNfsVolumeUsage,
 		deleteKcpIpRange,
 		removeFinalizer,
 		updateStatus,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Verify no GcpNfsVolume has a ref to IpRange while deleting IpRange

Changes proposed in this pull request:

- Fixing preventDeleteOnAwsNfsVolumeUsage to skip if not an aws skr
- Adding preventDeleteOnGcpNfsVolumeUsage
- Making sure gcpNfsVolume validation doesn't run for deletion scenario. If not check, this can block deletion of gcpNfsVolume if ipRange is in warning state

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://jira.tools.sap/browse/PHX-104