### PR TITLE
refactor(GcpNfsVolume): move validation from loadPVC to validatePVC

### DIFF
--- a/api/cloud-resources/v1beta1/gcpnfsvolume_types.go
+++ b/api/cloud-resources/v1beta1/gcpnfsvolume_types.go
@@ -48,15 +48,14 @@ const (
 
 // Additional error reasons
 const (
-	ConditionReasonCapacityInvalid           = "CapacityGbInvalid"
-	ConditionReasonIpRangeNotReady           = "IpRangeNotReady"
-	ConditionReasonFileShareNameInvalid      = "FileShareNameInvalid"
-	ConditionReasonTierInvalid               = "TierInvalid"
-	ConditionReasonPVNotReadyForDeletion     = "PVNotReadyForDeletion"
-	ConditionReasonPVNotReadyForNameChange   = "PVNotReadyForNameChange"
-	ConditionReasonPVNameInvalid             = "PVNameInvalid"
-	ConditionReasonPVCNameInvalid            = "PVCNameInvalid"
-	ConditionPVCBelongsToAnotherGcpNfsVolume = "PVCNameAlreadyUsed"
+	ConditionReasonCapacityInvalid         = "CapacityGbInvalid"
+	ConditionReasonIpRangeNotReady         = "IpRangeNotReady"
+	ConditionReasonFileShareNameInvalid    = "FileShareNameInvalid"
+	ConditionReasonTierInvalid             = "TierInvalid"
+	ConditionReasonPVNotReadyForDeletion   = "PVNotReadyForDeletion"
+	ConditionReasonPVNotReadyForNameChange = "PVNotReadyForNameChange"
+	ConditionReasonPVNameInvalid           = "PVNameInvalid"
+	ConditionReasonPVCNameInvalid          = "PVCNameInvalid"
 )
 
 // GcpNfsVolumeSpec defines the desired state of GcpNfsVolume

--- a/pkg/skr/gcpnfsvolume/loadPersistentVolumeClaim.go
+++ b/pkg/skr/gcpnfsvolume/loadPersistentVolumeClaim.go
@@ -2,12 +2,9 @@ package gcpnfsvolume
 
 import (
 	"context"
-	"fmt"
 
-	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -29,23 +26,6 @@ func loadPersistentVolumeClaim(ctx context.Context, st composed.State) (error, c
 
 	if err != nil { // PVC not-found
 		return nil, nil
-	}
-
-	pvcLabels := pvc.Labels
-	parentGcpNfsVolumeName := pvcLabels[cloudresourcesv1beta1.LabelNfsVolName]
-
-	if parentGcpNfsVolumeName != gcpNfsVolume.Name {
-		errorMsg := fmt.Sprintf("Loaded PVC(%s/%s) belongs to another GcpNfsVolume (%s)", pvc.Namespace, pvc.Name, parentGcpNfsVolumeName)
-		return composed.UpdateStatus(state.ObjAsGcpNfsVolume()).
-			SetCondition(metav1.Condition{
-				Type:    cloudresourcesv1beta1.ConditionTypeError,
-				Status:  metav1.ConditionTrue,
-				Reason:  cloudresourcesv1beta1.ConditionPVCBelongsToAnotherGcpNfsVolume,
-				Message: errorMsg,
-			}).
-			RemoveConditions(cloudresourcesv1beta1.ConditionTypeReady).
-			ErrorLogMessage(errorMsg).
-			Run(ctx, state)
 	}
 
 	state.PVC = pvc


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- fixes existing validatePVC
- removes validation from loadPVC

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
