### PR TITLE
fix(GcpNfsVolume): ensure Error state is set if GcpNfsVolume specifie…

### DIFF
--- a/api/cloud-resources/v1beta1/gcpnfsvolume_types.go
+++ b/api/cloud-resources/v1beta1/gcpnfsvolume_types.go
@@ -48,14 +48,15 @@ const (
 
 // Additional error reasons
 const (
-	ConditionReasonCapacityInvalid         = "CapacityGbInvalid"
-	ConditionReasonIpRangeNotReady         = "IpRangeNotReady"
-	ConditionReasonFileShareNameInvalid    = "FileShareNameInvalid"
-	ConditionReasonTierInvalid             = "TierInvalid"
-	ConditionReasonPVNotReadyForDeletion   = "PVNotReadyForDeletion"
-	ConditionReasonPVNotReadyForNameChange = "PVNotReadyForNameChange"
-	ConditionReasonPVNameInvalid           = "PVNameInvalid"
-	ConditionReasonPVCNameInvalid          = "PVCNameInvalid"
+	ConditionReasonCapacityInvalid           = "CapacityGbInvalid"
+	ConditionReasonIpRangeNotReady           = "IpRangeNotReady"
+	ConditionReasonFileShareNameInvalid      = "FileShareNameInvalid"
+	ConditionReasonTierInvalid               = "TierInvalid"
+	ConditionReasonPVNotReadyForDeletion     = "PVNotReadyForDeletion"
+	ConditionReasonPVNotReadyForNameChange   = "PVNotReadyForNameChange"
+	ConditionReasonPVNameInvalid             = "PVNameInvalid"
+	ConditionReasonPVCNameInvalid            = "PVCNameInvalid"
+	ConditionPVCBelongsToAnotherGcpNfsVolume = "PVCNameAlreadyUsed"
 )
 
 // GcpNfsVolumeSpec defines the desired state of GcpNfsVolume

--- a/internal/controller/cloud-resources/gcpnfsvolume_test.go
+++ b/internal/controller/cloud-resources/gcpnfsvolume_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Feature: SKR GcpNfsVolume", func() {
 
 		pvc := &corev1.PersistentVolumeClaim{}
 		pvcSpec := &cloudresourcesv1beta1.GcpNfsVolumePvcSpec{
-			Name: "gcp-nfs-pvc",
+			Name: "gcp-nfs-pvc-1",
 			Labels: map[string]string{
 				"foo": "bar",
 			},
@@ -308,7 +308,7 @@ var _ = Describe("Feature: SKR GcpNfsVolume", func() {
 
 		pvc := &corev1.PersistentVolumeClaim{}
 		prevPvcSpec := &cloudresourcesv1beta1.GcpNfsVolumePvcSpec{
-			Name: "gcp-nfs-pvc",
+			Name: "gcp-nfs-pvc-2",
 			Labels: map[string]string{
 				"foo": "bar",
 			},
@@ -317,7 +317,7 @@ var _ = Describe("Feature: SKR GcpNfsVolume", func() {
 			},
 		}
 		pvcSpec := &cloudresourcesv1beta1.GcpNfsVolumePvcSpec{
-			Name: "gcp-nfs-pvc",
+			Name: "gcp-nfs-pvc-2",
 			Labels: map[string]string{
 				"foo":  "bar-changed",
 				"foo2": "bar2",

--- a/pkg/skr/gcpnfsvolume/loadPersistentVolumeClaim.go
+++ b/pkg/skr/gcpnfsvolume/loadPersistentVolumeClaim.go
@@ -2,9 +2,12 @@ package gcpnfsvolume
 
 import (
 	"context"
+	"fmt"
 
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -12,18 +15,40 @@ import (
 func loadPersistentVolumeClaim(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
 
+	gcpNfsVolume := state.ObjAsGcpNfsVolume()
+
 	pvc := &corev1.PersistentVolumeClaim{}
 	err := state.Cluster().K8sClient().Get(ctx, types.NamespacedName{
 		Namespace: state.Obj().GetNamespace(),
-		Name:      getVolumeClaimName(state.ObjAsGcpNfsVolume()),
+		Name:      getVolumeClaimName(gcpNfsVolume),
 	}, pvc)
+
 	if client.IgnoreNotFound(err) != nil {
 		return composed.LogErrorAndReturn(err, "Error getting PersistentVolumeClaim by getVolumeName()", composed.StopWithRequeue, ctx)
 	}
 
-	if err == nil {
-		state.PVC = pvc
+	if err != nil { // PVC not-found
+		return nil, nil
 	}
+
+	pvcLabels := pvc.Labels
+	parentGcpNfsVolumeName := pvcLabels[cloudresourcesv1beta1.LabelNfsVolName]
+
+	if parentGcpNfsVolumeName != gcpNfsVolume.Name {
+		errorMsg := fmt.Sprintf("Loaded PVC(%s/%s) belongs to another GcpNfsVolume (%s)", pvc.Namespace, pvc.Name, parentGcpNfsVolumeName)
+		return composed.UpdateStatus(state.ObjAsGcpNfsVolume()).
+			SetCondition(metav1.Condition{
+				Type:    cloudresourcesv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  cloudresourcesv1beta1.ConditionPVCBelongsToAnotherGcpNfsVolume,
+				Message: errorMsg,
+			}).
+			RemoveConditions(cloudresourcesv1beta1.ConditionTypeReady).
+			ErrorLogMessage(errorMsg).
+			Run(ctx, state)
+	}
+
+	state.PVC = pvc
 
 	return nil, nil
 }


### PR DESCRIPTION
…s PVC name that already exists

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- if GcpNfsVolume specifies a PVC name that already exists, an Error state will be set on said GcpNfsVolume

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
