### PR TITLE
fix: gcpNfsVolume to reference iprange with correct namespace

### DIFF
--- a/pkg/skr/gcpnfsvolume/state_test.go
+++ b/pkg/skr/gcpnfsvolume/state_test.go
@@ -30,7 +30,7 @@ var gcpNfsVolume = cloudresourcesv1beta1.GcpNfsVolume{
 	Spec: cloudresourcesv1beta1.GcpNfsVolumeSpec{
 		IpRange: cloudresourcesv1beta1.IpRangeRef{
 			Name:      "test-gcp-ip-range",
-			Namespace: "test",
+			Namespace: "test2",
 		},
 		Location:      "us-west1",
 		Tier:          "BASIC_HDD",

--- a/pkg/skr/gcpnfsvolume/validateSpec.go
+++ b/pkg/skr/gcpnfsvolume/validateSpec.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 )
@@ -83,9 +82,7 @@ func validateIpRange(ctx context.Context, st composed.State) (error, context.Con
 	ipRangeName := state.ObjAsGcpNfsVolume().Spec.IpRange
 	ipRange := &cloudresourcesv1beta1.IpRange{}
 	err := st.Cluster().K8sClient().Get(ctx,
-		types.NamespacedName{
-			Namespace: state.Obj().GetNamespace(),
-			Name:      ipRangeName.Name},
+		ipRangeName.ObjKey(),
 		ipRange)
 	if client.IgnoreNotFound(err) != nil {
 		return composed.LogErrorAndReturn(err, "Error loading referred IpRange", composed.StopWithRequeue, ctx)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- gcpNfsVolume to reference iprange with correct namespace
- updating unit test to test an iprange in a different namespace

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://jira.tools.sap/browse/PHX-117