### PR TITLE
feat(AzureVpcPeering): KCP Create VpcPeering change peering name

### DIFF
--- a/internal/controller/cloud-control/vpcpeering_azure_test.go
+++ b/internal/controller/cloud-control/vpcpeering_azure_test.go
@@ -18,13 +18,13 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 		const (
 			kymaName            = "6a62936d-aa6e-4d5b-aaaa-5eae646d1bd5"
 			vpcpeeringName      = "281bc581-8635-4d56-ba52-fa48ec6f7c69"
-			subscriptionId      = "3f1d2fbd-117a-4742-8bde-6edbcdee6a04"
-			remoteSubscription  = "9c05f3c1-314b-4c4b-bfff-b5a0650177cb"
+			subscriptionId      = "2bfba5a4-c5d1-4b03-a7db-4ead64232fd6"
+			remoteSubscription  = "afdbc79f-de19-4df4-94cd-6be2739dc0e0"
 			remoteResourceGroup = "MyResourceGroup"
 			remoteVnetName      = "MyVnet"
 			remoteRefNamespace  = "skr-namespace"
 			remoteRefName       = "skr-azure-vpcpeering"
-			remoteVnet          = "/subscriptions/9c05f3c1-314b-4c4b-bfff-b5a0650177cb/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVnet"
+			remoteVnet          = "/subscriptions/afdbc79f-de19-4df4-94cd-6be2739dc0e0/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVnet"
 		)
 
 		scope := &cloudcontrolv1beta1.Scope{}

--- a/pkg/kcp/provider/azure/util/resources_test.go
+++ b/pkg/kcp/provider/azure/util/resources_test.go
@@ -7,10 +7,10 @@ import (
 
 func TestParseResourceID(t *testing.T) {
 
-	id := "/subscriptions/9c05f3c1-314b-4c4b-bfff-b5a0650177cb/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVnet/virtualNetworkPeerings/MyVnet-shoot--spm-test01--phx-azr-02"
+	id := "/subscriptions/afdbc79f-de19-4df4-94cd-6be2739dc0e0/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVnet/virtualNetworkPeerings/MyVnet-shoot--spm-test01--phx-azr-02"
 
 	d, _ := ParseResourceID(id)
-	assert.Equal(t, d.Subscription, "9c05f3c1-314b-4c4b-bfff-b5a0650177cb")
+	assert.Equal(t, d.Subscription, "afdbc79f-de19-4df4-94cd-6be2739dc0e0")
 	assert.Equal(t, d.ResourceGroup, "MyResourceGroup")
 	assert.Equal(t, d.ResourceName, "MyVnet")
 	assert.Equal(t, d.Provider, "Microsoft.Network")
@@ -19,10 +19,10 @@ func TestParseResourceID(t *testing.T) {
 
 func TestParseSubResourceID(t *testing.T) {
 
-	id := "/subscriptions/9c05f3c1-314b-4c4b-bfff-b5a0650177cb/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVnet/virtualNetworkPeerings/MyVnet-shoot--spm-test01--phx-azr-02"
+	id := "/subscriptions/afdbc79f-de19-4df4-94cd-6be2739dc0e0/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVnet/virtualNetworkPeerings/MyVnet-shoot--spm-test01--phx-azr-02"
 
 	d, _ := ParseResourceID(id)
-	assert.Equal(t, d.Subscription, "9c05f3c1-314b-4c4b-bfff-b5a0650177cb")
+	assert.Equal(t, d.Subscription, "afdbc79f-de19-4df4-94cd-6be2739dc0e0")
 	assert.Equal(t, d.ResourceGroup, "MyResourceGroup")
 	assert.Equal(t, d.ResourceName, "MyVnet")
 	assert.Equal(t, d.Provider, "Microsoft.Network")
@@ -33,9 +33,9 @@ func TestParseSubResourceID(t *testing.T) {
 
 func TestVirtualNetworkPeeringResourceId(t *testing.T) {
 
-	expected := "/subscriptions/9c05f3c1-314b-4c4b-bfff-b5a0650177cb/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVnet/virtualNetworkPeerings/MyVnet-shoot--spm-test01--phx-azr-02"
+	expected := "/subscriptions/afdbc79f-de19-4df4-94cd-6be2739dc0e0/resourceGroups/MyResourceGroup/providers/Microsoft.Network/virtualNetworks/MyVnet/virtualNetworkPeerings/MyVnet-shoot--spm-test01--phx-azr-02"
 
-	actual := VirtualNetworkPeeringResourceId("9c05f3c1-314b-4c4b-bfff-b5a0650177cb", "MyResourceGroup", "MyVnet", "MyVnet-shoot--spm-test01--phx-azr-02")
+	actual := VirtualNetworkPeeringResourceId("afdbc79f-de19-4df4-94cd-6be2739dc0e0", "MyResourceGroup", "MyVnet", "MyVnet-shoot--spm-test01--phx-azr-02")
 
 	assert.Equal(t, expected, actual)
 }

--- a/pkg/kcp/provider/azure/vpcpeering/client/client.go
+++ b/pkg/kcp/provider/azure/vpcpeering/client/client.go
@@ -17,6 +17,7 @@ type Client interface {
 		allowVnetAccess bool) (*armnetwork.VirtualNetworkPeering, error)
 
 	List(ctx context.Context, resourceGroupName string, virtualNetworkName string) ([]*armnetwork.VirtualNetworkPeering, error)
+	Get(ctx context.Context, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName string) (*armnetwork.VirtualNetworkPeering, error)
 }
 
 func NewClientProvider() azureclient.SkrClientProvider[Client] {
@@ -105,4 +106,15 @@ func (c *client) List(ctx context.Context, resourceGroupName string, virtualNetw
 	}
 
 	return items, nil
+}
+
+func (c *client) Get(ctx context.Context, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName string) (*armnetwork.VirtualNetworkPeering, error) {
+
+	response, err := c.svc.Get(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.VirtualNetworkPeering, nil
 }

--- a/pkg/kcp/provider/azure/vpcpeering/createVpcPeeringConnection.go
+++ b/pkg/kcp/provider/azure/vpcpeering/createVpcPeeringConnection.go
@@ -3,7 +3,6 @@ package vpcpeering
 import (
 	"context"
 	"fmt"
-	"github.com/google/uuid"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,7 +20,7 @@ func createVpcPeeringConnection(ctx context.Context, st composed.State) (error, 
 	}
 
 	resourceGroupName := state.Scope().Spec.Scope.Azure.VpcNetwork // TBD resourceGroup name have the same name as VPC
-	virtualNetworkPeeringName := uuid.NewString()
+	virtualNetworkPeeringName := obj.Name
 
 	peering, err := state.client.BeginCreateOrUpdate(ctx,
 		resourceGroupName,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Azure peering name should be the same as the name of the applied resource in KCP
