### PR TITLE
feat(AwsNfsVolume): optional iprange

### DIFF
--- a/api/cloud-resources/v1beta1/awsnfsvolume_types.go
+++ b/api/cloud-resources/v1beta1/awsnfsvolume_types.go
@@ -43,7 +43,7 @@ const (
 // AwsNfsVolumeSpec defines the desired state of AwsNfsVolume
 type AwsNfsVolumeSpec struct {
 
-	// +kubebuilder:validation:Required
+	// +optional
 	IpRange IpRangeRef `json:"ipRange"`
 
 	// +kubebuilder:validation:Required
@@ -111,6 +111,32 @@ func (in *AwsNfsVolume) SpecificToFeature() featuretypes.FeatureName {
 
 func (in *AwsNfsVolume) SpecificToProviders() []string {
 	return []string{"aws"}
+}
+
+func (in *AwsNfsVolume) GetIpRangeRef() IpRangeRef {
+	return in.Spec.IpRange
+}
+
+func (in *AwsNfsVolume) State() string {
+	return in.Status.State
+}
+
+func (in *AwsNfsVolume) SetState(v string) {
+	in.Status.State = v
+}
+
+func (in *AwsNfsVolume) CloneForPatchStatus() client.Object {
+	return &AwsNfsVolume{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AwsNfsVolume",
+			APIVersion: GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: in.Namespace,
+			Name:      in.Name,
+		},
+		Status: in.Status,
+	}
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/cloud-resources.kyma-project.io_awsnfsvolumes.yaml
+++ b/config/crd/bases/cloud-resources.kyma-project.io_awsnfsvolumes.yaml
@@ -87,7 +87,6 @@ spec:
                 type: object
             required:
             - capacity
-            - ipRange
             type: object
           status:
             description: AwsNfsVolumeStatus defines the observed state of AwsNfsVolume

--- a/config/dist/skr/crd/bases/providers/aws/cloud-resources.kyma-project.io_awsnfsvolumes.yaml
+++ b/config/dist/skr/crd/bases/providers/aws/cloud-resources.kyma-project.io_awsnfsvolumes.yaml
@@ -87,7 +87,6 @@ spec:
                 type: object
             required:
             - capacity
-            - ipRange
             type: object
           status:
             description: AwsNfsVolumeStatus defines the observed state of AwsNfsVolume

--- a/internal/controller/cloud-resources/suite_test.go
+++ b/internal/controller/cloud-resources/suite_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
 	"github.com/kyma-project/cloud-manager/pkg/quota"
 	"github.com/kyma-project/cloud-manager/pkg/testinfra"
+	testinfradsl "github.com/kyma-project/cloud-manager/pkg/testinfra/dsl"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -65,7 +66,11 @@ var _ = BeforeSuite(func() {
 
 	Expect(infra.KCP().GivenNamespaceExists(infra.KCP().Namespace())).
 		NotTo(HaveOccurred(), "failed creating namespace %s in KCP", infra.KCP().Namespace())
+	Expect(infra.KCP().GivenNamespaceExists(testinfradsl.DefaultKcpNamespace)).
+		NotTo(HaveOccurred(), "failed creating namespace %s in KCP", infra.KCP().Namespace())
 	Expect(infra.SKR().GivenNamespaceExists(infra.SKR().Namespace())).
+		NotTo(HaveOccurred(), "failed creating namespace %s in SKR", infra.SKR().Namespace())
+	Expect(infra.SKR().GivenNamespaceExists(testinfradsl.DefaultSkrNamespace)).
 		NotTo(HaveOccurred(), "failed creating namespace %s in SKR", infra.SKR().Namespace())
 	Expect(infra.Garden().GivenNamespaceExists(infra.Garden().Namespace())).
 		NotTo(HaveOccurred(), "failed creating namespace %s in Garden", infra.Garden().Namespace())

--- a/pkg/skr/awsnfsvolume/reconciler.go
+++ b/pkg/skr/awsnfsvolume/reconciler.go
@@ -5,6 +5,7 @@ import (
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/kyma-project/cloud-manager/pkg/feature"
+	"github.com/kyma-project/cloud-manager/pkg/skr/common/defaultiprange"
 	skrruntime "github.com/kyma-project/cloud-manager/pkg/skr/runtime/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -42,8 +43,9 @@ func (r *reconciler) newAction() composed.Action {
 		"crAwsNfsVolumeMain",
 		feature.LoadFeatureContextFromObj(&cloudresourcesv1beta1.AwsNfsVolume{}),
 		composed.LoadObj,
-		loadSkrIpRange,
-		waitIpRangeReady,
+
+		defaultiprange.New(),
+
 		loadVolume,
 		addFinalizer,
 		updateId,

--- a/pkg/skr/awsnfsvolume/state.go
+++ b/pkg/skr/awsnfsvolume/state.go
@@ -4,6 +4,7 @@ import (
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/skr/common/defaultiprange"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -47,4 +48,16 @@ func (f *stateFactory) NewState(req ctrl.Request) *State {
 
 func (s *State) ObjAsAwsNfsVolume() *cloudresourcesv1beta1.AwsNfsVolume {
 	return s.Obj().(*cloudresourcesv1beta1.AwsNfsVolume)
+}
+
+func (s *State) GetSkrIpRange() *cloudresourcesv1beta1.IpRange {
+	return s.SkrIpRange
+}
+
+func (s *State) SetSkrIpRange(skrIpRange *cloudresourcesv1beta1.IpRange) {
+	s.SkrIpRange = skrIpRange
+}
+
+func (s *State) ObjAsObjWithIpRangeRef() defaultiprange.ObjWithIpRangeRef {
+	return s.ObjAsAwsNfsVolume()
 }

--- a/pkg/skr/common/defaultiprange/checkIfIpRangeIsSpecified.go
+++ b/pkg/skr/common/defaultiprange/checkIfIpRangeIsSpecified.go
@@ -1,0 +1,40 @@
+package defaultiprange
+
+import (
+	"context"
+	"fmt"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/feature"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func checkIfIpRangeIsSpecified(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(State)
+
+	if feature.IpRangeAutomaticCidrAllocation.Value(ctx) {
+		return nil, nil
+	}
+
+	if len(state.ObjAsObjWithIpRangeRef().GetIpRangeRef().Name) > 0 {
+		return nil, nil
+	}
+
+	state.ObjAsObjWithIpRangeRef().SetState(cloudresourcesv1beta1.StateError)
+	var sb *composed.UpdateStatusBuilder
+	if _, ok := state.ObjAsObjWithIpRangeRef().(composed.ObjWithCloneForPatchStatus); ok {
+		sb = composed.PatchStatus(state.ObjAsObjWithIpRangeRef())
+	} else {
+		sb = composed.UpdateStatus(state.ObjAsObjWithIpRangeRef())
+	}
+	return sb.
+		SetExclusiveConditions(metav1.Condition{
+			Type:    cloudresourcesv1beta1.ConditionTypeError,
+			Status:  metav1.ConditionTrue,
+			Reason:  cloudresourcesv1beta1.ConditionReasonIpRangeNotFound,
+			Message: "IpRangeRef is required",
+		}).
+		SuccessLogMsg(fmt.Sprintf("Forgetting SKR %T with empty IpRangeRef when IpRangeAutomaticCidrAllocation is disabled", state.ObjAsObjWithIpRangeRef())).
+		ErrorLogMessage(fmt.Sprintf("Error patching SKR %T status with error for empty IpRangeRef when IpRangeAutomaticCidrAllocation is disabled", state.ObjAsObjWithIpRangeRef())).
+		Run(ctx, state)
+}

--- a/pkg/skr/common/defaultiprange/createDefaultSkrIpRange.go
+++ b/pkg/skr/common/defaultiprange/createDefaultSkrIpRange.go
@@ -1,0 +1,46 @@
+package defaultiprange
+
+import (
+	"context"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func createDefaultSkrIpRange(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	if composed.MarkedForDeletionPredicate(ctx, state) {
+		return nil, nil
+	}
+
+	if state.GetSkrIpRange() != nil {
+		return nil, nil
+	}
+
+	skrIpRange := &cloudresourcesv1beta1.IpRange{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "kyma-system",
+			Name:      "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "default-iprange",
+				"app.kubernetes.io/instance":   "default",
+				"app.kubernetes.io/version":    "1.0.0",
+				"app.kubernetes.io/component":  "cloud-manager",
+				"app.kubernetes.io/part-of":    "kyma",
+				"app.kubernetes.io/managed-by": "cloud-manager",
+			},
+		},
+	}
+
+	err := state.Cluster().K8sClient().Create(ctx, skrIpRange)
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error creating default SKR IpRange", composed.StopWithRequeue, ctx)
+	}
+
+	logger.Info("Created default SKR IpRange")
+	state.SetSkrIpRange(skrIpRange)
+
+	return nil, nil
+}

--- a/pkg/skr/common/defaultiprange/findDefaultSkrIpRange.go
+++ b/pkg/skr/common/defaultiprange/findDefaultSkrIpRange.go
@@ -1,0 +1,36 @@
+package defaultiprange
+
+import (
+	"context"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func findDefaultSkrIpRange(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	if state.GetSkrIpRange() != nil {
+		return nil, nil
+	}
+
+	skrIpRange := &cloudresourcesv1beta1.IpRange{}
+	err := state.Cluster().K8sClient().Get(ctx, types.NamespacedName{
+		Namespace: "kyma-system",
+		Name:      "default",
+	}, skrIpRange)
+	if apierrors.IsNotFound(err) {
+		logger.Info("Default SKR IpRange does not exist")
+		return nil, nil
+	}
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error getting default SKR IpRange", composed.StopWithRequeue, ctx)
+	}
+
+	logger.Info("Loaded default SKR IpRange")
+	state.SetSkrIpRange(skrIpRange)
+
+	return nil, nil
+}

--- a/pkg/skr/common/defaultiprange/loadSpecifiedIpRange.go
+++ b/pkg/skr/common/defaultiprange/loadSpecifiedIpRange.go
@@ -1,0 +1,44 @@
+package defaultiprange
+
+import (
+	"context"
+	"fmt"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func loadSpecifiedIpRange(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	ipRangeRef := state.ObjAsObjWithIpRangeRef().GetIpRangeRef()
+	if len(ipRangeRef.Name) == 0 {
+		return nil, nil
+	}
+
+	skrIpRange := &cloudresourcesv1beta1.IpRange{}
+	err := state.Cluster().K8sClient().Get(ctx, ipRangeRef.ObjKey(), skrIpRange)
+	if apierrors.IsNotFound(err) {
+		logger.Info("Specified SKR IpRange does not exist")
+		state.ObjAsObjWithIpRangeRef().SetState(cloudresourcesv1beta1.StateError)
+		return composed.PatchStatus(state.ObjAsObjWithIpRangeRef()).
+			SetExclusiveConditions(metav1.Condition{
+				Type:    cloudresourcesv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  cloudresourcesv1beta1.ConditionReasonIpRangeNotFound,
+				Message: fmt.Sprintf("Specified IpRange %s does not exist", ipRangeRef.ObjKey()),
+			}).
+			SuccessLogMsg(fmt.Sprintf("Forgetting SKR %T after specified IpRange does not exist", state.Obj())).
+			ErrorLogMessage(fmt.Sprintf("Error patching SKR %T after specified IpRange does not exist", state.Obj())).
+			Run(ctx, state)
+	}
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error loading specified SKR IpRange", composed.StopWithRequeue, ctx)
+	}
+
+	state.SetSkrIpRange(skrIpRange)
+
+	return nil, nil
+}

--- a/pkg/skr/common/defaultiprange/new.go
+++ b/pkg/skr/common/defaultiprange/new.go
@@ -1,0 +1,51 @@
+package defaultiprange
+
+import (
+	"context"
+	"fmt"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+)
+
+// New returns a composed.Action that implements the following flow:
+// * load IpRange specified in the reconciled object
+// * if no IpRange found, find default SKR IpRange kyma-system/default
+// * if no IpRange found, create default SKR IpRange kyma-system/default with empty cidr
+// * requeue until found or created IpRange has Ready condition
+// The provided state MUST implement State interface and object in the state
+// MUST implement ObjWithIpRangeRef.
+// The flow following this action can relay that the state will have non nil SKR IpRange
+// instance with Ready condition, unless object is marked for deletion and
+// default IpRange has to be created - then the state's SKR IpRange will be nil. In other words,
+// this action will not create default SKR IpRange if object is marked for deletion.
+func New() composed.Action {
+	return func(ctx context.Context, st composed.State) (error, context.Context) {
+		state, ok := st.(State)
+		if !ok {
+			return composed.LogErrorAndReturn(
+				fmt.Errorf("state %T provided to defaultiprange flow does not implement defaultiprange.State", st),
+				"Logical error",
+				composed.StopAndForget,
+				ctx,
+			)
+		}
+
+		_, ok = state.Obj().(ObjWithIpRangeRef)
+		if !ok {
+			return composed.LogErrorAndReturn(
+				fmt.Errorf("object %T provided to defaultiprange flow does not implement defaultiprange.ObjWithIpRangeRef", state.Obj()),
+				"Logical error",
+				composed.StopAndForget,
+				ctx,
+			)
+		}
+
+		return composed.ComposeActions(
+			"defaultiprange",
+			checkIfIpRangeIsSpecified,
+			loadSpecifiedIpRange,
+			findDefaultSkrIpRange,
+			createDefaultSkrIpRange,
+			waitIpRangeReady,
+		)(ctx, state)
+	}
+}

--- a/pkg/skr/common/defaultiprange/state.go
+++ b/pkg/skr/common/defaultiprange/state.go
@@ -1,0 +1,18 @@
+package defaultiprange
+
+import (
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+)
+
+type ObjWithIpRangeRef interface {
+	composed.ObjWithConditionsAndState
+	GetIpRangeRef() cloudresourcesv1beta1.IpRangeRef
+}
+
+type State interface {
+	composed.State
+	GetSkrIpRange() *cloudresourcesv1beta1.IpRange
+	SetSkrIpRange(skrIpRange *cloudresourcesv1beta1.IpRange)
+	ObjAsObjWithIpRangeRef() ObjWithIpRangeRef
+}

--- a/pkg/skr/common/defaultiprange/waitIpRangeReady.go
+++ b/pkg/skr/common/defaultiprange/waitIpRangeReady.go
@@ -1,0 +1,30 @@
+package defaultiprange
+
+import (
+	"context"
+	"fmt"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+)
+
+func waitIpRangeReady(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(State)
+
+	if composed.MarkedForDeletionPredicate(ctx, state) {
+		return nil, nil
+	}
+
+	isReady := meta.IsStatusConditionTrue(state.GetSkrIpRange().Status.Conditions, cloudresourcesv1beta1.ConditionTypeReady)
+	if isReady {
+		return nil, nil
+	}
+
+	logger := composed.LoggerFromCtx(ctx)
+	logger.
+		WithValues("IpRange", fmt.Sprintf("%s/%s", state.GetSkrIpRange().Namespace, state.GetSkrIpRange().Name)).
+		Info("IpRange is not ready, requeue delayed")
+
+	return composed.StopWithRequeueDelay(util.Timing.T1000ms()), nil
+}

--- a/pkg/testinfra/dsl/awsNfsVolume.go
+++ b/pkg/testinfra/dsl/awsNfsVolume.go
@@ -117,10 +117,7 @@ func CreateAwsNfsVolume(ctx context.Context, clnt client.Client, obj *cloudresou
 	if obj.Name == "" {
 		return errors.New("the SKR AwsNfsVolume must have name set")
 	}
-	if obj.Spec.IpRange.Name == "" {
-		return errors.New("the SKR AwsNfsVolume must have spec.iprange.name set")
-	}
-	if obj.Spec.IpRange.Namespace == "" {
+	if obj.Spec.IpRange.Name != "" && obj.Spec.IpRange.Namespace == "" {
 		obj.Spec.IpRange.Namespace = DefaultSkrNamespace
 	}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- set `spec.iprangeref` as optional in AwsNfsVolume
- added `skr/common/defaultiprange` package that implements the feature 
- modified `AwsNfsVolume` flow to use new `defaultiprange` package
- modified `testinfra/dsl/CreateAwsNfsVolume` not to force `spec.iprangeref`
- added test scenarios for empty iprangeref

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
