### PR TITLE
fix(GcpNfsVolume) : Fix for GCP NfsInstance naming.

### DIFF
--- a/pkg/kcp/provider/gcp/nfsinstance/loadNfsInstance.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/loadNfsInstance.go
@@ -3,6 +3,7 @@ package nfsinstance
 import (
 	"context"
 	"errors"
+	"fmt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
@@ -21,7 +22,7 @@ func loadNfsInstance(ctx context.Context, st composed.State) (error, context.Con
 	gcpScope := state.Scope().Spec.Scope.Gcp
 	project := gcpScope.Project
 	location := state.getGcpLocation()
-	name := nfsInstance.Spec.RemoteRef.Name
+	name := fmt.Sprintf("cm-%.60s", nfsInstance.Name)
 
 	inst, err := state.filestoreClient.GetFilestoreInstance(ctx, project, location, name)
 	if err != nil {

--- a/pkg/kcp/provider/gcp/nfsinstance/loadNfsInstance_test.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/loadNfsInstance_test.go
@@ -28,7 +28,7 @@ func (suite *loadNfsInstanceSuite) TestLoadNfsInstanceNotFound() {
 		switch r.Method {
 
 		case http.MethodGet:
-			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/test-gcp-nfs-volume") {
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/cm-test-gcp-nfs-instance") {
 				//Return 404
 				http.Error(w, "Not Found", http.StatusNotFound)
 			} else {
@@ -59,7 +59,7 @@ func (suite *loadNfsInstanceSuite) TestLoadNfsInstanceOtherErrors() {
 	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/test-gcp-nfs-volume") {
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/cm-test-gcp-nfs-instance") {
 				//Return 500
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			} else {
@@ -92,7 +92,7 @@ func (suite *loadNfsInstanceSuite) TestLoadNfsInstanceSuccess() {
 	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/test-gcp-nfs-volume") {
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/cm-test-gcp-nfs-instance") {
 				//Return 200
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"name":"test-gcp-nfs-volume"}`))

--- a/pkg/kcp/provider/gcp/nfsinstance/syncNfsInstance.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/syncNfsInstance.go
@@ -23,7 +23,7 @@ func syncNfsInstance(ctx context.Context, st composed.State) (error, context.Con
 	gcpScope := state.Scope().Spec.Scope.Gcp
 	project := gcpScope.Project
 	location := state.getGcpLocation()
-	name := nfsInstance.Spec.RemoteRef.Name
+	name := fmt.Sprintf("cm-%.60s", nfsInstance.Name)
 
 	var operation *file.Operation
 	var err error

--- a/pkg/kcp/provider/gcp/nfsinstance/syncNfsInstance_test.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/syncNfsInstance_test.go
@@ -137,7 +137,7 @@ func (suite *syncNfsInstanceSuite) TestSyncNfsInstancePatchSuccess() {
 	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodPatch:
-			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/test-gcp-nfs-volume") {
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/cm-test-gcp-nfs-instance") {
 				b, err := io.ReadAll(r.Body)
 				assert.Nil(suite.T(), err)
 				//create filestore instance from byte[] and check if it is equal to the expected filestore instance
@@ -185,7 +185,7 @@ func (suite *syncNfsInstanceSuite) TestSyncNfsInstancePatchError() {
 	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodPatch:
-			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/test-gcp-nfs-volume") {
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/cm-test-gcp-nfs-instance") {
 				b, err := io.ReadAll(r.Body)
 				assert.Nil(suite.T(), err)
 				//create filestore instance from byte[] and check if it is equal to the expected filestore instance
@@ -240,7 +240,7 @@ func (suite *syncNfsInstanceSuite) TestSyncNfsInstanceDeleteSuccess() {
 	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodDelete:
-			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/test-gcp-nfs-volume") {
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/cm-test-gcp-nfs-instance") {
 				//Return 200
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"name":"delete-instance-operation"}`))
@@ -279,7 +279,7 @@ func (suite *syncNfsInstanceSuite) TestSyncNfsInstanceDeleteError() {
 	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodDelete:
-			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/test-gcp-nfs-volume") {
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/instances/cm-test-gcp-nfs-instance") {
 				//Return 200
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write([]byte(`{"error":"error"}`))

--- a/pkg/skr/gcpnfsvolume/reconciler.go
+++ b/pkg/skr/gcpnfsvolume/reconciler.go
@@ -42,6 +42,7 @@ func (r *Reconciler) newAction() composed.Action {
 		composed.ComposeActions(
 			"crGcpNfsVolumeValidateSpec",
 			validateIpRange, validateFileShareName, validateCapacity, validatePV, validatePVC),
+		setProcessing,
 		defaultiprange.New(),
 		addFinalizer,
 		loadKcpIpRange,

--- a/pkg/skr/gcpnfsvolume/setProcessing.go
+++ b/pkg/skr/gcpnfsvolume/setProcessing.go
@@ -1,0 +1,33 @@
+package gcpnfsvolume
+
+import (
+	"context"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+)
+
+func setProcessing(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+	nfsVolume := state.ObjAsGcpNfsVolume()
+
+	//If deleting, continue with next steps.
+	deleting := composed.IsMarkedForDeletion(state.Obj())
+	if deleting {
+		return nil, nil
+	}
+
+	logger.WithValues("GcpNfsVolume :", nfsVolume.Name).Info("Checking States")
+
+	//If state is not empty, continue
+	if nfsVolume.Status.State != "" {
+		return nil, nil
+	}
+
+	//Set the state to processing
+	nfsVolume.Status.State = cloudresourcesv1beta1.StateProcessing
+	return composed.UpdateStatus(nfsVolume).
+		SetExclusiveConditions().
+		SuccessError(composed.StopWithRequeue).
+		Run(ctx, state)
+}

--- a/pkg/skr/gcpnfsvolume/setProcessing_test.go
+++ b/pkg/skr/gcpnfsvolume/setProcessing_test.go
@@ -1,0 +1,124 @@
+package gcpnfsvolume
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+type setProcessingSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *setProcessingSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *setProcessingSuite) TestSetProcessingWhenDeleting() {
+
+	obj := deletedGcpNfsVolume.DeepCopy()
+	factory, err := newTestStateFactory()
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	err, ctx = setProcessing(ctx, state)
+	suite.Nil(err)
+	suite.Nil(ctx)
+}
+
+func (suite *setProcessingSuite) TestSetProcessingWhenStateDone() {
+
+	obj := gcpNfsVolume.DeepCopy()
+	factory, err := newTestStateFactory()
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	obj.Status.State = v1beta1.StateReady
+	meta.SetStatusCondition(&obj.Status.Conditions, metav1.Condition{
+		Type:    cloudcontrolv1beta1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "test",
+		Message: "test",
+	})
+	state := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	err, ctx = setProcessing(ctx, state)
+	suite.Nil(err)
+	suite.Nil(ctx)
+}
+
+func (suite *setProcessingSuite) TestSetProcessingWhenStateError() {
+
+	obj := gcpNfsVolume.DeepCopy()
+	factory, err := newTestStateFactory()
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	obj.Status.State = v1beta1.StateError
+	meta.SetStatusCondition(&obj.Status.Conditions, metav1.Condition{
+		Type:    cloudcontrolv1beta1.ConditionTypeError,
+		Status:  metav1.ConditionTrue,
+		Reason:  "test",
+		Message: "test",
+	})
+	state := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	err, ctx = setProcessing(ctx, state)
+	suite.Nil(err)
+	suite.Nil(ctx)
+}
+
+func (suite *setProcessingSuite) TestSetProcessingWhenStateEmpty() {
+
+	obj := gcpNfsVolume.DeepCopy()
+	factory, err := newTestStateFactory()
+	suite.Nil(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Set the Status.State to empty.
+	obj.Status.State = ""
+
+	//Get state object with GcpNfsVolume
+	state := factory.newStateWith(obj)
+	suite.Nil(err)
+
+	err, ctx = setProcessing(ctx, state)
+	suite.Equal(composed.StopWithRequeue, err)
+	fromK8s := &v1beta1.GcpNfsVolume{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: obj.Name,
+			Namespace: obj.Namespace},
+		fromK8s)
+	suite.Nil(err)
+	suite.Equal(v1beta1.GcpNfsVolumeProcessing, fromK8s.Status.State)
+	suite.Nil(fromK8s.Status.Conditions)
+}
+
+func TestSetProcessing(t *testing.T) {
+	suite.Run(t, new(setProcessingSuite))
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fixed the GCP NFS Instance to be created with name `cm-<kcp-nfs-instance-name>` instead of the GcpNfsVolume name to avoid name collisions
- Fixed the GcpNfsVolume.Status.State was empty for long time when the long running IpRange creation is in progress.


**Related issue(s)**
https://jira.tools.sap/browse/PHX-178
https://jira.tools.sap/browse/PHX-179
