### PR TITLE
feat(GcpRedisInstance): add auth settings to API

### DIFF
--- a/api/cloud-control/v1beta1/redisinstance_types.go
+++ b/api/cloud-control/v1beta1/redisinstance_types.go
@@ -118,6 +118,17 @@ type RedisInstanceGcp struct {
 	RedisVersion string `json:"redisVersion"`
 
 	// +optional
+	// +kubebuilder:default=true
+	// +kubebuilder:validation:XValidation:rule=(self == oldSelf), message="AuthEnabled is immutable."
+	AuthEnabled bool `json:"authEnabled"`
+
+	// +optional
+	// +kubebuilder:default=TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+	// +kubebuilder:validation:XValidation:rule=(self == oldSelf), message="TransitEncryptionMode is immutable."
+	// +kubebuilder:validation:Enum=TRANSIT_ENCRYPTION_MODE_UNSPECIFIED;SERVER_AUTHENTICATION;DISABLED
+	TransitEncryptionMode string `json:"transitEncryptionMode"`
+
+	// +optional
 	// +kubebuilder:validation:XValidation:rule=(self == oldSelf), message="RedisConfigs is immutable."
 	RedisConfigs RedisInstanceGcpConfigs `json:"redisConfigs"`
 }

--- a/api/cloud-resources/v1beta1/gcpredisinstance_types.go
+++ b/api/cloud-resources/v1beta1/gcpredisinstance_types.go
@@ -68,6 +68,17 @@ type GcpRedisInstanceSpec struct {
 	RedisVersion string `json:"redisVersion"`
 
 	// +optional
+	// +kubebuilder:default=true
+	// +kubebuilder:validation:XValidation:rule=(self == oldSelf), message="AuthEnabled is immutable."
+	AuthEnabled bool `json:"authEnabled"`
+
+	// +optional
+	// +kubebuilder:default=TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+	// +kubebuilder:validation:XValidation:rule=(self == oldSelf), message="TransitEncryptionMode is immutable."
+	// +kubebuilder:validation:Enum=TRANSIT_ENCRYPTION_MODE_UNSPECIFIED;SERVER_AUTHENTICATION;DISABLED
+	TransitEncryptionMode string `json:"transitEncryptionMode"`
+
+	// +optional
 	// +kubebuilder:validation:XValidation:rule=(self == oldSelf), message="RedisConfigs is immutable."
 	RedisConfigs RedisInstanceGcpConfigs `json:"redisConfigs"`
 

--- a/config/crd/bases/cloud-control.kyma-project.io_redisinstances.yaml
+++ b/config/crd/bases/cloud-control.kyma-project.io_redisinstances.yaml
@@ -44,6 +44,12 @@ spec:
                     type: object
                   gcp:
                     properties:
+                      authEnabled:
+                        default: true
+                        type: boolean
+                        x-kubernetes-validations:
+                        - message: AuthEnabled is immutable.
+                          rule: (self == oldSelf)
                       memorySizeGb:
                         format: int32
                         type: integer
@@ -89,6 +95,16 @@ spec:
                         type: string
                         x-kubernetes-validations:
                         - message: Tier is immutable.
+                          rule: (self == oldSelf)
+                      transitEncryptionMode:
+                        default: TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+                        enum:
+                        - TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+                        - SERVER_AUTHENTICATION
+                        - DISABLED
+                        type: string
+                        x-kubernetes-validations:
+                        - message: TransitEncryptionMode is immutable.
                           rule: (self == oldSelf)
                     required:
                     - memorySizeGb

--- a/config/crd/bases/cloud-resources.kyma-project.io_gcpredisinstances.yaml
+++ b/config/crd/bases/cloud-resources.kyma-project.io_gcpredisinstances.yaml
@@ -38,6 +38,12 @@ spec:
           spec:
             description: GcpRedisInstanceSpec defines the desired state of GcpRedisInstance
             properties:
+              authEnabled:
+                default: true
+                type: boolean
+                x-kubernetes-validations:
+                - message: AuthEnabled is immutable.
+                  rule: (self == oldSelf)
               ipRange:
                 properties:
                   name:
@@ -93,6 +99,16 @@ spec:
                 type: string
                 x-kubernetes-validations:
                 - message: Tier is immutable.
+                  rule: (self == oldSelf)
+              transitEncryptionMode:
+                default: TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+                enum:
+                - TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+                - SERVER_AUTHENTICATION
+                - DISABLED
+                type: string
+                x-kubernetes-validations:
+                - message: TransitEncryptionMode is immutable.
                   rule: (self == oldSelf)
               volume:
                 properties:

--- a/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_redisinstances.yaml
+++ b/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_redisinstances.yaml
@@ -44,6 +44,12 @@ spec:
                     type: object
                   gcp:
                     properties:
+                      authEnabled:
+                        default: true
+                        type: boolean
+                        x-kubernetes-validations:
+                        - message: AuthEnabled is immutable.
+                          rule: (self == oldSelf)
                       memorySizeGb:
                         format: int32
                         type: integer
@@ -89,6 +95,16 @@ spec:
                         type: string
                         x-kubernetes-validations:
                         - message: Tier is immutable.
+                          rule: (self == oldSelf)
+                      transitEncryptionMode:
+                        default: TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+                        enum:
+                        - TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+                        - SERVER_AUTHENTICATION
+                        - DISABLED
+                        type: string
+                        x-kubernetes-validations:
+                        - message: TransitEncryptionMode is immutable.
                           rule: (self == oldSelf)
                     required:
                     - memorySizeGb

--- a/config/dist/skr/crd/bases/providers/gcp/cloud-resources.kyma-project.io_gcpredisinstances.yaml
+++ b/config/dist/skr/crd/bases/providers/gcp/cloud-resources.kyma-project.io_gcpredisinstances.yaml
@@ -38,6 +38,12 @@ spec:
           spec:
             description: GcpRedisInstanceSpec defines the desired state of GcpRedisInstance
             properties:
+              authEnabled:
+                default: true
+                type: boolean
+                x-kubernetes-validations:
+                - message: AuthEnabled is immutable.
+                  rule: (self == oldSelf)
               ipRange:
                 properties:
                   name:
@@ -93,6 +99,16 @@ spec:
                 type: string
                 x-kubernetes-validations:
                 - message: Tier is immutable.
+                  rule: (self == oldSelf)
+              transitEncryptionMode:
+                default: TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+                enum:
+                - TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+                - SERVER_AUTHENTICATION
+                - DISABLED
+                type: string
+                x-kubernetes-validations:
+                - message: TransitEncryptionMode is immutable.
                   rule: (self == oldSelf)
               volume:
                 properties:

--- a/pkg/kcp/provider/gcp/redisinstance/client/memorystoreClient.go
+++ b/pkg/kcp/provider/gcp/redisinstance/client/memorystoreClient.go
@@ -13,12 +13,14 @@ import (
 )
 
 type CreateRedisInstanceOptions struct {
-	VPCNetworkFullName string
-	IPRangeName        string
-	MemorySizeGb       int32
-	Tier               string
-	RedisVersion       string
-	RedisConfigs       map[string]string
+	VPCNetworkFullName    string
+	IPRangeName           string
+	MemorySizeGb          int32
+	Tier                  string
+	RedisVersion          string
+	AuthEnabled           bool
+	TransitEncryptionMode string
+	RedisConfigs          map[string]string
 }
 
 type MemorystoreClient interface {
@@ -53,14 +55,16 @@ func (memorystoreClient *memorystoreClient) CreateRedisInstance(ctx context.Cont
 		Parent:     parent,
 		InstanceId: instanceId,
 		Instance: &redispb.Instance{
-			Name:              fmt.Sprintf("%s/%s", parent, instanceId),
-			MemorySizeGb:      options.MemorySizeGb,
-			Tier:              redispb.Instance_Tier(redispb.Instance_Tier_value[options.Tier]),
-			RedisVersion:      options.RedisVersion,
-			ConnectMode:       redispb.Instance_PRIVATE_SERVICE_ACCESS, // always
-			AuthorizedNetwork: options.VPCNetworkFullName,
-			ReservedIpRange:   options.IPRangeName,
-			RedisConfigs:      options.RedisConfigs,
+			Name:                  fmt.Sprintf("%s/%s", parent, instanceId),
+			MemorySizeGb:          options.MemorySizeGb,
+			Tier:                  redispb.Instance_Tier(redispb.Instance_Tier_value[options.Tier]),
+			RedisVersion:          options.RedisVersion,
+			ConnectMode:           redispb.Instance_PRIVATE_SERVICE_ACCESS, // always
+			AuthorizedNetwork:     options.VPCNetworkFullName,
+			ReservedIpRange:       options.IPRangeName,
+			RedisConfigs:          options.RedisConfigs,
+			AuthEnabled:           options.AuthEnabled,
+			TransitEncryptionMode: redispb.Instance_TransitEncryptionMode(redispb.Instance_TransitEncryptionMode_value[options.TransitEncryptionMode]),
 		},
 	}
 

--- a/pkg/kcp/provider/gcp/redisinstance/createRedis.go
+++ b/pkg/kcp/provider/gcp/redisinstance/createRedis.go
@@ -30,12 +30,14 @@ func createRedis(ctx context.Context, st composed.State) (error, context.Context
 	vpcNetworkFullName := fmt.Sprintf("projects/%s/global/networks/%s", gcpScope.Project, gcpScope.VpcNetwork)
 
 	redisInstanceOptions := client.CreateRedisInstanceOptions{
-		VPCNetworkFullName: vpcNetworkFullName,
-		IPRangeName:        state.IpRange().Spec.RemoteRef.Name,
-		MemorySizeGb:       redisInstance.Spec.Instance.Gcp.MemorySizeGb,
-		Tier:               redisInstance.Spec.Instance.Gcp.Tier,
-		RedisVersion:       redisInstance.Spec.Instance.Gcp.RedisVersion,
-		RedisConfigs:       redisInstance.Spec.Instance.Gcp.RedisConfigs.ToMap(),
+		VPCNetworkFullName:    vpcNetworkFullName,
+		IPRangeName:           state.IpRange().Spec.RemoteRef.Name,
+		MemorySizeGb:          redisInstance.Spec.Instance.Gcp.MemorySizeGb,
+		Tier:                  redisInstance.Spec.Instance.Gcp.Tier,
+		RedisVersion:          redisInstance.Spec.Instance.Gcp.RedisVersion,
+		AuthEnabled:           redisInstance.Spec.Instance.Gcp.AuthEnabled,
+		TransitEncryptionMode: redisInstance.Spec.Instance.Gcp.TransitEncryptionMode,
+		RedisConfigs:          redisInstance.Spec.Instance.Gcp.RedisConfigs.ToMap(),
 	}
 
 	_, err := state.memorystoreClient.CreateRedisInstance(ctx, gcpScope.Project, region, state.GetRemoteRedisName(), redisInstanceOptions)

--- a/pkg/skr/gcpredisinstance/createKcpRedisInstance.go
+++ b/pkg/skr/gcpredisinstance/createKcpRedisInstance.go
@@ -42,9 +42,11 @@ func createKcpRedisInstance(ctx context.Context, st composed.State) (error, cont
 			},
 			Instance: cloudcontrolv1beta1.RedisInstanceInfo{
 				Gcp: &cloudcontrolv1beta1.RedisInstanceGcp{
-					Tier:         gcpRedisInstance.Spec.Tier,
-					MemorySizeGb: gcpRedisInstance.Spec.MemorySizeGb,
-					RedisVersion: gcpRedisInstance.Spec.RedisVersion,
+					Tier:                  gcpRedisInstance.Spec.Tier,
+					MemorySizeGb:          gcpRedisInstance.Spec.MemorySizeGb,
+					RedisVersion:          gcpRedisInstance.Spec.RedisVersion,
+					AuthEnabled:           gcpRedisInstance.Spec.AuthEnabled,
+					TransitEncryptionMode: gcpRedisInstance.Spec.TransitEncryptionMode,
 					RedisConfigs: cloudcontrolv1beta1.RedisInstanceGcpConfigs{
 						MaxmemoryPolicy:      gcpRedisInstance.Spec.RedisConfigs.MaxmemoryPolicy,
 						NotifyKeyspaceEvents: gcpRedisInstance.Spec.RedisConfigs.NotifyKeyspaceEvents,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- allow user to define if auth is enabled `.spec.authEnabled`
- allow user to define transit encryption mode `.spec.transitEncryptionMode`
- show `Deleting` state while GcpRedisInstance is being deleted

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
