### PR TITLE
feat (AzureVpcPeering): Handles object deletion

### DIFF
--- a/internal/controller/cloud-control/vpcpeering_azure_test.go
+++ b/internal/controller/cloud-control/vpcpeering_azure_test.go
@@ -2,6 +2,7 @@ package cloudcontrol
 
 import (
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/util"
 	scopePkg "github.com/kyma-project/cloud-manager/pkg/kcp/scope"
@@ -9,9 +10,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
+	"time"
 )
 
-var _ = Describe("Feature: KCP VpcPeering", func() {
+var _ = FDescribe("Feature: KCP VpcPeering", func() {
 
 	It("Scenario: KCP Azure VpcPeering is created", func() {
 		const (
@@ -93,6 +95,25 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 
 		By("And Then found remote VirtualNetworkPeering has ID equal to remote vpc peering id", func() {
 			Expect(pointer.StringDeref(remotePeering.ID, "xxx")).To(Equal(remotePeeringId))
+		})
+
+		// DELETE
+
+		By("When KCP VpcPeering is deleted", func() {
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), obj).
+				Should(Succeed(), "failed deleting VpcPeering")
+		})
+
+		By("Then VpcPeering does not exist", func() {
+			Eventually(IsDeleted, 5*time.Second).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), obj).
+				Should(Succeed(), "expected VpcPeering not to exist (be deleted), but it still exists")
+		})
+
+		By("And Then VirtualNetworkPeering is deleted", func() {
+			peering, _ = c.GetPeering(infra.Ctx(), resourceGroupName, virtualNetworkName, vpcpeeringName)
+			Expect(peering).To(Equal((*armnetwork.VirtualNetworkPeering)(nil)))
 		})
 
 	})

--- a/internal/controller/cloud-control/vpcpeering_azure_test.go
+++ b/internal/controller/cloud-control/vpcpeering_azure_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-var _ = FDescribe("Feature: KCP VpcPeering", func() {
+var _ = Describe("Feature: KCP VpcPeering", func() {
 
 	It("Scenario: KCP Azure VpcPeering is created", func() {
 		const (

--- a/pkg/kcp/provider/azure/mock/storeSubscriptionContext.go
+++ b/pkg/kcp/provider/azure/mock/storeSubscriptionContext.go
@@ -75,3 +75,13 @@ func (c *storeSubscriptionContext) GetPeering(ctx context.Context, resourceGroup
 	}
 	return nil, nil
 }
+
+func (c *storeSubscriptionContext) DeletePeering(ctx context.Context, resourceGroup, virtualNetworkName, virtualNetworkPeeringName string) error {
+	c.peeringStore.items = pie.Filter(c.peeringStore.items, func(x *peeringEntry) bool {
+		return !(x.resourceGroupName == resourceGroup &&
+			x.virtualNetworkName == virtualNetworkName &&
+			virtualNetworkPeeringName == pointer.StringDeref(x.peering.Name, ""))
+	})
+
+	return nil
+}

--- a/pkg/kcp/provider/azure/vpcpeering/client/client.go
+++ b/pkg/kcp/provider/azure/vpcpeering/client/client.go
@@ -19,6 +19,7 @@ type Client interface {
 	ListPeerings(ctx context.Context, resourceGroupName string, virtualNetworkName string) ([]*armnetwork.VirtualNetworkPeering, error)
 	GetPeering(ctx context.Context, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName string) (*armnetwork.VirtualNetworkPeering, error)
 	GetNetwork(ctx context.Context, resourceGroupName, virtualNetworkName string) (*armnetwork.VirtualNetwork, error)
+	DeletePeering(ctx context.Context, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName string) error
 }
 
 func NewClientProvider() azureclient.SkrClientProvider[Client] {
@@ -135,4 +136,20 @@ func (c *client) GetNetwork(ctx context.Context, resourceGroupName, virtualNetwo
 	}
 
 	return &response.VirtualNetwork, nil
+}
+
+func (c *client) DeletePeering(ctx context.Context, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName string) error {
+	pooler, err := c.peering.BeginDelete(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, nil)
+
+	if err != nil {
+		return err
+	}
+
+	_, err = pooler.PollUntilDone(ctx, nil)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/kcp/provider/azure/vpcpeering/createVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/createVpcPeering.go
@@ -2,9 +2,9 @@ package vpcpeering
 
 import (
 	"context"
-	"fmt"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	azuremeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"time"
@@ -33,12 +33,14 @@ func createVpcPeering(ctx context.Context, st composed.State) (error, context.Co
 	if err != nil {
 		logger.Error(err, "Error creating VPC Peering")
 
+		message := azuremeta.GetErrorMessage(err)
+
 		return composed.UpdateStatus(obj).
 			SetCondition(metav1.Condition{
 				Type:    cloudcontrolv1beta1.ConditionTypeError,
 				Status:  "True",
 				Reason:  cloudcontrolv1beta1.ReasonFailedCreatingVpcPeeringConnection,
-				Message: fmt.Sprintf("Failed creating VpcPeerings %s", err),
+				Message: message,
 			}).
 			ErrorLogMessage("Error updating VpcPeering status due to failed creating vpc peering connection").
 			FailedError(composed.StopWithRequeue).

--- a/pkg/kcp/provider/azure/vpcpeering/deleteVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/deleteVpcPeering.go
@@ -1,0 +1,38 @@
+package vpcpeering
+
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	azuremeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/meta"
+)
+
+func deleteVpcPeering(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+	obj := state.ObjAsVpcPeering()
+
+	lll := logger.WithValues("vpcPeeringName", obj.Name)
+
+	if len(obj.Status.Id) == 0 {
+		lll.Info("VpcPeering deleted before Azure peering is created")
+		return nil, nil
+	}
+
+	resourceGroupName := state.Scope().Spec.Scope.Azure.VpcNetwork
+
+	lll = lll.WithValues("vpcPeeringId", obj.Status.Id)
+	lll.Info("Deleting VPC Peering")
+
+	err := state.client.DeletePeering(
+		ctx,
+		resourceGroupName,
+		state.Scope().Spec.Scope.Azure.VpcNetwork,
+		obj.Name,
+	)
+
+	if err != nil {
+		return azuremeta.LogErrorAndReturn(err, "Error deleting vpc peering", composed.LoggerIntoCtx(ctx, lll))
+	}
+
+	return nil, nil
+}

--- a/pkg/kcp/provider/azure/vpcpeering/new.go
+++ b/pkg/kcp/provider/azure/vpcpeering/new.go
@@ -23,7 +23,8 @@ func New(stateFactory StateFactory) composed.Action {
 			composed.BuildSwitchAction(
 				"azureVpcPeering-switch",
 				// default action
-				composed.ComposeActions("azureVpcPeering-non-delete",
+				composed.ComposeActions(
+					"azureVpcPeering-non-delete",
 					addFinalizer,
 					loadVpcPeering,
 					loadRemoteVpcPeering,
@@ -32,7 +33,17 @@ func New(stateFactory StateFactory) composed.Action {
 					createVpcPeering,
 					createRemoteVpcPeering,
 					updateStatus,
-					composed.StopAndForgetAction),
+					composed.StopAndForgetAction,
+				),
+				composed.NewCase(
+					composed.MarkedForDeletionPredicate,
+					composed.ComposeActions(
+						"azureVpcPeering-delete",
+						removeReadyCondition,
+						deleteVpcPeering,
+						removeFinalizer,
+					),
+				),
 			), // switch
 			composed.StopAndForgetAction,
 		)(ctx, state)

--- a/pkg/kcp/provider/azure/vpcpeering/removeFinalizer.go
+++ b/pkg/kcp/provider/azure/vpcpeering/removeFinalizer.go
@@ -1,0 +1,27 @@
+package vpcpeering
+
+import (
+	"context"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func removeFinalizer(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	isUpdated := controllerutil.RemoveFinalizer(state.ObjAsVpcPeering(), cloudcontrolv1beta1.FinalizerName)
+	if !isUpdated {
+		return nil, nil
+	}
+
+	logger.Info("Removing finalizer")
+
+	err := state.UpdateObj(ctx)
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error updating KCP VpcPeering after finalizer removed", composed.StopWithRequeue, ctx)
+	}
+
+	return composed.StopAndForget, nil
+}

--- a/pkg/kcp/provider/azure/vpcpeering/removeReadyCondition.go
+++ b/pkg/kcp/provider/azure/vpcpeering/removeReadyCondition.go
@@ -1,0 +1,28 @@
+package vpcpeering
+
+import (
+	"context"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"k8s.io/apimachinery/pkg/api/meta"
+)
+
+func removeReadyCondition(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	readyCond := meta.FindStatusCondition(*state.ObjAsVpcPeering().Conditions(), cloudcontrolv1beta1.ConditionTypeReady)
+	if readyCond == nil {
+		return nil, nil
+	}
+
+	logger.Info("Removing Ready condition")
+
+	meta.RemoveStatusCondition(state.ObjAsVpcPeering().Conditions(), cloudcontrolv1beta1.ConditionTypeReady)
+	err := state.UpdateObjStatus(ctx)
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error updating KCP VpcPeering status after removing Ready condition", composed.StopWithRequeue, ctx)
+	}
+
+	return composed.StopWithRequeue, nil
+}

--- a/pkg/skr/azurevpcpeering/deleteKcpVpcPeering.go
+++ b/pkg/skr/azurevpcpeering/deleteKcpVpcPeering.go
@@ -1,0 +1,36 @@
+package azurevpcpeering
+
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+)
+
+func deleteKcpVpcPeering(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	if !composed.MarkedForDeletionPredicate(ctx, state) {
+		return nil, nil
+	}
+
+	if state.KcpVpcPeering == nil {
+		// SKR AzureVpcPeering is marked for deletion, but none found in KCP, probably already deleted
+		return nil, nil
+	}
+
+	if composed.IsMarkedForDeletion(state.KcpVpcPeering) {
+		return nil, nil
+	}
+
+	logger.Info("Deleting KCP VpcPeering")
+
+	err := state.KcpCluster.K8sClient().Delete(ctx, state.KcpVpcPeering)
+
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error creating KCP VpcPeering", composed.StopWithRequeue, ctx)
+	}
+
+	// give some time to cloud-control and cloud providers to delete it, and then run again
+	return composed.StopWithRequeueDelay(util.Timing.T10000ms()), nil
+}

--- a/pkg/skr/azurevpcpeering/loadKcpAzureVpcPeering.go
+++ b/pkg/skr/azurevpcpeering/loadKcpAzureVpcPeering.go
@@ -16,7 +16,7 @@ func loadKcpAzureVpcPeering(ctx context.Context, st composed.State) (error, cont
 	if state.ObjAsAzureVpcPeering().Status.Id == "" {
 		return composed.LogErrorAndReturn(
 			errors.New("missing SKR AzureVpcPeering state.id"),
-			"Logical error in loadKcpNfsInstance",
+			"Logical error in loadKcpAzureVpcPeering",
 			composed.StopAndForget,
 			ctx,
 		)

--- a/pkg/skr/azurevpcpeering/reconciler.go
+++ b/pkg/skr/azurevpcpeering/reconciler.go
@@ -46,6 +46,8 @@ func (r *reconciler) newAction() composed.Action {
 		updateId,
 		loadKcpAzureVpcPeering,
 		createKcpVpcPeering,
+		deleteKcpVpcPeering,
+		removeFinalizer,
 		updateStatus,
 		composed.StopAndForgetAction,
 	)

--- a/pkg/skr/azurevpcpeering/removeFinalizer.go
+++ b/pkg/skr/azurevpcpeering/removeFinalizer.go
@@ -1,0 +1,36 @@
+package azurevpcpeering
+
+import (
+	"context"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func removeFinalizer(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	if !composed.MarkedForDeletionPredicate(ctx, state) {
+		return nil, nil
+	}
+
+	if state.KcpVpcPeering != nil {
+		// KCP VpcPeering is not yet deleted
+		return nil, nil
+	}
+
+	logger.Info("Removing AzureVpcPeering finalizer")
+
+	// KCP VpcPeering does not exist, remove the finalizer so SKR AzureVpcPeering is also deleted
+	controllerutil.RemoveFinalizer(state.Obj(), cloudresourcesv1beta1.Finalizer)
+
+	err := state.UpdateObj(ctx)
+
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error saving SKR AzureVpcPeering after finalizer remove", composed.StopWithRequeue, ctx)
+	}
+
+	// bye, bye AzureVpcPeering
+	return composed.StopAndForget, nil
+}

--- a/pkg/skr/azurevpcpeering/updateStatus.go
+++ b/pkg/skr/azurevpcpeering/updateStatus.go
@@ -24,7 +24,7 @@ func updateStatus(ctx context.Context, st composed.State) (error, context.Contex
 	skrCondErr := meta.FindStatusCondition(state.ObjAsAzureVpcPeering().Status.Conditions, cloudresourcesv1beta1.ConditionTypeError)
 	skrCondReady := meta.FindStatusCondition(state.ObjAsAzureVpcPeering().Status.Conditions, cloudresourcesv1beta1.ConditionTypeReady)
 
-	if kcpCondErr != nil && skrCondErr == nil {
+	if kcpCondErr != nil && (skrCondErr == nil || skrCondErr.Message != kcpCondErr.Message) {
 		return composed.UpdateStatus(state.ObjAsAzureVpcPeering()).
 			SetCondition(metav1.Condition{
 				Type:    cloudresourcesv1beta1.ConditionTypeError,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Deletes VirtualNetworkPeering from SKR subscription when VpcPeering on KCP is deleted.
- Deletes KCP VpcPeering when SKR AzureVpcPeering is deleted
- Shows friendly error to user instead of provider API error 