### PR TITLE
feat(AzureVpcPeering): KCP Load vpc peerings

### DIFF
--- a/api/cloud-control/v1beta1/vpcpeering_types.go
+++ b/api/cloud-control/v1beta1/vpcpeering_types.go
@@ -80,6 +80,9 @@ type VpcPeeringStatus struct {
 	// +optional
 	Id string `json:"id,omitempty"`
 
+	// +optional
+	RemoteId string `json:"remoteId,omitempty"`
+
 	// List of status conditions to indicate the status of a Peering.
 	// +optional
 	// +listType=map

--- a/config/crd/bases/cloud-control.kyma-project.io_vpcpeerings.yaml
+++ b/config/crd/bases/cloud-control.kyma-project.io_vpcpeerings.yaml
@@ -167,6 +167,8 @@ spec:
                 x-kubernetes-list-type: map
               id:
                 type: string
+              remoteId:
+                type: string
               state:
                 type: string
               vpcId:

--- a/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_vpcpeerings.yaml
+++ b/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_vpcpeerings.yaml
@@ -167,6 +167,8 @@ spec:
                 x-kubernetes-list-type: map
               id:
                 type: string
+              remoteId:
+                type: string
               state:
                 type: string
               vpcId:

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21.4
 
 require (
 	github.com/3th1nk/cidr v0.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5 v5.1.1
 	github.com/aws/aws-sdk-go-v2 v1.26.1
@@ -46,7 +47,6 @@ require (
 require (
 	cloud.google.com/go/compute v1.23.3 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/BurntSushi/toml v1.3.2 // indirect

--- a/pkg/kcp/provider/azure/config/config.go
+++ b/pkg/kcp/provider/azure/config/config.go
@@ -5,10 +5,8 @@ import (
 )
 
 type AzureConfigStruct struct {
-	ClientId       string `json:"clientId,omitempty" yaml:"clientId,omitempty"`
-	ClientSecret   string `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
-	SubscriptionId string `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
-	TenantId       string `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
+	ClientId     string `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+	ClientSecret string `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
 }
 
 var AzureConfig = &AzureConfigStruct{}
@@ -28,18 +26,6 @@ func InitConfig(cfg config.Config) {
 			config.Sensitive(),
 			config.SourceEnv("AZ_CLIENT_SECRET"),
 			config.SourceFile("AZ_CLIENT_SECRET"),
-		),
-		config.Path(
-			"subscriptionId",
-			config.Sensitive(),
-			config.SourceEnv("AZ_SUBSCRIPTION_ID"),
-			config.SourceFile("AZ_SUBSCRIPTION_ID"),
-		),
-		config.Path(
-			"tenantId",
-			config.Sensitive(),
-			config.SourceEnv("AZ_TENANT_ID"),
-			config.SourceFile("AZ_TENANT_ID"),
 		),
 	)
 }

--- a/pkg/kcp/provider/azure/meta/metadata.go
+++ b/pkg/kcp/provider/azure/meta/metadata.go
@@ -1,0 +1,28 @@
+package meta
+
+import (
+	"context"
+	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+)
+
+func TooManyRequests(err error) bool {
+	var respErr *azcore.ResponseError
+
+	// https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/request-limits-and-throttling
+	return errors.As(err, &respErr) && respErr.StatusCode == 429
+}
+
+func ErrorToRequeueResponse(err error) error {
+	if TooManyRequests(err) {
+		return composed.StopWithRequeueDelay(util.Timing.T10000ms())
+	}
+	return composed.StopWithRequeueDelay(util.Timing.T300000ms())
+}
+
+func LogErrorAndReturn(err error, msg string, ctx context.Context) (error, context.Context) {
+	result := ErrorToRequeueResponse(err)
+	return composed.LogErrorAndReturn(err, msg, result, ctx)
+}

--- a/pkg/kcp/provider/azure/mock/server.go
+++ b/pkg/kcp/provider/azure/mock/server.go
@@ -19,7 +19,8 @@ type server struct {
 }
 
 func (s *server) VpcPeeringSkrProvider() provider.SkrClientProvider[client.Client] {
-	return func(ctx context.Context, region, key, secret, role string) (client.Client, error) {
+	return func(ctx context.Context, clientId, clientSecret, subscriptionId, tenantId string) (client.Client, error) {
+		s.subscriptionId = subscriptionId
 		return s, nil
 	}
 }

--- a/pkg/kcp/provider/azure/mock/vpcPeeringStore.go
+++ b/pkg/kcp/provider/azure/mock/vpcPeeringStore.go
@@ -83,7 +83,8 @@ func (s *vpcPeeringStore) List(ctx context.Context, resourceGroupName string, vi
 
 func (s *vpcPeeringStore) Get(ctx context.Context, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName string) (*armnetwork.VirtualNetworkPeering, error) {
 	for _, x := range s.items {
-		if virtualNetworkPeeringName == pointer.StringDeref(x.peering.Name, "") &&
+		if s.subscriptionId == x.subscription &&
+			virtualNetworkPeeringName == pointer.StringDeref(x.peering.Name, "") &&
 			resourceGroupName == x.resourceGroupName &&
 			virtualNetworkName == x.virtualNetworkName {
 			return &x.peering, nil

--- a/pkg/kcp/provider/azure/vpcpeering/createVpcPeeringConnection.go
+++ b/pkg/kcp/provider/azure/vpcpeering/createVpcPeeringConnection.go
@@ -15,7 +15,7 @@ func createVpcPeeringConnection(ctx context.Context, st composed.State) (error, 
 	logger := composed.LoggerFromCtx(ctx)
 	obj := state.ObjAsVpcPeering()
 
-	if len(state.ObjAsVpcPeering().Status.Id) > 0 {
+	if state.peering != nil {
 		return nil, nil
 	}
 

--- a/pkg/kcp/provider/azure/vpcpeering/loadRemoteVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/loadRemoteVpcPeering.go
@@ -1,0 +1,41 @@
+package vpcpeering
+
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	azuremeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/meta"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/util"
+	"k8s.io/utils/pointer"
+)
+
+func loadRemoteVpcPeering(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+	obj := state.ObjAsVpcPeering()
+
+	if state.remotePeering == nil {
+		return nil, nil
+	}
+
+	resource, err := util.ParseResourceID(obj.Status.RemoteId)
+
+	if err != nil {
+		return azuremeta.LogErrorAndReturn(err, "Error parsing remote virtual network peering ID", nil)
+	}
+
+	peering, err := state.client.Get(ctx, resource.ResourceGroup, resource.ResourceName, resource.SubResourceName)
+
+	if err != nil {
+		return azuremeta.LogErrorAndReturn(err, "Error loading remote VPC Peering", nil)
+	}
+
+	logger = logger.WithValues("remoteId", pointer.StringDeref(peering.ID, ""))
+
+	ctx = composed.LoggerIntoCtx(ctx, logger)
+
+	state.remotePeering = peering
+
+	logger.Info("Azure remote VPC peering loaded")
+
+	return nil, ctx
+}

--- a/pkg/kcp/provider/azure/vpcpeering/loadVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/loadVpcPeering.go
@@ -1,0 +1,41 @@
+package vpcpeering
+
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	azuremeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/meta"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/util"
+	"k8s.io/utils/pointer"
+)
+
+func loadVpcPeering(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+	obj := state.ObjAsVpcPeering()
+
+	if len(obj.Status.Id) == 0 {
+		return nil, nil
+	}
+
+	resource, err := util.ParseResourceID(obj.Status.Id)
+
+	if err != nil {
+		return azuremeta.LogErrorAndReturn(err, "Error parsing virtual network peering ID", ctx)
+	}
+
+	peering, err := state.client.Get(ctx, resource.ResourceGroup, resource.ResourceName, resource.SubResourceName)
+
+	if err != nil {
+		return azuremeta.LogErrorAndReturn(err, "Error loading VPC Peering", ctx)
+	}
+
+	logger = logger.WithValues("id", pointer.StringDeref(peering.ID, ""))
+
+	ctx = composed.LoggerIntoCtx(ctx, logger)
+
+	state.peering = peering
+
+	logger.Info("Azure VPC Peering loaded")
+
+	return nil, ctx
+}

--- a/pkg/kcp/provider/azure/vpcpeering/new.go
+++ b/pkg/kcp/provider/azure/vpcpeering/new.go
@@ -25,6 +25,8 @@ func New(stateFactory StateFactory) composed.Action {
 				// default action
 				composed.ComposeActions("azureVpcPeering-non-delete",
 					addFinalizer,
+					loadVpcPeering,
+					loadRemoteVpcPeering,
 					createVpcPeeringConnection,
 					createVpcPeeringRemote,
 					updateSuccessStatus,

--- a/pkg/kcp/provider/azure/vpcpeering/state.go
+++ b/pkg/kcp/provider/azure/vpcpeering/state.go
@@ -2,6 +2,7 @@ package vpcpeering
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
 	"github.com/go-logr/logr"
 	azureclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/client"
 	azureconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/config"
@@ -18,6 +19,9 @@ type State struct {
 	clientSecret   string
 	subscriptionId string
 	tenantId       string
+
+	peering       *armnetwork.VirtualNetworkPeering
+	remotePeering *armnetwork.VirtualNetworkPeering
 }
 
 // goes to new.go
@@ -39,12 +43,8 @@ func (f *stateFactory) NewState(ctx context.Context, vpcPeeringState vpcpeeringt
 
 	clientId := azureconfig.AzureConfig.ClientId
 	clientSecret := azureconfig.AzureConfig.ClientSecret
-	subscriptionId := azureconfig.AzureConfig.SubscriptionId
-	tenantId := azureconfig.AzureConfig.TenantId
-
-	logger.WithValues(
-		"awsRegion", vpcPeeringState.Scope().Spec.Region,
-	).Info("Assuming AWS role")
+	subscriptionId := vpcPeeringState.Scope().Spec.Scope.Azure.SubscriptionId
+	tenantId := vpcPeeringState.Scope().Spec.Scope.Azure.TenantId
 
 	c, err := f.skrProvider(ctx, clientId, clientSecret, subscriptionId, tenantId)
 

--- a/pkg/testinfra/dsl/scope.go
+++ b/pkg/testinfra/dsl/scope.go
@@ -88,7 +88,7 @@ func CreateScopeAzure(ctx context.Context, infra testinfra.Infra, scope *cloudco
 		Scope: cloudcontrolv1beta1.ScopeInfo{
 			Azure: &cloudcontrolv1beta1.AzureScope{
 				TenantId:       "fdd97055-c316-462f-8769-f99b670c2c4d",
-				SubscriptionId: "44753ea6-98e9-4e46-b6db-8e03e790e10e",
+				SubscriptionId: "2bfba5a4-c5d1-4b03-a7db-4ead64232fd6",
 				VpcNetwork:     fmt.Sprintf("shoot--%s--%s", project, scope.Name),
 			},
 		},


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- added remoteId which identifies remote vpc peering connection
- subscriptionId and tenantId has been removed from config as they will be read from scope (for KCP) or specified in VpcPeering (SKR)