### PR TITLE
chore(KCP IpRange): preps for KCP IpRange impl v2 and optional cidr

### DIFF
--- a/pkg/kcp/provider/aws/iprange/client/client.go
+++ b/pkg/kcp/provider/aws/iprange/client/client.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Client interface {
+	DescribeVpc(ctx context.Context, vpcId string) (*types.Vpc, error)
 	DescribeVpcs(ctx context.Context) ([]types.Vpc, error)
 	AssociateVpcCidrBlock(ctx context.Context, vpcId, cidr string) (*types.VpcCidrBlockAssociation, error)
 	DisassociateVpcCidrBlockInput(ctx context.Context, associationId string) error
@@ -34,6 +35,19 @@ func newClient(svc *ec2.Client) Client {
 
 type client struct {
 	svc *ec2.Client
+}
+
+func (c *client) DescribeVpc(ctx context.Context, vpcId string) (*types.Vpc, error) {
+	out, err := c.svc.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{
+		VpcIds: []string{vpcId},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(out.Vpcs) > 0 {
+		return &out.Vpcs[0], nil
+	}
+	return nil, nil
 }
 
 func (c *client) DescribeVpcs(ctx context.Context) ([]types.Vpc, error) {

--- a/pkg/kcp/provider/aws/iprange/new.go
+++ b/pkg/kcp/provider/aws/iprange/new.go
@@ -2,59 +2,12 @@ package iprange
 
 import (
 	"context"
-	"fmt"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	iprangetypes "github.com/kyma-project/cloud-manager/pkg/kcp/iprange/types"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	v1 "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/iprange/v1"
 )
 
 func New(stateFactory StateFactory) composed.Action {
 	return func(ctx context.Context, st composed.State) (error, context.Context) {
-		logger := composed.LoggerFromCtx(ctx)
-		ipRangeState := st.(iprangetypes.State)
-		state, err := stateFactory.NewState(ctx, ipRangeState, logger)
-		if err != nil {
-			err = fmt.Errorf("error creating new aws iprange state: %w", err)
-			logger.Error(err, "Error")
-			return composed.StopAndForget, nil
-		}
-		return composed.BuildSwitchAction(
-			"awsIpRange",
-			composed.ComposeActions(
-				"awsIpRange-non-delete",
-				addFinalizer,
-				preventCidrEdit,
-				splitRangeByZones,
-				ensureShootZonesAndRangeSubnetsMatch,
-				loadVpc,
-				checkCidrOverlap,
-				checkCidrBlockStatus,
-				extendVpcAddressSpace,
-				loadSubnets,
-				findCloudResourceSubnets,
-				checkSubnetOverlap,
-				createSubnets,
-				updateSuccessStatus,
-				composed.StopAndForgetAction,
-			),
-			composed.NewCase(
-				composed.MarkedForDeletionPredicate,
-				composed.ComposeActions(
-					"awsIpRange-delete",
-					removeReadyCondition,
-					loadVpc,
-					loadSubnets,
-					findCloudResourceSubnets,
-
-					deleteSubnets,
-					waitSubnetsDeleted,
-
-					disassociateVpcAddressSpace,
-					waitCidrBlockDisassociated,
-
-					removeFinalizer,
-				),
-			),
-		)(awsmeta.SetAwsAccountId(ctx, ipRangeState.Scope().Spec.Scope.Aws.AccountId), state)
+		return v1.New(stateFactory.(*generealStateFactory).v1StateFactory)(ctx, st)
 	}
 }

--- a/pkg/kcp/provider/aws/iprange/state.go
+++ b/pkg/kcp/provider/aws/iprange/state.go
@@ -2,70 +2,28 @@ package iprange
 
 import (
 	"context"
-	"fmt"
-	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/go-logr/logr"
-	"github.com/kyma-project/cloud-manager/pkg/kcp/iprange/types"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	iprangetypes "github.com/kyma-project/cloud-manager/pkg/kcp/iprange/types"
 	awsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/client"
-	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
 	iprangeclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/iprange/client"
+	v1 "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/iprange/v1"
 )
 
-// State is state of the IpRange reconciliation for AWS
-// Though there's no need for it to be public, still made like that
-// to avoid conflict with variable names - DO NOT LOWERCASE IT TO MAKE IT PRIVATE
-type State struct {
-	types.State
-
-	client iprangeclient.Client
-
-	vpc                  *ec2Types.Vpc
-	associatedCidrBlock  *ec2Types.VpcCidrBlockAssociation
-	allSubnets           []ec2Types.Subnet
-	cloudResourceSubnets []ec2Types.Subnet
-}
-
 type StateFactory interface {
-	NewState(ctx context.Context, ipRangeState types.State, logger logr.Logger) (*State, error)
+	NewState(ctx context.Context, ipRangeState iprangetypes.State, logger logr.Logger) (composed.State, error)
 }
 
 func NewStateFactory(skrProvider awsclient.SkrClientProvider[iprangeclient.Client]) StateFactory {
-	return &stateFactory{
-		skrProvider: skrProvider,
+	return &generealStateFactory{
+		v1StateFactory: v1.NewStateFactory(skrProvider),
 	}
 }
 
-type stateFactory struct {
-	skrProvider awsclient.SkrClientProvider[iprangeclient.Client]
+type generealStateFactory struct {
+	v1StateFactory v1.StateFactory
 }
 
-func (f *stateFactory) NewState(ctx context.Context, ipRangeState types.State, logger logr.Logger) (*State, error) {
-	roleName := fmt.Sprintf("arn:aws:iam::%s:role/%s", ipRangeState.Scope().Spec.Scope.Aws.AccountId, awsconfig.AwsConfig.AssumeRoleName)
-
-	logger.
-		WithValues(
-			"awsRegion", ipRangeState.Scope().Spec.Region,
-			"awsRole", roleName,
-		).
-		Info("Assuming AWS role")
-
-	c, err := f.skrProvider(
-		ctx,
-		ipRangeState.Scope().Spec.Region,
-		awsconfig.AwsConfig.AccessKeyId,
-		awsconfig.AwsConfig.SecretAccessKey,
-		roleName,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return newState(ipRangeState, c), nil
-}
-
-func newState(ipRangeState types.State, c iprangeclient.Client) *State {
-	return &State{
-		State:  ipRangeState,
-		client: c,
-	}
+func (f *generealStateFactory) NewState(ctx context.Context, ipRangeState iprangetypes.State, logger logr.Logger) (composed.State, error) {
+	return f.v1StateFactory.NewState(ctx, ipRangeState, logger)
 }

--- a/pkg/kcp/provider/aws/iprange/v1/addFinalizer.go
+++ b/pkg/kcp/provider/aws/iprange/v1/addFinalizer.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/checkCidrBlockStatus.go
+++ b/pkg/kcp/provider/aws/iprange/v1/checkCidrBlockStatus.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/checkCidrOverlap.go
+++ b/pkg/kcp/provider/aws/iprange/v1/checkCidrOverlap.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/checkSubnetOverlap.go
+++ b/pkg/kcp/provider/aws/iprange/v1/checkSubnetOverlap.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/createSubnets.go
+++ b/pkg/kcp/provider/aws/iprange/v1/createSubnets.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/deleteSubnets.go
+++ b/pkg/kcp/provider/aws/iprange/v1/deleteSubnets.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/disassociateVpcAddressSpace.go
+++ b/pkg/kcp/provider/aws/iprange/v1/disassociateVpcAddressSpace.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/ensureShootZonesAndRangeSubnetsMatch.go
+++ b/pkg/kcp/provider/aws/iprange/v1/ensureShootZonesAndRangeSubnetsMatch.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/extendVpcAddressSpace.go
+++ b/pkg/kcp/provider/aws/iprange/v1/extendVpcAddressSpace.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/findCloudResourceSubnets.go
+++ b/pkg/kcp/provider/aws/iprange/v1/findCloudResourceSubnets.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/loadSubnets.go
+++ b/pkg/kcp/provider/aws/iprange/v1/loadSubnets.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/loadVpc.go
+++ b/pkg/kcp/provider/aws/iprange/v1/loadVpc.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/new.go
+++ b/pkg/kcp/provider/aws/iprange/v1/new.go
@@ -1,0 +1,60 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	iprangetypes "github.com/kyma-project/cloud-manager/pkg/kcp/iprange/types"
+	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+)
+
+func New(stateFactory StateFactory) composed.Action {
+	return func(ctx context.Context, st composed.State) (error, context.Context) {
+		logger := composed.LoggerFromCtx(ctx)
+		ipRangeState := st.(iprangetypes.State)
+		state, err := stateFactory.NewState(ctx, ipRangeState, logger)
+		if err != nil {
+			err = fmt.Errorf("error creating new aws iprange state: %w", err)
+			logger.Error(err, "Error")
+			return composed.StopAndForget, nil
+		}
+		return composed.BuildSwitchAction(
+			"awsIpRange",
+			composed.ComposeActions(
+				"awsIpRange-non-delete",
+				addFinalizer,
+				preventCidrEdit,
+				splitRangeByZones,
+				ensureShootZonesAndRangeSubnetsMatch,
+				loadVpc,
+				checkCidrOverlap,
+				checkCidrBlockStatus,
+				extendVpcAddressSpace,
+				loadSubnets,
+				findCloudResourceSubnets,
+				checkSubnetOverlap,
+				createSubnets,
+				updateSuccessStatus,
+				composed.StopAndForgetAction,
+			),
+			composed.NewCase(
+				composed.MarkedForDeletionPredicate,
+				composed.ComposeActions(
+					"awsIpRange-delete",
+					removeReadyCondition,
+					loadVpc,
+					loadSubnets,
+					findCloudResourceSubnets,
+
+					deleteSubnets,
+					waitSubnetsDeleted,
+
+					disassociateVpcAddressSpace,
+					waitCidrBlockDisassociated,
+
+					removeFinalizer,
+				),
+			),
+		)(awsmeta.SetAwsAccountId(ctx, ipRangeState.Scope().Spec.Scope.Aws.AccountId), state)
+	}
+}

--- a/pkg/kcp/provider/aws/iprange/v1/preventCidrEdit.go
+++ b/pkg/kcp/provider/aws/iprange/v1/preventCidrEdit.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/removeFinalizer.go
+++ b/pkg/kcp/provider/aws/iprange/v1/removeFinalizer.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/removeReadyCondition.go
+++ b/pkg/kcp/provider/aws/iprange/v1/removeReadyCondition.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/splitRangeByZones.go
+++ b/pkg/kcp/provider/aws/iprange/v1/splitRangeByZones.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/state.go
+++ b/pkg/kcp/provider/aws/iprange/v1/state.go
@@ -1,0 +1,71 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/go-logr/logr"
+	iprangetypes "github.com/kyma-project/cloud-manager/pkg/kcp/iprange/types"
+	awsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/client"
+	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
+	iprangeclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/iprange/client"
+)
+
+// State is state of the IpRange reconciliation for AWS
+// Though there's no need for it to be public, still made like that
+// to avoid conflict with variable names - DO NOT LOWERCASE IT TO MAKE IT PRIVATE
+type State struct {
+	iprangetypes.State
+
+	client iprangeclient.Client
+
+	vpc                  *ec2Types.Vpc
+	associatedCidrBlock  *ec2Types.VpcCidrBlockAssociation
+	allSubnets           []ec2Types.Subnet
+	cloudResourceSubnets []ec2Types.Subnet
+}
+
+type StateFactory interface {
+	NewState(ctx context.Context, ipRangeState iprangetypes.State, logger logr.Logger) (*State, error)
+}
+
+func NewStateFactory(skrProvider awsclient.SkrClientProvider[iprangeclient.Client]) StateFactory {
+	return &stateFactory{
+		skrProvider: skrProvider,
+	}
+}
+
+type stateFactory struct {
+	skrProvider awsclient.SkrClientProvider[iprangeclient.Client]
+}
+
+func (f *stateFactory) NewState(ctx context.Context, ipRangeState iprangetypes.State, logger logr.Logger) (*State, error) {
+	roleName := fmt.Sprintf("arn:aws:iam::%s:role/%s", ipRangeState.Scope().Spec.Scope.Aws.AccountId, awsconfig.AwsConfig.AssumeRoleName)
+
+	logger.
+		WithValues(
+			"awsRegion", ipRangeState.Scope().Spec.Region,
+			"awsRole", roleName,
+		).
+		Info("Assuming AWS role")
+
+	c, err := f.skrProvider(
+		ctx,
+		ipRangeState.Scope().Spec.Region,
+		awsconfig.AwsConfig.AccessKeyId,
+		awsconfig.AwsConfig.SecretAccessKey,
+		roleName,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return newState(ipRangeState, c), nil
+}
+
+func newState(ipRangeState iprangetypes.State, c iprangeclient.Client) *State {
+	return &State{
+		State:  ipRangeState,
+		client: c,
+	}
+}

--- a/pkg/kcp/provider/aws/iprange/v1/updateSuccessStatus.go
+++ b/pkg/kcp/provider/aws/iprange/v1/updateSuccessStatus.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/util.go
+++ b/pkg/kcp/provider/aws/iprange/v1/util.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 const (
 	tagKey = "cloud-manager.kyma-project.io/iprange"

--- a/pkg/kcp/provider/aws/iprange/v1/waitCidrBlockDisassociated.go
+++ b/pkg/kcp/provider/aws/iprange/v1/waitCidrBlockDisassociated.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/iprange/v1/waitSubnetsDeleted.go
+++ b/pkg/kcp/provider/aws/iprange/v1/waitSubnetsDeleted.go
@@ -1,4 +1,4 @@
-package iprange
+package v1
 
 import (
 	"context"

--- a/pkg/kcp/provider/aws/mock/vpcStore.go
+++ b/pkg/kcp/provider/aws/mock/vpcStore.go
@@ -106,6 +106,22 @@ func (s *vpcStore) AddVpc(id, cidr string, tags []ec2Types.Tag, subnets []VpcSub
 
 // Client implementation ========================================
 
+func (s *vpcStore) DescribeVpc(ctx context.Context, vpcId string) (*ec2Types.Vpc, error) {
+	if isContextCanceled(ctx) {
+		return nil, context.Canceled
+	}
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	for _, item := range s.items {
+		if pointer.StringDeref(item.vpc.VpcId, "") == vpcId {
+			return &item.vpc, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func (s *vpcStore) DescribeVpcs(ctx context.Context) ([]ec2Types.Vpc, error) {
 	if isContextCanceled(ctx) {
 		return nil, context.Canceled


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

Simple refactoring and move of `pkg/kcp/provider/aws/iprange` into `pkg/kcp/provider/aws/iprange/v1` to make room for `pkg/kcp/provider/aws/iprange/v2` implementation

- moved `pkg/kcp/provider/aws/iprange` to `pkg/kcp/provider/aws/iprange/v1`
- added general `StateFactory` and `New()` constructor in `pkg/kcp/provider/aws/iprange` that simply delegates to old v1 implementation, so that external usage remains the same
- added `DescribeVpc()` to iprange aws client, not used yet

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
