### PR TITLE
fix: verify no gcpNfsVolume has a ref to ipRange while deleting

### DIFF
--- a/api/cloud-resources/v1beta1/awsnfsvolume_types.go
+++ b/api/cloud-resources/v1beta1/awsnfsvolume_types.go
@@ -39,10 +39,6 @@ const (
 	AwsThroughputModeElastic  = AwsThroughputMode("elastic")
 )
 
-const (
-	IpRangeField = ".spec.ipRange"
-)
-
 // AwsNfsVolumeSpec defines the desired state of AwsNfsVolume
 type AwsNfsVolumeSpec struct {
 

--- a/api/cloud-resources/v1beta1/iprange_ref.go
+++ b/api/cloud-resources/v1beta1/iprange_ref.go
@@ -11,6 +11,10 @@ type IpRangeRef struct {
 	Namespace string `json:"namespace"`
 }
 
+const (
+	IpRangeField = ".spec.ipRange"
+)
+
 func (in *IpRangeRef) ObjKey() types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: in.Namespace,

--- a/internal/controller/cloud-resources/iprange_controller.go
+++ b/internal/controller/cloud-resources/iprange_controller.go
@@ -78,6 +78,17 @@ func SetupIpRangeReconciler(reg skrruntime.SkrRegistry) error {
 		}
 		return []string{fmt.Sprintf("%s/%s", ns, nfsVol.Spec.IpRange.Name)}
 	})
+	reg.IndexField(&cloudresourcesv1beta1.GcpNfsVolume{}, cloudresourcesv1beta1.IpRangeField, func(object client.Object) []string {
+		nfsVol := object.(*cloudresourcesv1beta1.GcpNfsVolume)
+		if nfsVol.Spec.IpRange.Name == "" {
+			return nil
+		}
+		ns := nfsVol.Spec.IpRange.Namespace
+		if len(ns) == 0 {
+			ns = nfsVol.Namespace
+		}
+		return []string{fmt.Sprintf("%s/%s", ns, nfsVol.Spec.IpRange.Name)}
+	})
 
 	return reg.Register().
 		WithFactory(&IpRangeReconcilerFactory{}).

--- a/pkg/skr/gcpnfsvolume/validateSpec.go
+++ b/pkg/skr/gcpnfsvolume/validateSpec.go
@@ -14,6 +14,9 @@ import (
 
 func validateCapacity(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
+	if composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
 	// Capacity hasn't changed. No need to validate
 	if state.ObjAsGcpNfsVolume().Spec.CapacityGb == state.ObjAsGcpNfsVolume().Status.CapacityGb {
 		return nil, nil
@@ -71,7 +74,11 @@ func validateCapacityForTier(ctx context.Context, st composed.State, min, max, c
 }
 
 func validateIpRange(ctx context.Context, st composed.State) (error, context.Context) {
+	if composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
 	logger := composed.LoggerFromCtx(ctx)
+
 	state := st.(*State)
 	ipRangeName := state.ObjAsGcpNfsVolume().Spec.IpRange
 	ipRange := &cloudresourcesv1beta1.IpRange{}
@@ -130,6 +137,9 @@ func validateIpRange(ctx context.Context, st composed.State) (error, context.Con
 
 func validateFileShareName(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
+	if composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
 	tier := state.ObjAsGcpNfsVolume().Spec.Tier
 	fileShareName := state.ObjAsGcpNfsVolume().Spec.FileShareName
 	switch tier {

--- a/pkg/skr/iprange/reconciler.go
+++ b/pkg/skr/iprange/reconciler.go
@@ -21,6 +21,7 @@ func (f *reconcilerFactory) New(args skrruntime.ReconcilerArguments) reconcile.R
 			composed.NewStateFactory(composed.NewStateClusterFromCluster(args.SkrCluster)),
 			args.KymaRef,
 			composed.NewStateClusterFromCluster(args.KcpCluster),
+			args.Provider,
 		),
 	}
 }
@@ -53,6 +54,7 @@ func (r *reconciler) newAction() composed.Action {
 		addFinalizer,
 		createKcpIpRange,
 		preventDeleteOnAwsNfsVolumeUsage,
+		preventDeleteOnGcpNfsVolumeUsage,
 		deleteKcpIpRange,
 		removeFinalizer,
 		updateStatus,

--- a/pkg/skr/iprange/state.go
+++ b/pkg/skr/iprange/state.go
@@ -12,15 +12,17 @@ type State struct {
 	composed.State
 	KymaRef    klog.ObjectRef
 	KcpCluster composed.StateCluster
+	Provider   *cloudcontrolv1beta1.ProviderType
 
 	KcpIpRange *cloudcontrolv1beta1.IpRange
 }
 
-func newStateFactory(baseStateFactory composed.StateFactory, kymaRef klog.ObjectRef, kcpCluster composed.StateCluster) *stateFactory {
+func newStateFactory(baseStateFactory composed.StateFactory, kymaRef klog.ObjectRef, kcpCluster composed.StateCluster, provider *cloudcontrolv1beta1.ProviderType) *stateFactory {
 	return &stateFactory{
 		baseStateFactory: baseStateFactory,
 		kymaRef:          kymaRef,
 		kcpCluster:       kcpCluster,
+		provider:         provider,
 	}
 }
 
@@ -28,6 +30,7 @@ type stateFactory struct {
 	baseStateFactory composed.StateFactory
 	kymaRef          klog.ObjectRef
 	kcpCluster       composed.StateCluster
+	provider         *cloudcontrolv1beta1.ProviderType
 }
 
 func (f *stateFactory) NewState(req ctrl.Request) *State {
@@ -35,6 +38,7 @@ func (f *stateFactory) NewState(req ctrl.Request) *State {
 		State:      f.baseStateFactory.NewState(req.NamespacedName, &cloudresourcesv1beta1.IpRange{}),
 		KymaRef:    f.kymaRef,
 		KcpCluster: f.kcpCluster,
+		Provider:   f.provider,
 	}
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Verify no GcpNfsVolume has a ref to IpRange while deleting IpRange

Changes proposed in this pull request:

- Fixing preventDeleteOnAwsNfsVolumeUsage to skip if not an aws skr
- Adding preventDeleteOnGcpNfsVolumeUsage
- Making sure gcpNfsVolume validation doesn't run for deletion scenario. If not check, this can block deletion of gcpNfsVolume if ipRange is in warning state

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://jira.tools.sap/browse/PHX-104