### PR TITLE
test: GcpNfsVolumeBackup unit tests

### DIFF
--- a/pkg/skr/gcpnfsvolumebackup/addFinalizer_test.go
+++ b/pkg/skr/gcpnfsvolumebackup/addFinalizer_test.go
@@ -1,0 +1,69 @@
+package gcpnfsvolumebackup
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+type addFinalizerSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *addFinalizerSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *addFinalizerSuite) TestAddFinalizer() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	assert.Nil(suite.T(), err)
+	err, _ = addFinalizer(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Contains(suite.T(), state.Obj().GetFinalizers(), cloudresourcesv1beta1.Finalizer)
+}
+
+func (suite *addFinalizerSuite) TestDoNotAddFinalizerOnDeletingObject() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+	deletingObj := deletingGpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, deletingObj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	state, err := factory.newStateWith(deletingObj)
+	state.Obj().SetFinalizers([]string{})
+	assert.Nil(suite.T(), err)
+
+	//Call addFinalizer
+	err, _ = addFinalizer(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.NotContains(suite.T(), state.Obj().GetFinalizers(), cloudresourcesv1beta1.Finalizer)
+}
+
+func TestAddFinalizer(t *testing.T) {
+	suite.Run(t, new(addFinalizerSuite))
+}

--- a/pkg/skr/gcpnfsvolumebackup/createNfsBackup.go
+++ b/pkg/skr/gcpnfsvolumebackup/createNfsBackup.go
@@ -43,6 +43,7 @@ func createNfsBackup(ctx context.Context, st composed.State) (error, context.Con
 	_, err := state.fileBackupClient.CreateFileBackup(ctx, project, location, name, fileBackup)
 
 	if err != nil {
+		backup.Status.State = cloudresourcesv1beta1.ConditionTypeError
 		return composed.UpdateStatus(backup).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    cloudresourcesv1beta1.ConditionTypeError,
@@ -55,5 +56,9 @@ func createNfsBackup(ctx context.Context, st composed.State) (error, context.Con
 			Run(ctx, state)
 	}
 
-	return nil, nil
+	backup.Status.State = cloudresourcesv1beta1.ConditionTypeProcessing
+	return composed.UpdateStatus(backup).
+		SetExclusiveConditions().
+		SuccessErrorNil().
+		Run(ctx, state)
 }

--- a/pkg/skr/gcpnfsvolumebackup/createNfsBackup_test.go
+++ b/pkg/skr/gcpnfsvolumebackup/createNfsBackup_test.go
@@ -1,0 +1,181 @@
+package gcpnfsvolumebackup
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/file/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
+	"testing"
+)
+
+type createNfsBackupSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *createNfsBackupSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *createNfsBackupSuite) TestWhenBackupIsDeleting() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	obj := deletingGpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	//Invoke createNfsBackup API
+	err, _ctx := createNfsBackup(ctx, state)
+
+	//validate expected return values
+	suite.Nil(err)
+	suite.Nil(_ctx)
+}
+
+func (suite *createNfsBackupSuite) TestWhenGcpBackupExists() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	state.fileBackup = &file.Backup{}
+	err, _ctx := createNfsBackup(ctx, state)
+
+	//validate expected return values
+	suite.Nil(err)
+	suite.Nil(_ctx)
+}
+
+func (suite *createNfsBackupSuite) TestWhenCreateBackupReturnsError() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+
+		case http.MethodPost:
+			fmt.Println(r.URL.Path)
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups") {
+				//Return 500
+				http.Error(w, "Internal error", http.StatusInternalServerError)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+	}))
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	//Set the scope and gcpNfsVolume objects in state
+	state.Scope = scope.DeepCopy()
+	state.GcpNfsVolume = gcpNfsVolume.DeepCopy()
+
+	//Invoke createNfsBackup API
+	err, _ctx := createNfsBackup(ctx, state)
+
+	//validate expected return values
+	suite.Equal(composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), err)
+	suite.NotNil(_ctx)
+
+	fromK8s := &v1beta1.GcpNfsVolumeBackup{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: gcpNfsVolumeBackup.Name,
+			Namespace: gcpNfsVolumeBackup.Namespace},
+		fromK8s)
+
+	//Validate expected status
+	suite.Equal(v1beta1.ConditionTypeError, string(fromK8s.Status.State))
+	suite.Equal(metav1.ConditionTrue, fromK8s.Status.Conditions[0].Status)
+	suite.Equal(cloudresourcesv1beta1.ConditionTypeError, fromK8s.Status.Conditions[0].Type)
+	suite.Equal(cloudresourcesv1beta1.ReasonGcpError, fromK8s.Status.Conditions[0].Reason)
+}
+
+func (suite *createNfsBackupSuite) TestWhenCreateBackupSuccessful() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+
+		case http.MethodPost:
+			fmt.Println(r.URL.Path)
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups") {
+				//Return 200
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"name":"test-gcp-nfs-volume-backup-operation-id"}`))
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+	}))
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	//Set the scope and gcpNfsVolume objects in state
+	state.Scope = scope.DeepCopy()
+	state.GcpNfsVolume = gcpNfsVolume.DeepCopy()
+
+	//Invoke createNfsBackup API
+	err, _ctx := createNfsBackup(ctx, state)
+
+	//validate expected return values
+	suite.Nil(err)
+	suite.NotNil(_ctx)
+
+	fromK8s := &v1beta1.GcpNfsVolumeBackup{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: gcpNfsVolumeBackup.Name,
+			Namespace: gcpNfsVolumeBackup.Namespace},
+		fromK8s)
+
+	//Validate expected status
+	suite.Equal(v1beta1.ConditionTypeProcessing, string(fromK8s.Status.State))
+	suite.Equal(0, len(fromK8s.Status.Conditions))
+}
+
+func TestCreateNfsBackup(t *testing.T) {
+	suite.Run(t, new(createNfsBackupSuite))
+}

--- a/pkg/skr/gcpnfsvolumebackup/deleteNfsBackup.go
+++ b/pkg/skr/gcpnfsvolumebackup/deleteNfsBackup.go
@@ -36,6 +36,7 @@ func deleteNfsBackup(ctx context.Context, st composed.State) (error, context.Con
 	_, err := state.fileBackupClient.DeleteFileBackup(ctx, project, location, name)
 
 	if err != nil {
+		backup.Status.State = cloudresourcesv1beta1.ConditionTypeError
 		return composed.UpdateStatus(backup).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    cloudresourcesv1beta1.ConditionTypeError,
@@ -48,5 +49,9 @@ func deleteNfsBackup(ctx context.Context, st composed.State) (error, context.Con
 			Run(ctx, state)
 	}
 
-	return nil, nil
+	backup.Status.State = cloudresourcesv1beta1.ConditionTypeDeleting
+	return composed.UpdateStatus(backup).
+		SetExclusiveConditions().
+		SuccessErrorNil().
+		Run(ctx, state)
 }

--- a/pkg/skr/gcpnfsvolumebackup/deleteNfsBackup_test.go
+++ b/pkg/skr/gcpnfsvolumebackup/deleteNfsBackup_test.go
@@ -1,0 +1,184 @@
+package gcpnfsvolumebackup
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/file/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
+	"testing"
+)
+
+type deleteNfsBackupSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *deleteNfsBackupSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *deleteNfsBackupSuite) TestWhenBackupIsNotDeleting() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	//Invoke deleteNfsBackup API
+	state.fileBackup = &file.Backup{}
+	err, _ctx := deleteNfsBackup(ctx, state)
+
+	//validate expected return values
+	suite.Nil(err)
+	suite.Nil(_ctx)
+}
+
+func (suite *deleteNfsBackupSuite) TestWhenGcpBackupNotExists() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	state.fileBackup = nil
+	err, _ctx := deleteNfsBackup(ctx, state)
+
+	//validate expected return values
+	suite.Nil(err)
+	suite.Nil(_ctx)
+}
+
+func (suite *deleteNfsBackupSuite) TestWhenDeleteBackupReturnsError() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+
+		case http.MethodDelete:
+			fmt.Println(r.URL.Path)
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups/test-gcp-nfs-volume-restore") {
+				//Return 500
+				http.Error(w, "Internal error", http.StatusInternalServerError)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+	}))
+	obj := deletingGpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	//Set the scope and gcpNfsVolume objects in state
+	state.Scope = scope.DeepCopy()
+	state.GcpNfsVolume = nil
+	state.fileBackup = &file.Backup{}
+
+	//Invoke deleteNfsBackup API
+	err, _ctx := deleteNfsBackup(ctx, state)
+
+	//validate expected return values
+	suite.Equal(composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), err)
+	suite.NotNil(_ctx)
+
+	fromK8s := &v1beta1.GcpNfsVolumeBackup{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: deletingGpNfsVolumeBackup.Name,
+			Namespace: deletingGpNfsVolumeBackup.Namespace},
+		fromK8s)
+
+	//Validate expected status
+	suite.Equal(v1beta1.ConditionTypeError, string(fromK8s.Status.State))
+	suite.Equal(metav1.ConditionTrue, fromK8s.Status.Conditions[0].Status)
+	suite.Equal(cloudresourcesv1beta1.ConditionTypeError, fromK8s.Status.Conditions[0].Type)
+	suite.Equal(cloudresourcesv1beta1.ReasonGcpError, fromK8s.Status.Conditions[0].Reason)
+}
+
+func (suite *deleteNfsBackupSuite) TestWhenDeleteBackupSuccessful() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+
+		case http.MethodDelete:
+			fmt.Println(r.URL.Path)
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups/test-gcp-nfs-volume-restore") {
+				//Return 200
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"name":"test-gcp-nfs-volume-backup-operation-id"}`))
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+	}))
+	obj := deletingGpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	//Set the scope and gcpNfsVolume objects in state
+	state.Scope = scope.DeepCopy()
+	state.GcpNfsVolume = nil
+	state.fileBackup = &file.Backup{}
+
+	//Invoke deleteNfsBackup API
+	err, _ctx := deleteNfsBackup(ctx, state)
+
+	//validate expected return values
+	suite.Nil(err)
+	suite.NotNil(_ctx)
+
+	fromK8s := &v1beta1.GcpNfsVolumeBackup{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: deletingGpNfsVolumeBackup.Name,
+			Namespace: deletingGpNfsVolumeBackup.Namespace},
+		fromK8s)
+
+	//Validate expected status
+	suite.Equal(v1beta1.ConditionTypeDeleting, string(fromK8s.Status.State))
+	suite.Equal(0, len(fromK8s.Status.Conditions))
+}
+
+func TestDeleteNfsBackup(t *testing.T) {
+	suite.Run(t, new(deleteNfsBackupSuite))
+}

--- a/pkg/skr/gcpnfsvolumebackup/loadGcpNfsVolume.go
+++ b/pkg/skr/gcpnfsvolumebackup/loadGcpNfsVolume.go
@@ -36,6 +36,7 @@ func loadGcpNfsVolume(ctx context.Context, st composed.State) (error, context.Co
 	}
 	err := state.SkrCluster.K8sClient().Get(ctx, nfsVolumeKey, nfsVolume)
 	if err != nil {
+		backup.Status.State = cloudresourcesv1beta1.ConditionTypeError
 		return composed.UpdateStatus(backup).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    cloudresourcesv1beta1.ConditionTypeError,
@@ -54,6 +55,7 @@ func loadGcpNfsVolume(ctx context.Context, st composed.State) (error, context.Co
 	//If the nfsVolume is not ready, return an error
 	if volumeReady == nil || volumeReady.Status != metav1.ConditionTrue {
 		logger.WithValues("GcpNfsVolume", nfsVolume.Name).Info("GcpNfsVolume is ready")
+		backup.Status.State = cloudresourcesv1beta1.ConditionTypeError
 		return composed.UpdateStatus(backup).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    cloudresourcesv1beta1.ConditionTypeError,

--- a/pkg/skr/gcpnfsvolumebackup/loadGcpNfsVolume_test.go
+++ b/pkg/skr/gcpnfsvolumebackup/loadGcpNfsVolume_test.go
@@ -1,0 +1,161 @@
+package gcpnfsvolumebackup
+
+import (
+	"context"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/file/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type loadGcpNfsVolumeSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *loadGcpNfsVolumeSuite) SetupTest() {
+	suite.ctx = context.Background()
+}
+
+func (suite *loadGcpNfsVolumeSuite) TestWhenBackupIsDeleting() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	obj := deletingGpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	//Invoke loadGcpNfsVolume API
+	err, _ctx := loadGcpNfsVolume(ctx, state)
+
+	//validate expected return values
+	suite.Nil(err)
+	suite.Nil(_ctx)
+}
+
+func (suite *loadGcpNfsVolumeSuite) TestWhenGcpBackupExists() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	state.fileBackup = &file.Backup{}
+	err, _ctx := loadGcpNfsVolume(ctx, state)
+
+	//validate expected return values
+	suite.Nil(err)
+	suite.Nil(_ctx)
+}
+
+func (suite *loadGcpNfsVolumeSuite) TestVolumeNotFound() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+	objDiffName := gcpNfsVolumeBackup.DeepCopy()
+	objDiffName.Spec.Source.Volume.Name = "diffName"
+
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, objDiffName)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(objDiffName)
+	suite.Nil(err)
+
+	//Invoke loadGcpNfsVolume API
+	err, _ctx := loadGcpNfsVolume(ctx, state)
+
+	//validate expected return values
+	suite.Equal(composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), err)
+	suite.Equal(ctx, _ctx)
+}
+
+func (suite *loadGcpNfsVolumeSuite) TestVolumeNotReady() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	// Remove the conditions from volume
+	notReadyVolume := gcpNfsVolume.DeepCopy()
+	notReadyVolume.Status.Conditions = []metav1.Condition{}
+	err = factory.skrCluster.K8sClient().Status().Update(ctx, notReadyVolume)
+	suite.Nil(err)
+	err, _ = loadGcpNfsVolume(ctx, state)
+
+	//validate expected return values
+	suite.Equal(composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), err)
+	fromK8s := &v1beta1.GcpNfsVolumeBackup{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: gcpNfsVolumeBackup.Name,
+			Namespace: gcpNfsVolumeBackup.Namespace},
+		fromK8s)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), "Error", string(fromK8s.Status.State))
+	assert.Equal(suite.T(), metav1.ConditionTrue, fromK8s.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), cloudresourcesv1beta1.ConditionTypeError, fromK8s.Status.Conditions[0].Type)
+}
+
+func (suite *loadGcpNfsVolumeSuite) TestVolumeReady() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	//Invoke loadGcpNfsVolume API
+	err, ctx = loadGcpNfsVolume(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), ctx)
+}
+
+func TestLoadGcpNfsVolumeSuite(t *testing.T) {
+	suite.Run(t, new(loadGcpNfsVolumeSuite))
+}

--- a/pkg/skr/gcpnfsvolumebackup/loadNfsBackup.go
+++ b/pkg/skr/gcpnfsvolumebackup/loadNfsBackup.go
@@ -35,6 +35,7 @@ func loadNfsBackup(ctx context.Context, st composed.State) (error, context.Conte
 				return nil, nil
 			}
 		}
+		backup.Status.State = cloudresourcesv1beta1.ConditionTypeError
 		return composed.UpdateStatus(backup).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    cloudresourcesv1beta1.ConditionTypeError,

--- a/pkg/skr/gcpnfsvolumebackup/loadNfsBackup_test.go
+++ b/pkg/skr/gcpnfsvolumebackup/loadNfsBackup_test.go
@@ -1,0 +1,133 @@
+package gcpnfsvolumebackup
+
+import (
+	"context"
+	"fmt"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type loadGcpNfsVolumeBackupSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *loadGcpNfsVolumeBackupSuite) SetupTest() {
+	suite.ctx = context.Background()
+}
+
+func (suite *loadGcpNfsVolumeBackupSuite) TestVolumeBackupNotFound() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+
+		case http.MethodGet:
+			fmt.Println(r.URL.Path)
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups/test-gcp-nfs-volume-backup") {
+				//Return 404
+				http.Error(w, "Not Found", http.StatusNotFound)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+	}))
+	defer fakeHttpServer.Close()
+	objDiffName := gcpNfsVolumeBackup.DeepCopy()
+
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, objDiffName)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolumeBackup
+	state, err := factory.newStateWith(objDiffName)
+	suite.Nil(err)
+	state.Scope = &scope
+
+	//Invoke loadNfsBackup API
+	err, _ctx := loadNfsBackup(ctx, state)
+
+	//validate expected return values
+	suite.Nil(err)
+	suite.Nil(_ctx)
+}
+
+func (suite *loadGcpNfsVolumeBackupSuite) TestVolumeBackupOtherError() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+
+		case http.MethodGet:
+			fmt.Println(r.URL.Path)
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups/test-gcp-nfs-volume-backup") {
+				//Return 500
+				http.Error(w, "Internal error", http.StatusInternalServerError)
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+	}))
+	defer fakeHttpServer.Close()
+	objDiffName := gcpNfsVolumeBackup.DeepCopy()
+
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, objDiffName)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolumeBackup
+	state, err := factory.newStateWith(objDiffName)
+	suite.Nil(err)
+	state.Scope = &scope
+
+	//Invoke loadNfsBackup API
+	err, _ctx := loadNfsBackup(ctx, state)
+
+	//validate expected return values
+	suite.Equal(composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), err)
+	suite.Equal(ctx, _ctx)
+}
+
+func (suite *loadGcpNfsVolumeBackupSuite) TestVolumeBackupReady() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups/test-gcp-nfs-volume-backup") {
+				//Return 200
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"name":"test-gcp-nfs-volume-backup"}`))
+			} else {
+				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+			}
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+	}))
+	defer fakeHttpServer.Close()
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+	state.Scope = &scope
+
+	//Invoke loadNfsBackup API
+	err, ctx = loadNfsBackup(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), ctx)
+}
+
+func TestLoadGcpNfsVolumeBackupSuite(t *testing.T) {
+	suite.Run(t, new(loadGcpNfsVolumeBackupSuite))
+}

--- a/pkg/skr/gcpnfsvolumebackup/loadScope.go
+++ b/pkg/skr/gcpnfsvolumebackup/loadScope.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,8 +32,9 @@ func loadScope(ctx context.Context, st composed.State) (error, context.Context) 
 	if apierrors.IsNotFound(err) {
 		logger.Info("Scope not found")
 
+		backup.Status.State = cloudresourcesv1beta1.ConditionTypeError
 		return composed.UpdateStatus(backup).
-			SetCondition(metav1.Condition{
+			SetExclusiveConditions(metav1.Condition{
 				Type:    cloudcontrolv1beta1.ConditionTypeError,
 				Status:  metav1.ConditionTrue,
 				Reason:  cloudcontrolv1beta1.ReasonScopeNotFound,

--- a/pkg/skr/gcpnfsvolumebackup/loadScope_test.go
+++ b/pkg/skr/gcpnfsvolumebackup/loadScope_test.go
@@ -1,0 +1,79 @@
+package gcpnfsvolumebackup
+
+import (
+	"context"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type loadScopeSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *loadScopeSuite) SetupTest() {
+	suite.ctx = context.Background()
+}
+
+func (suite *loadScopeSuite) TestScopeNotFound() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	//remove scope
+	err = factory.kcpCluster.K8sClient().Delete(context.Background(), scope.DeepCopy())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	err, _ = loadScope(ctx, state)
+
+	//validate expected return values
+	suite.Equal(composed.StopAndForget, err)
+	fromK8s := &v1beta1.GcpNfsVolumeBackup{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: gcpNfsVolumeBackup.Name,
+			Namespace: gcpNfsVolumeBackup.Namespace},
+		fromK8s)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, string(fromK8s.Status.State))
+	assert.Equal(suite.T(), metav1.ConditionTrue, fromK8s.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), cloudresourcesv1beta1.ConditionTypeError, fromK8s.Status.Conditions[0].Type)
+}
+
+func (suite *loadScopeSuite) TestScopeExists() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+	err, _ = loadScope(ctx, state)
+	assert.Nil(suite.T(), err)
+}
+
+func TestLoadScopeSuite(t *testing.T) {
+	suite.Run(t, new(loadScopeSuite))
+}

--- a/pkg/skr/gcpnfsvolumebackup/removeFinalizer_test.go
+++ b/pkg/skr/gcpnfsvolumebackup/removeFinalizer_test.go
@@ -1,0 +1,70 @@
+package gcpnfsvolumebackup
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+type removeFinalizerSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *removeFinalizerSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *removeFinalizerSuite) TestRemoveFinalizer() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+	deletingObj := deletingGpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, deletingObj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	state, err := factory.newStateWith(deletingObj)
+	assert.Nil(suite.T(), err)
+	err, _ = removeFinalizer(ctx, state)
+	assert.Equal(suite.T(), composed.StopAndForget, err)
+	assert.Equal(suite.T(), len(state.Obj().GetFinalizers()), 0)
+}
+
+func (suite *removeFinalizerSuite) TestDoNotRemoveFinalizerIfNotDeleting() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	defer fakeHttpServer.Close()
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	state, err := factory.newStateWith(obj)
+	assert.Nil(suite.T(), err)
+
+	//First add finalizer
+	err, _ = addFinalizer(ctx, state)
+	//Call removeFinalizer
+	err, _ = removeFinalizer(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), len(state.Obj().GetFinalizers()), 1)
+}
+
+func TestRemoveFinalizer(t *testing.T) {
+	suite.Run(t, new(removeFinalizerSuite))
+}

--- a/pkg/skr/gcpnfsvolumebackup/state_test.go
+++ b/pkg/skr/gcpnfsvolumebackup/state_test.go
@@ -1,0 +1,189 @@
+package gcpnfsvolumebackup
+
+import (
+	"context"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	client2 "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsbackup/client"
+	"google.golang.org/api/file/v1"
+	"google.golang.org/api/option"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"time"
+)
+
+var kymaRef = klog.ObjectRef{
+	Name:      "skr",
+	Namespace: "test",
+}
+
+var scope = cloudcontrolv1beta1.Scope{
+	ObjectMeta: v1.ObjectMeta{
+		Name:      "skr",
+		Namespace: "test",
+	},
+	Spec: cloudcontrolv1beta1.ScopeSpec{
+		Provider: "gcp",
+		Scope: cloudcontrolv1beta1.ScopeInfo{
+			Gcp: &cloudcontrolv1beta1.GcpScope{
+				Project:    "test-project",
+				VpcNetwork: "test-network",
+			},
+		},
+	},
+}
+
+var gcpNfsVolume = cloudresourcesv1beta1.GcpNfsVolume{
+	ObjectMeta: v1.ObjectMeta{
+		Name:      "test-gcp-nfs-volume",
+		Namespace: "test",
+	},
+	Spec: cloudresourcesv1beta1.GcpNfsVolumeSpec{
+		IpRange: cloudresourcesv1beta1.IpRangeRef{
+			Name:      "test-gcp-ip-range",
+			Namespace: "test",
+		},
+		Location:      "us-west1",
+		Tier:          "BASIC_HDD",
+		FileShareName: "vol1",
+		CapacityGb:    1024,
+	},
+	Status: cloudresourcesv1beta1.GcpNfsVolumeStatus{
+		Id:         "test-gcp-nfs-instance",
+		Hosts:      []string{"10.20.30.2"},
+		CapacityGb: 1024,
+		Conditions: []v1.Condition{
+			{
+				Type:               "Ready",
+				Status:             "True",
+				LastTransitionTime: v1.Time{Time: time.Now()},
+				Reason:             "Ready",
+				Message:            "NFS instance is ready",
+			},
+		},
+	},
+}
+var gcpNfsVolumeBackup = cloudresourcesv1beta1.GcpNfsVolumeBackup{
+	ObjectMeta: v1.ObjectMeta{
+		Name:      "test-gcp-nfs-volume-backup",
+		Namespace: "test",
+	},
+	Spec: cloudresourcesv1beta1.GcpNfsVolumeBackupSpec{
+		Location: "us-west1",
+		Source: cloudresourcesv1beta1.GcpNfsVolumeBackupSource{
+			Volume: cloudresourcesv1beta1.GcpNfsVolumeRef{
+				Name:      "test-gcp-nfs-volume",
+				Namespace: "test",
+			},
+		},
+	},
+	Status: cloudresourcesv1beta1.GcpNfsVolumeBackupStatus{
+		State: "Ready",
+		Conditions: []v1.Condition{
+			{
+				Type:               "Ready",
+				Status:             "True",
+				LastTransitionTime: v1.Time{Time: time.Now()},
+				Reason:             "Ready",
+				Message:            "NFS backup is ready",
+			},
+		},
+	},
+}
+
+var deletingGpNfsVolumeBackup = cloudresourcesv1beta1.GcpNfsVolumeBackup{
+	ObjectMeta: v1.ObjectMeta{
+		Name:              "test-gcp-nfs-volume-restore",
+		Namespace:         "test",
+		DeletionTimestamp: &v1.Time{Time: time.Now()},
+		Finalizers:        []string{cloudresourcesv1beta1.Finalizer},
+	},
+	Spec: cloudresourcesv1beta1.GcpNfsVolumeBackupSpec{
+		Location: "us-west1",
+		Source: cloudresourcesv1beta1.GcpNfsVolumeBackupSource{
+			Volume: cloudresourcesv1beta1.GcpNfsVolumeRef{
+				Name:      "test-gcp-nfs-volume",
+				Namespace: "test",
+			},
+		},
+	},
+}
+
+type testStateFactory struct {
+	factory                  StateFactory
+	skrCluster               composed.StateCluster
+	kcpCluster               composed.StateCluster
+	fileBackupClientProvider client.ClientProvider[client2.FileBackupClient]
+	env                      abstractions.Environment
+	gcpConfig                *client.GcpConfig
+	fakeHttpServer           *httptest.Server
+}
+
+func NewFakeFileBackupClientProvider(fakeHttpServer *httptest.Server) client.ClientProvider[client2.FileBackupClient] {
+	return client.NewCachedClientProvider(
+		func(ctx context.Context, saJsonKeyPath string) (client2.FileBackupClient, error) {
+			fsClient, err := file.NewService(ctx, option.WithoutAuthentication(), option.WithEndpoint(fakeHttpServer.URL))
+			if err != nil {
+				return nil, err
+			}
+			return client2.NewFileBackupClient(fsClient), nil
+		},
+	)
+}
+
+func newTestStateFactoryWithObj(fakeHttpServer *httptest.Server, gcpNfsVolumeBackup *cloudresourcesv1beta1.GcpNfsVolumeBackup) (*testStateFactory, error) {
+
+	kcpScheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(kcpScheme))
+	utilruntime.Must(cloudcontrolv1beta1.AddToScheme(kcpScheme))
+
+	kcpClient := fake.NewClientBuilder().
+		WithScheme(kcpScheme).
+		WithObjects(&scope).
+		Build()
+	kcpCluster := composed.NewStateCluster(kcpClient, kcpClient, nil, kcpScheme)
+
+	skrScheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(skrScheme))
+	utilruntime.Must(cloudresourcesv1beta1.AddToScheme(skrScheme))
+
+	skrClient := fake.NewClientBuilder().
+		WithScheme(skrScheme).
+		WithObjects(&gcpNfsVolume).
+		WithStatusSubresource(&gcpNfsVolume).
+		WithObjects(gcpNfsVolumeBackup).
+		WithStatusSubresource(gcpNfsVolumeBackup).
+		Build()
+	skrCluster := composed.NewStateCluster(skrClient, skrClient, nil, skrScheme)
+	nfsBackupClient := NewFakeFileBackupClientProvider(fakeHttpServer)
+	env := abstractions.NewMockedEnvironment(map[string]string{"GCP_SA_JSON_KEY_PATH": "test"})
+	factory := NewStateFactory(kymaRef, kcpCluster, skrCluster, nfsBackupClient, env)
+
+	return &testStateFactory{
+		factory:                  factory,
+		skrCluster:               skrCluster,
+		kcpCluster:               kcpCluster,
+		fileBackupClientProvider: nfsBackupClient,
+		env:                      env,
+		gcpConfig:                client.GetGcpConfig(env),
+		fakeHttpServer:           fakeHttpServer,
+	}, nil
+
+}
+
+func (f *testStateFactory) newStateWith(nfsBackup *cloudresourcesv1beta1.GcpNfsVolumeBackup) (*State, error) {
+	return f.factory.NewState(context.Background(), composed.NewStateFactory(f.skrCluster).NewState(
+		types.NamespacedName{
+			Name:      nfsBackup.Name,
+			Namespace: nfsBackup.Namespace,
+		}, nfsBackup))
+}

--- a/pkg/skr/gcpnfsvolumebackup/updateStatus.go
+++ b/pkg/skr/gcpnfsvolumebackup/updateStatus.go
@@ -39,6 +39,7 @@ func updateStatus(ctx context.Context, st composed.State) (error, context.Contex
 		return composed.StopAndForget, nil
 	} else {
 		logger.Info("Updating SKR GcpNfsVolumeBackup status with Ready condition")
+		backup.Status.State = cloudresourcesv1beta1.ConditionTypeReady
 		return composed.UpdateStatus(backup).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    cloudresourcesv1beta1.ConditionTypeReady,

--- a/pkg/skr/gcpnfsvolumebackup/updateStatus_test.go
+++ b/pkg/skr/gcpnfsvolumebackup/updateStatus_test.go
@@ -1,0 +1,177 @@
+package gcpnfsvolumebackup
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/file/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+type updateStatusSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *updateStatusSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *updateStatusSuite) TestDeletingBackupExists() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	obj := deletingGpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	state.fileBackup = &file.Backup{}
+	err, _ctx := updateStatus(ctx, state)
+
+	//validate expected return values
+	suite.Equal(err, composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime))
+	suite.Nil(_ctx)
+}
+
+func (suite *updateStatusSuite) TestDeletingBackupNotExists() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	obj := deletingGpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	err, _ctx := updateStatus(ctx, state)
+
+	//validate expected return values
+	suite.Equal(err, composed.StopAndForget)
+	suite.Nil(_ctx)
+}
+
+func (suite *updateStatusSuite) TestReadyAndBackupExists() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	state.fileBackup = &file.Backup{State: "READY"}
+	err, _ctx := updateStatus(ctx, state)
+
+	//validate expected return values
+	suite.Equal(composed.StopAndForget, err)
+	suite.Nil(_ctx)
+
+	fromK8s := &v1beta1.GcpNfsVolumeBackup{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: gcpNfsVolumeBackup.Name,
+			Namespace: gcpNfsVolumeBackup.Namespace},
+		fromK8s)
+
+	suite.Equal(v1beta1.ConditionTypeReady, string(fromK8s.Status.State))
+	suite.Equal(metav1.ConditionTrue, fromK8s.Status.Conditions[0].Status)
+	suite.Equal(cloudresourcesv1beta1.ConditionTypeReady, fromK8s.Status.Conditions[0].Type)
+}
+
+func (suite *updateStatusSuite) TestNotReadyAndBackupReady() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolumeBackup
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	//Update the status with empty conditions
+	obj.Status.Conditions = []metav1.Condition{}
+	err = state.SkrCluster.K8sClient().Status().Update(ctx, obj)
+	suite.Nil(err)
+
+	state.fileBackup = &file.Backup{State: "READY"}
+	err, _ctx := updateStatus(ctx, state)
+
+	//validate expected return values
+	suite.Equal(composed.StopWithRequeue, err)
+	suite.NotNil(_ctx)
+
+	fromK8s := &v1beta1.GcpNfsVolumeBackup{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: gcpNfsVolumeBackup.Name,
+			Namespace: gcpNfsVolumeBackup.Namespace},
+		fromK8s)
+
+	suite.Equal(v1beta1.ConditionTypeReady, string(fromK8s.Status.State))
+	suite.Equal(metav1.ConditionTrue, fromK8s.Status.Conditions[0].Status)
+	suite.Equal(cloudresourcesv1beta1.ConditionTypeReady, fromK8s.Status.Conditions[0].Type)
+}
+
+func (suite *updateStatusSuite) TestNotReadyAndBackupNotReady() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		return
+	}))
+
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//Get state object with GcpNfsVolumeBackup
+	state, err := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	//Update the status with empty conditions
+	obj.Status.Conditions = []metav1.Condition{}
+	err = state.SkrCluster.K8sClient().Status().Update(ctx, obj)
+	suite.Nil(err)
+
+	state.fileBackup = &file.Backup{State: "CREATING"}
+	err, _ctx := updateStatus(ctx, state)
+
+	//validate expected return values
+	suite.Equal(composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), err)
+	suite.Nil(_ctx)
+}
+
+func TestUpdateStatus(t *testing.T) {
+	suite.Run(t, new(updateStatusSuite))
+}


### PR DESCRIPTION
**Description**

Added unit tests for the following GcpNfsVolumeBackup actions

- addFinalizer
- createNfsBackup
- deleteNfsBackup
- loadGcpNfsVolume
- loadNfsBackup
- loadScope
- removeFinalizer
- updateStatus

**Related issue(s)**
https://jira.tools.sap/browse/PHX-121