### PR TITLE
feat(AzureVpcPeering): adding remote network tag challenge

### DIFF
--- a/api/cloud-control/v1beta1/vpcpeering_types.go
+++ b/api/cloud-control/v1beta1/vpcpeering_types.go
@@ -23,6 +23,7 @@ import (
 const (
 	ReasonFailedCreatingVpcPeeringConnection  = "FailedCreatingVpcPeeringConnection"
 	ReasonFailedAcceptingVpcPeeringConnection = "FailedAcceptingVpcPeeringConnection"
+	ReasonFailedLoadingRemoteVpcNetwork       = "FailedLoadingRemoteVpcNetwork"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/internal/controller/cloud-control/vpcpeering_azure_test.go
+++ b/internal/controller/cloud-control/vpcpeering_azure_test.go
@@ -40,6 +40,8 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 		subscriptionId := scope.Spec.Scope.Azure.SubscriptionId
 		resourceGroupName := virtualNetworkName //TODO resource group name is the same as VPC name
 
+		infra.AzureMock().AddNetwork(remoteSubscription, remoteResourceGroup, remoteVnetName, map[string]*string{"shoot-name": pointer.String(kymaName)})
+
 		obj := &cloudcontrolv1beta1.VpcPeering{}
 
 		By("When KCP VpcPeering is created", func() {
@@ -63,8 +65,9 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 				Should(Succeed())
 		})
 
-		infra.AzureMock().SetSubscription(subscriptionId)
-		peering, _ := infra.AzureMock().Get(infra.Ctx(), resourceGroupName, virtualNetworkName, vpcpeeringName)
+		c, _ := infra.AzureMock().VpcPeeringSkrProvider()(infra.Ctx(), "", "", subscriptionId, "")
+
+		peering, _ := c.GetPeering(infra.Ctx(), resourceGroupName, virtualNetworkName, vpcpeeringName)
 
 		By("And Then found VirtualNetworkPeering has ID equal to Status.Id", func() {
 			Expect(pointer.StringDeref(peering.ID, "xxx")).To(Equal(obj.Status.Id))
@@ -74,8 +77,9 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 			remoteRefNamespace,
 			remoteRefName)
 
-		infra.AzureMock().SetSubscription(remoteSubscription)
-		remotePeering, _ := infra.AzureMock().Get(infra.Ctx(), remoteResourceGroup, remoteVnetName, virtualNetworkPeeringName)
+		r, _ := infra.AzureMock().VpcPeeringSkrProvider()(infra.Ctx(), "", "", remoteSubscription, "")
+
+		remotePeering, _ := r.GetPeering(infra.Ctx(), remoteResourceGroup, remoteVnetName, virtualNetworkPeeringName)
 
 		By("And Then found remote VirtualNetworkPeering has ID equal to Status.RemoteId", func() {
 			Expect(pointer.StringDeref(remotePeering.ID, "xxx")).To(Equal(obj.Status.RemoteId))

--- a/pkg/kcp/provider/azure/mock/networkStore.go
+++ b/pkg/kcp/provider/azure/mock/networkStore.go
@@ -1,0 +1,20 @@
+package mock
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
+	"sync"
+)
+
+type VpcNetworkConfig interface {
+	AddNetwork(subscription, resourceGroup, virtualNetworkName string, tags map[string]*string)
+}
+
+type networkEntry struct {
+	resourceGroup string
+	network       armnetwork.VirtualNetwork
+}
+
+type networkStore struct {
+	m     sync.Mutex
+	items []*networkEntry
+}

--- a/pkg/kcp/provider/azure/mock/server.go
+++ b/pkg/kcp/provider/azure/mock/server.go
@@ -2,25 +2,55 @@ package mock
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
 	provider "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/client"
 	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/vpcpeering/client"
+	"k8s.io/utils/pointer"
 )
 
 var _ Server = &server{}
 
 func New() Server {
 	return &server{
-		vpcPeeringStore: &vpcPeeringStore{},
+		stores: map[string]*storeSubscriptionContext{},
 	}
 }
 
 type server struct {
-	*vpcPeeringStore
+	stores map[string]*storeSubscriptionContext
 }
 
 func (s *server) VpcPeeringSkrProvider() provider.SkrClientProvider[client.Client] {
-	return func(ctx context.Context, clientId, clientSecret, subscriptionId, tenantId string) (client.Client, error) {
-		s.subscriptionId = subscriptionId
-		return s, nil
+	return func(ctx context.Context, clientId, clientSecret, subscription, tenant string) (client.Client, error) {
+
+		return s.getStoreSubscriptionContext(subscription), nil
 	}
+}
+
+func (s *server) AddNetwork(subscription, resourceGroup, virtualNetworkName string, tags map[string]*string) {
+
+	entry := &networkEntry{
+		resourceGroup: resourceGroup,
+		network: armnetwork.VirtualNetwork{
+			Name: pointer.String(virtualNetworkName),
+			Tags: tags,
+		},
+	}
+
+	store := s.getStoreSubscriptionContext(subscription)
+
+	store.networkStore.items = append(store.networkStore.items, entry)
+}
+
+func (s *server) getStoreSubscriptionContext(subscription string) *storeSubscriptionContext {
+
+	if s.stores[subscription] == nil {
+		s.stores[subscription] = &storeSubscriptionContext{
+			peeringStore: &peeringStore{},
+			networkStore: &networkStore{},
+			subscription: subscription,
+		}
+	}
+
+	return s.stores[subscription]
 }

--- a/pkg/kcp/provider/azure/mock/storeSubscriptionContext.go
+++ b/pkg/kcp/provider/azure/mock/storeSubscriptionContext.go
@@ -1,0 +1,77 @@
+package mock
+
+import (
+	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
+	"github.com/elliotchance/pie/v2"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/util"
+	"k8s.io/utils/pointer"
+)
+
+type storeSubscriptionContext struct {
+	peeringStore *peeringStore
+	networkStore *networkStore
+	subscription string
+}
+
+func (c *storeSubscriptionContext) CreatePeering(ctx context.Context, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, remoteVnetId string, allowVnetAccess bool) (*armnetwork.VirtualNetworkPeering, error) {
+	if isContextCanceled(ctx) {
+		return nil, context.Canceled
+	}
+	c.peeringStore.m.Lock()
+	defer c.peeringStore.m.Unlock()
+
+	id := util.VirtualNetworkPeeringResourceId(c.subscription, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName)
+
+	item := &peeringEntry{
+		resourceGroupName:  resourceGroupName,
+		virtualNetworkName: virtualNetworkName,
+		peering: armnetwork.VirtualNetworkPeering{
+			ID:   pointer.String(id),
+			Name: pointer.String(virtualNetworkPeeringName),
+			Properties: &armnetwork.VirtualNetworkPeeringPropertiesFormat{
+				AllowForwardedTraffic:     pointer.Bool(true),
+				AllowGatewayTransit:       pointer.Bool(false),
+				AllowVirtualNetworkAccess: pointer.Bool(allowVnetAccess),
+				UseRemoteGateways:         pointer.Bool(false),
+				RemoteVirtualNetwork: &armnetwork.SubResource{
+					ID: pointer.String(remoteVnetId),
+				},
+			},
+		},
+	}
+
+	c.peeringStore.items = append(c.peeringStore.items, item)
+
+	return &item.peering, nil
+}
+
+func (c *storeSubscriptionContext) GetNetwork(ctx context.Context, resourceGroupName, virtualNetworkName string) (*armnetwork.VirtualNetwork, error) {
+	for _, x := range c.networkStore.items {
+		if virtualNetworkName == pointer.StringDeref(x.network.Name, "") &&
+			resourceGroupName == x.resourceGroup {
+			return &x.network, nil
+		}
+	}
+	return nil, nil
+}
+
+func (c *storeSubscriptionContext) ListPeerings(ctx context.Context, resourceGroup string, virtualNetworkName string) ([]*armnetwork.VirtualNetworkPeering, error) {
+	items := pie.Filter(c.peeringStore.items, func(e *peeringEntry) bool {
+		return e.resourceGroupName == resourceGroup && e.virtualNetworkName == virtualNetworkName
+	})
+	return pie.Map(items, func(e *peeringEntry) *armnetwork.VirtualNetworkPeering {
+		return &e.peering
+	}), nil
+}
+
+func (c *storeSubscriptionContext) GetPeering(ctx context.Context, resourceGroup, virtualNetworkName, virtualNetworkPeeringName string) (*armnetwork.VirtualNetworkPeering, error) {
+	for _, x := range c.peeringStore.items {
+		if virtualNetworkPeeringName == pointer.StringDeref(x.peering.Name, "") &&
+			resourceGroup == x.resourceGroupName &&
+			virtualNetworkName == x.virtualNetworkName {
+			return &x.peering, nil
+		}
+	}
+	return nil, nil
+}

--- a/pkg/kcp/provider/azure/mock/type.go
+++ b/pkg/kcp/provider/azure/mock/type.go
@@ -5,22 +5,12 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/vpcpeering/client"
 )
 
-type VpcPeeringClient interface {
-	client.Client
-}
-
-type Clients interface {
-	VpcPeeringClient
-}
-
 type Providers interface {
 	VpcPeeringSkrProvider() provider.SkrClientProvider[client.Client]
 }
 
 type Server interface {
-	Clients
-
 	Providers
 
-	VpcPeeringConfig
+	VpcNetworkConfig
 }

--- a/pkg/kcp/provider/azure/mock/vpcPeeringStore.go
+++ b/pkg/kcp/provider/azure/mock/vpcPeeringStore.go
@@ -1,94 +1,17 @@
 package mock
 
 import (
-	"context"
-	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
-	"github.com/elliotchance/pie/v2"
-	"k8s.io/utils/pointer"
 	"sync"
 )
 
-type VpcPeeringConfig interface {
-	SetSubscription(subscriptionId string)
-}
-
-type vpcPeeringEntry struct {
-	subscription       string
+type peeringEntry struct {
 	resourceGroupName  string
 	virtualNetworkName string
 	peering            armnetwork.VirtualNetworkPeering
 }
-type vpcPeeringStore struct {
-	m              sync.Mutex
-	items          []*vpcPeeringEntry
-	subscriptionId string
-}
 
-func (s *vpcPeeringStore) SetSubscription(subscriptionId string) {
-	s.subscriptionId = subscriptionId
-}
-
-func (s *vpcPeeringStore) BeginCreateOrUpdate(
-	ctx context.Context,
-	resourceGroupName,
-	virtualNetworkName,
-	virtualNetworkPeeringName,
-	remoteVnetId string,
-	allowVnetAccess bool) (*armnetwork.VirtualNetworkPeering, error) {
-	if isContextCanceled(ctx) {
-		return nil, context.Canceled
-	}
-	s.m.Lock()
-	defer s.m.Unlock()
-
-	id := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/virtualNetworkPeerings/%s",
-		s.subscriptionId,
-		resourceGroupName,
-		virtualNetworkName,
-		virtualNetworkPeeringName)
-
-	item := &vpcPeeringEntry{
-		subscription:       s.subscriptionId,
-		resourceGroupName:  resourceGroupName,
-		virtualNetworkName: virtualNetworkName,
-		peering: armnetwork.VirtualNetworkPeering{
-			ID:   pointer.String(id),
-			Name: pointer.String(virtualNetworkPeeringName),
-			Properties: &armnetwork.VirtualNetworkPeeringPropertiesFormat{
-				AllowForwardedTraffic:     pointer.Bool(true),
-				AllowGatewayTransit:       pointer.Bool(false),
-				AllowVirtualNetworkAccess: pointer.Bool(allowVnetAccess),
-				UseRemoteGateways:         pointer.Bool(false),
-				RemoteVirtualNetwork: &armnetwork.SubResource{
-					ID: pointer.String(remoteVnetId),
-				},
-			},
-		},
-	}
-
-	s.items = append(s.items, item)
-
-	return &item.peering, nil
-}
-
-func (s *vpcPeeringStore) List(ctx context.Context, resourceGroupName string, virtualNetworkName string) ([]*armnetwork.VirtualNetworkPeering, error) {
-	items := pie.Filter(s.items, func(e *vpcPeeringEntry) bool {
-		return e.resourceGroupName == resourceGroupName && e.virtualNetworkName == virtualNetworkName
-	})
-	return pie.Map(items, func(e *vpcPeeringEntry) *armnetwork.VirtualNetworkPeering {
-		return &e.peering
-	}), nil
-}
-
-func (s *vpcPeeringStore) Get(ctx context.Context, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName string) (*armnetwork.VirtualNetworkPeering, error) {
-	for _, x := range s.items {
-		if s.subscriptionId == x.subscription &&
-			virtualNetworkPeeringName == pointer.StringDeref(x.peering.Name, "") &&
-			resourceGroupName == x.resourceGroupName &&
-			virtualNetworkName == x.virtualNetworkName {
-			return &x.peering, nil
-		}
-	}
-	return nil, nil
+type peeringStore struct {
+	m     sync.Mutex
+	items []*peeringEntry
 }

--- a/pkg/kcp/provider/azure/vpcpeering/createRemoteVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/createRemoteVpcPeering.go
@@ -52,7 +52,7 @@ func createRemoteVpcPeering(ctx context.Context, st composed.State) (error, cont
 		state.Scope().Spec.Scope.Azure.VpcNetwork, // ResourceGroup name is the same as VPC network name.
 		state.Scope().Spec.Scope.Azure.VpcNetwork)
 
-	peering, err := c.BeginCreateOrUpdate(ctx,
+	peering, err := c.CreatePeering(ctx,
 		resourceGroupName,
 		virtualNetworkName,
 		virtualNetworkPeeringName,

--- a/pkg/kcp/provider/azure/vpcpeering/createVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/createVpcPeering.go
@@ -22,7 +22,7 @@ func createVpcPeering(ctx context.Context, st composed.State) (error, context.Co
 	resourceGroupName := state.Scope().Spec.Scope.Azure.VpcNetwork // TBD resourceGroup name have the same name as VPC
 	virtualNetworkPeeringName := obj.Name
 
-	peering, err := state.client.BeginCreateOrUpdate(ctx,
+	peering, err := state.client.CreatePeering(ctx,
 		resourceGroupName,
 		state.Scope().Spec.Scope.Azure.VpcNetwork,
 		virtualNetworkPeeringName,

--- a/pkg/kcp/provider/azure/vpcpeering/loadRemoteVpc.go
+++ b/pkg/kcp/provider/azure/vpcpeering/loadRemoteVpc.go
@@ -1,0 +1,99 @@
+package vpcpeering
+
+import (
+	"context"
+	"fmt"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	azureconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/config"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"time"
+)
+
+func loadRemoteVpc(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+	obj := state.ObjAsVpcPeering()
+
+	if state.remotePeering != nil {
+		return nil, nil
+	}
+
+	clientId := azureconfig.AzureConfig.ClientId
+	clientSecret := azureconfig.AzureConfig.ClientSecret
+	tenantId := state.tenantId
+
+	remote, err := util.ParseResourceID(obj.Spec.VpcPeering.Azure.RemoteVnet)
+
+	if err != nil {
+		logger.Error(err, "Error parsing remoteVnet")
+		return err, ctx
+	}
+
+	subscriptionId := remote.Subscription
+
+	c, err := state.provider(ctx, clientId, clientSecret, subscriptionId, tenantId)
+
+	if err != nil {
+		return err, ctx
+	}
+
+	network, err := c.GetNetwork(ctx, remote.ResourceGroup, remote.ResourceName)
+
+	if err != nil {
+		logger.Error(err, "Error loading remote network")
+
+		return composed.UpdateStatus(obj).
+			SetCondition(metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  "True",
+				Reason:  cloudcontrolv1beta1.ReasonFailedLoadingRemoteVpcNetwork,
+				Message: fmt.Sprintf("Failed loading VpcNetwork %s", err),
+			}).
+			ErrorLogMessage("Error updating VpcPeering status due to failed loading of remote vpc network").
+			FailedError(composed.StopWithRequeue).
+			SuccessError(composed.StopWithRequeueDelay(time.Minute)).
+			Run(ctx, state)
+	}
+
+	// If VpcNetwork is not found user can not recover from this error without updating the resource so, we are doing
+	// stop and forget.
+	if network == nil {
+		logger.Error(err, "Remote VPC Network not found")
+
+		return composed.UpdateStatus(obj).
+			SetCondition(metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  "True",
+				Reason:  cloudcontrolv1beta1.ReasonFailedLoadingRemoteVpcNetwork,
+				Message: fmt.Sprintf("Failed loading VpcNetwork %s", err),
+			}).
+			ErrorLogMessage("Error updating VpcPeering status due to failed loading of remote vpc network").
+			FailedError(composed.StopWithRequeue).
+			SuccessError(composed.StopAndForget).
+			Run(ctx, state)
+	}
+
+	// If VpcNetwork is found but tags don't match user can recover by adding tag to remote VPC network so, we are
+	//adding stop with requeue delay of one minute.
+	if pointer.StringDeref(network.Tags["shoot-name"], "") != state.Scope().Spec.ShootName {
+
+		logger.Error(err, "Loaded remote VPC Network have no matching tags")
+
+		return composed.UpdateStatus(obj).
+			SetCondition(metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  "True",
+				Reason:  cloudcontrolv1beta1.ReasonFailedLoadingRemoteVpcNetwork,
+				Message: fmt.Sprintf("Loaded remote Vpc network has no matching tags"),
+			}).
+			ErrorLogMessage("Error updating VpcPeering status due to remote vpc network tag mismatch").
+			FailedError(composed.StopWithRequeue).
+			SuccessError(composed.StopWithRequeueDelay(time.Minute)).
+			Run(ctx, state)
+	}
+
+	return nil, nil
+}

--- a/pkg/kcp/provider/azure/vpcpeering/loadRemoteVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/loadRemoteVpcPeering.go
@@ -32,7 +32,7 @@ func loadRemoteVpcPeering(ctx context.Context, st composed.State) (error, contex
 
 	c, err := state.provider(ctx, clientId, clientSecret, subscriptionId, tenantId)
 
-	peering, err := c.Get(ctx, resource.ResourceGroup, resource.ResourceName, resource.SubResourceName)
+	peering, err := c.GetPeering(ctx, resource.ResourceGroup, resource.ResourceName, resource.SubResourceName)
 
 	if err != nil {
 		return azuremeta.LogErrorAndReturn(err, "Error loading remote VPC Peering", nil)

--- a/pkg/kcp/provider/azure/vpcpeering/loadVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/loadVpcPeering.go
@@ -23,7 +23,7 @@ func loadVpcPeering(ctx context.Context, st composed.State) (error, context.Cont
 		return azuremeta.LogErrorAndReturn(err, "Error parsing virtual network peering ID", ctx)
 	}
 
-	peering, err := state.client.Get(ctx, resource.ResourceGroup, resource.ResourceName, resource.SubResourceName)
+	peering, err := state.client.GetPeering(ctx, resource.ResourceGroup, resource.ResourceName, resource.SubResourceName)
 
 	if err != nil {
 		return azuremeta.LogErrorAndReturn(err, "Error loading VPC Peering", ctx)

--- a/pkg/kcp/provider/azure/vpcpeering/new.go
+++ b/pkg/kcp/provider/azure/vpcpeering/new.go
@@ -27,6 +27,7 @@ func New(stateFactory StateFactory) composed.Action {
 					addFinalizer,
 					loadVpcPeering,
 					loadRemoteVpcPeering,
+					loadRemoteVpc,
 					createVpcPeering,
 					createRemoteVpcPeering,
 					updateStatus,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- As part of the security enhancements remote network tag challenge has been added. In order to perform peering remote network must contain tag shoot-name with value matching the shoot where Kyma is installed. 