### PR TITLE
test(RedisInstance): add scenario tests

### DIFF
--- a/internal/controller/cloud-control/nfsinstance_aws_test.go
+++ b/internal/controller/cloud-control/nfsinstance_aws_test.go
@@ -2,6 +2,8 @@ package cloudcontrol
 
 import (
 	"fmt"
+	"time"
+
 	efsTypes "github.com/aws/aws-sdk-go-v2/service/efs/types"
 	"github.com/elliotchance/pie/v2"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
@@ -13,7 +15,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
-	"time"
 )
 
 var _ = Describe("Feature: KCP NfsInstance", func() {
@@ -74,7 +75,7 @@ var _ = Describe("Feature: KCP NfsInstance", func() {
 				WithArguments(infra.Ctx(), infra.KCP().Client(), nfsInstance,
 					WithName(name),
 					WithRemoteRef("foo"),
-					WithNfsInstanceScope(name),
+					WithInstanceScope(name),
 					WithNfsInstanceIpRange(name),
 					WithNfsInstanceAws(),
 				).

--- a/internal/controller/cloud-control/nfsinstance_aws_test.go
+++ b/internal/controller/cloud-control/nfsinstance_aws_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Feature: KCP NfsInstance", func() {
 					WithName(name),
 					WithRemoteRef("foo"),
 					WithInstanceScope(name),
-					WithNfsInstanceIpRange(name),
+					WithIpRange(name),
 					WithNfsInstanceAws(),
 				).
 				Should(Succeed(), "failed creating NfsInstance")

--- a/internal/controller/cloud-control/nfsinstance_gcp_test.go
+++ b/internal/controller/cloud-control/nfsinstance_gcp_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Feature: KCP NFSVolume for GCP", func() {
 						WithName("gcp-nfs-instance-1"),
 						WithRemoteRef("gcp-nfs-instance-1"),
 						WithInstanceScope(scope.Name),
-						WithNfsInstanceIpRange(kcpIpRange.Name),
+						WithIpRange(kcpIpRange.Name),
 						WithNfsInstanceGcp(scope.Spec.Region),
 					).
 					Should(Succeed())
@@ -233,7 +233,7 @@ var _ = Describe("Feature: KCP NFSVolume for GCP", func() {
 						WithName("gcp-nfs-instance-2"),
 						WithRemoteRef("gcp-nfs-instance-2"),
 						WithInstanceScope(scope.Name),
-						WithNfsInstanceIpRange(kcpIpRange.Name),
+						WithIpRange(kcpIpRange.Name),
 						WithNfsInstanceGcp(scope.Spec.Region),
 					).
 					Should(Succeed())

--- a/internal/controller/cloud-control/nfsinstance_gcp_test.go
+++ b/internal/controller/cloud-control/nfsinstance_gcp_test.go
@@ -1,6 +1,8 @@
 package cloudcontrol
 
 import (
+	"time"
+
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	iprangePkg "github.com/kyma-project/cloud-manager/pkg/kcp/iprange"
 	client2 "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
@@ -13,7 +15,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 var _ = Describe("Feature: KCP NFSVolume for GCP", func() {
@@ -84,7 +85,7 @@ var _ = Describe("Feature: KCP NFSVolume for GCP", func() {
 						infra.Ctx(), infra.KCP().Client(), gcpNfsInstance,
 						WithName("gcp-nfs-instance-1"),
 						WithRemoteRef("gcp-nfs-instance-1"),
-						WithNfsInstanceScope(scope.Name),
+						WithInstanceScope(scope.Name),
 						WithNfsInstanceIpRange(kcpIpRange.Name),
 						WithNfsInstanceGcp(scope.Spec.Region),
 					).
@@ -231,7 +232,7 @@ var _ = Describe("Feature: KCP NFSVolume for GCP", func() {
 						infra.Ctx(), infra.KCP().Client(), gcpNfsInstance,
 						WithName("gcp-nfs-instance-2"),
 						WithRemoteRef("gcp-nfs-instance-2"),
-						WithNfsInstanceScope(scope.Name),
+						WithInstanceScope(scope.Name),
 						WithNfsInstanceIpRange(kcpIpRange.Name),
 						WithNfsInstanceGcp(scope.Spec.Region),
 					).

--- a/internal/controller/cloud-control/redisinstance_gcp_test.go
+++ b/internal/controller/cloud-control/redisinstance_gcp_test.go
@@ -1,0 +1,125 @@
+package cloudcontrol
+
+import (
+	"time"
+
+	redispb "cloud.google.com/go/redis/apiv1/redispb"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	iprangePkg "github.com/kyma-project/cloud-manager/pkg/kcp/iprange"
+	scopePkg "github.com/kyma-project/cloud-manager/pkg/kcp/scope"
+	. "github.com/kyma-project/cloud-manager/pkg/testinfra/dsl"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Feature: KCP RedisInstance", func() {
+
+	It("Scenario: KCP GCP RedisInstance is created and deleted", func() {
+
+		name := "924a92cf-9e72-408d-a1e8-017a2fd8d42d"
+		scope := &cloudcontrolv1beta1.Scope{}
+
+		By("Given Scope exists", func() {
+			// Tell Scope reconciler to ignore this kymaName
+			scopePkg.Ignore.AddName(name)
+
+			Eventually(CreateScopeGcp).
+				WithArguments(infra.Ctx(), infra, scope, WithName(name)).
+				Should(Succeed())
+		})
+
+		kcpIpRangeName := "ffc7ebcc-114e-4d68-948c-241405fd01b5"
+		kcpIpRange := &cloudcontrolv1beta1.IpRange{}
+
+		// Tell IpRange reconciler to ignore this kymaName
+		iprangePkg.Ignore.AddName(kcpIpRangeName)
+		By("And Given KCP IPRange exists", func() {
+			Eventually(CreateKcpIpRange).
+				WithArguments(
+					infra.Ctx(), infra.KCP().Client(), kcpIpRange,
+					WithName(kcpIpRangeName),
+					WithKcpIpRangeSpecScope(scope.Name),
+				).
+				Should(Succeed())
+		})
+
+		By("And Given KCP IpRange has Ready condition", func() {
+			Eventually(UpdateStatus).
+				WithArguments(
+					infra.Ctx(), infra.KCP().Client(), kcpIpRange,
+					WithKcpIpRangeStatusCidr(kcpIpRange.Spec.Cidr),
+					WithConditions(KcpReadyCondition()),
+				).WithTimeout(20*time.Second).WithPolling(200*time.Millisecond).
+				Should(Succeed(), "Expected KCP IpRange to become ready")
+		})
+
+		redisInstance := &cloudcontrolv1beta1.RedisInstance{}
+
+		By("When RedisInstance is created", func() {
+			Eventually(CreateRedisInstance).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance,
+					WithName(name),
+					WithRemoteRef("skr-redis-example"),
+					WithIpRange(kcpIpRangeName),
+					WithInstanceScope(name),
+					WithRedisInstanceGcp(),
+					WithKcpGcpRedisInstanceTier("BASIC"),
+					WithKcpGcpRedisInstanceMemorySizeGb(5),
+					WithKcpGcpRedisInstanceRedisVersion("REDIS_7_0"),
+				).
+				Should(Succeed(), "failed creating RedisInstance")
+		})
+
+		var memorystoreRedisInstance *redispb.Instance
+		By("Then GCP Redis is created", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance,
+					NewObjActions(),
+					HavingRedisInstanceStatusId()).
+				Should(Succeed(), "expected RedisInstance to get status.id")
+			memorystoreRedisInstance = infra.GcpMock().GetMemoryStoreRedisByName(redisInstance.Status.Id)
+		})
+
+		By("When GCP Redis is Available", func() {
+			infra.GcpMock().SetMemoryStoreRedisLifeCycleState(memorystoreRedisInstance.Name, redispb.Instance_READY)
+		})
+
+		By("Then RedisInstance has Ready condition", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance,
+					NewObjActions(),
+					HavingConditionTrue(cloudcontrolv1beta1.ConditionTypeReady),
+				).
+				Should(Succeed(), "expected RedisInstance to has Ready state, but it didn't")
+		})
+
+		By("And Then RedisInstance has .status.primaryEndpoint set", func() {
+			Expect(len(redisInstance.Status.PrimaryEndpoint) > 0).To(Equal(true))
+		})
+		By("And Then RedisInstance has .status.readEndpoint set", func() {
+			Expect(len(redisInstance.Status.ReadEndpoint) > 0).To(Equal(true))
+		})
+		By("And Then RedisInstance has .status.authString set", func() {
+			Expect(len(redisInstance.Status.AuthString) > 0).To(Equal(true))
+		})
+
+		// DELETE
+
+		By("When RedisInstance is deleted", func() {
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance).
+				Should(Succeed(), "failed deleting RedisInstance")
+		})
+
+		By("And When GCP Redis state is deleted", func() {
+			infra.GcpMock().DeleteMemorStoreRedisByName(memorystoreRedisInstance.Name)
+		})
+
+		By("Then RedisInstance does not exist", func() {
+			Eventually(IsDeleted, 5*time.Second).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance).
+				Should(Succeed(), "expected RedisInstance not to exist (be deleted), but it still exists")
+		})
+	})
+
+})

--- a/internal/controller/cloud-control/suite_test.go
+++ b/internal/controller/cloud-control/suite_test.go
@@ -105,6 +105,12 @@ var _ = BeforeSuite(func() {
 		infra.GcpMock().VpcPeeringSkrProvider(),
 		env,
 	))
+	//RedisInstance
+	Expect(SetupRedisInstanceReconciler(
+		infra.KcpManager(),
+		infra.GcpMock().MemoryStoreProviderFake(),
+		env,
+	))
 
 	// Start controllers
 	infra.StartKcpControllers(context.Background())

--- a/pkg/kcp/provider/gcp/mock/memoryStoreClientFake.go
+++ b/pkg/kcp/provider/gcp/mock/memoryStoreClientFake.go
@@ -1,0 +1,96 @@
+package mock
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	redis "cloud.google.com/go/redis/apiv1"
+	"cloud.google.com/go/redis/apiv1/redispb"
+	memoryStoreClient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/redisinstance/client"
+)
+
+type MemoryStoreClientFakeUtils interface {
+	GetMemoryStoreRedisByName(name string) *redispb.Instance
+	SetMemoryStoreRedisLifeCycleState(name string, state redispb.Instance_State)
+	DeleteMemorStoreRedisByName(name string)
+}
+
+type memoryStoreClientFake struct {
+	mutex          sync.Mutex
+	redisInstances map[string]*redispb.Instance
+}
+
+func (memoryStoreClientFake *memoryStoreClientFake) GetMemoryStoreRedisByName(name string) *redispb.Instance {
+	return memoryStoreClientFake.redisInstances[name]
+}
+
+func (memoryStoreClientFake *memoryStoreClientFake) SetMemoryStoreRedisLifeCycleState(name string, state redispb.Instance_State) {
+	if instance, ok := memoryStoreClientFake.redisInstances[name]; ok {
+		instance.State = state
+	}
+}
+
+func (memoryStoreClientFake *memoryStoreClientFake) DeleteMemorStoreRedisByName(name string) {
+	delete(memoryStoreClientFake.redisInstances, name)
+}
+
+func (memoryStoreClientFake *memoryStoreClientFake) CreateRedisInstance(ctx context.Context, projectId string, locationId string, instanceId string, options memoryStoreClient.CreateRedisInstanceOptions) (*redis.CreateInstanceOperation, error) {
+	memoryStoreClientFake.mutex.Lock()
+	defer memoryStoreClientFake.mutex.Unlock()
+
+	name := fmt.Sprintf("projects/%s/locations/%s/%s", projectId, locationId, instanceId)
+	redisInstance := &redispb.Instance{
+		Name:             name,
+		State:            redispb.Instance_CREATING,
+		Host:             "192.168.0.1",
+		Port:             6093,
+		ReadEndpoint:     "192.168.24.1",
+		ReadEndpointPort: 5093,
+	}
+	memoryStoreClientFake.redisInstances[name] = redisInstance
+
+	// go func() {
+	// 	time.Sleep(1 * time.Second)
+	// 	memoryStoreClientFake.mutex.Lock()
+	// 	defer memoryStoreClientFake.mutex.Unlock()
+
+	// 	if instance, ok := memoryStoreClientFake.redisInstances[name]; ok {
+	// 		instance.State = redispb.Instance_READY
+	// 	}
+	// }()
+
+	return &redis.CreateInstanceOperation{}, nil // redis.CreateInstanceOperation is not used in actual code, so empty object is returned
+}
+
+func (memoryStoreClientFake *memoryStoreClientFake) DeleteRedisInstance(ctx context.Context, projectId string, locationId string, instanceId string) error {
+	memoryStoreClientFake.mutex.Lock()
+	defer memoryStoreClientFake.mutex.Unlock()
+
+	name := fmt.Sprintf("projects/%s/locations/%s/%s", projectId, locationId, instanceId)
+
+	if instance, ok := memoryStoreClientFake.redisInstances[name]; ok {
+		instance.State = redispb.Instance_DELETING
+	}
+
+	// go func() {
+	// 	time.Sleep(1 * time.Second)
+	// 	memoryStoreClientFake.mutex.Lock()
+	// 	defer memoryStoreClientFake.mutex.Unlock()
+
+	// 	delete(memoryStoreClientFake.redisInstances, name)
+	// }()
+
+	return nil
+}
+
+func (memoryStoreClientFake *memoryStoreClientFake) GetRedisInstance(ctx context.Context, projectId string, locationId string, instanceId string) (*redispb.Instance, *redispb.InstanceAuthString, error) {
+	memoryStoreClientFake.mutex.Lock()
+	defer memoryStoreClientFake.mutex.Unlock()
+
+	name := fmt.Sprintf("projects/%s/locations/%s/%s", projectId, locationId, instanceId)
+
+	instance := memoryStoreClientFake.redisInstances[name]
+
+	return instance, &redispb.InstanceAuthString{AuthString: "0df0aea4-2cd6-4b9a-900f-a650661e1740"}, nil
+}

--- a/pkg/kcp/provider/gcp/mock/type.go
+++ b/pkg/kcp/provider/gcp/mock/type.go
@@ -7,6 +7,7 @@ import (
 	backupclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsbackup/client"
 	nfsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsinstance/client"
 	restoreclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsrestore/client"
+	memoryStoreClient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/redisinstance/client"
 	gcpvpcpeeringclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/vpcpeering/client"
 	"google.golang.org/api/googleapi"
 )
@@ -33,6 +34,7 @@ type Providers interface {
 	FilerestoreClientProvider() client.ClientProvider[restoreclient.FileRestoreClient]
 	FileBackupClientProvider() client.ClientProvider[backupclient.FileBackupClient]
 	VpcPeeringSkrProvider() cloudclient.ClientProvider[gcpvpcpeeringclient.Client]
+	MemoryStoreProviderFake() client.ClientProvider[memoryStoreClient.MemorystoreClient]
 }
 
 // ClientErrors is an interface for setting errors on the mock client to simulate Hyperscaler API errors
@@ -50,4 +52,6 @@ type Server interface {
 	Providers
 
 	ClientErrors
+
+	MemoryStoreClientFakeUtils
 }

--- a/pkg/kcp/provider/gcp/redisinstance/new.go
+++ b/pkg/kcp/provider/gcp/redisinstance/new.go
@@ -38,6 +38,7 @@ func New(stateFactory StateFactory) composed.Action {
 				composed.ComposeActions(
 					"redisInstance-create",
 					createRedis,
+					updateStatusId,
 					waitRedisAvailable,
 					updateStatus,
 				),

--- a/pkg/kcp/provider/gcp/redisinstance/updateStatus.go
+++ b/pkg/kcp/provider/gcp/redisinstance/updateStatus.go
@@ -18,7 +18,6 @@ func updateStatus(ctx context.Context, st composed.State) (error, context.Contex
 
 	redisInstance := state.ObjAsRedisInstance()
 
-	redisInstance.Status.Id = state.gcpRedisInstance.Name
 	redisInstance.Status.PrimaryEndpoint = fmt.Sprintf("%s:%d", state.gcpRedisInstance.Host, state.gcpRedisInstance.Port)
 	if state.gcpRedisInstance.ReadEndpoint != "" {
 		redisInstance.Status.ReadEndpoint = fmt.Sprintf("%s:%d", state.gcpRedisInstance.ReadEndpoint, state.gcpRedisInstance.ReadEndpointPort)

--- a/pkg/kcp/provider/gcp/redisinstance/updateStatusId.go
+++ b/pkg/kcp/provider/gcp/redisinstance/updateStatusId.go
@@ -1,0 +1,31 @@
+package redisinstance
+
+import (
+	"context"
+
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+)
+
+func updateStatusId(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+
+	if composed.MarkedForDeletionPredicate(ctx, state) {
+		return nil, nil
+	}
+
+	redisInstance := state.ObjAsRedisInstance()
+
+	if redisInstance.Status.Id != "" { // already set
+		return nil, nil
+	}
+
+	redisInstance.Status.Id = state.gcpRedisInstance.Name
+
+	err := state.UpdateObjStatus(ctx)
+
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error updating RedisInstance success .status.id", composed.StopWithRequeue, ctx)
+	}
+
+	return composed.StopWithRequeue, nil
+}

--- a/pkg/skr/gcpredisinstance/deleteKcpRedisInstance.go
+++ b/pkg/skr/gcpredisinstance/deleteKcpRedisInstance.go
@@ -46,7 +46,7 @@ func deleteKcpRedisInstance(ctx context.Context, st composed.State) (error, cont
 	}
 
 	redisInstance.Status.State = cloudresourcesv1beta1.StateDeleting
-	err = state.Cluster().K8sClient().Status().Update(ctx, redisInstance)
+	err = state.UpdateObjStatus(ctx)
 
 	if err != nil {
 		return composed.LogErrorAndReturn(err, "Failed status update on GCP RedisInstance", composed.StopWithRequeue, ctx)

--- a/pkg/testinfra/dsl/commonAssertions.go
+++ b/pkg/testinfra/dsl/commonAssertions.go
@@ -2,6 +2,8 @@ package dsl
 
 import (
 	"fmt"
+
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -15,5 +17,41 @@ func HavingDeletionTimestamp() ObjAssertion {
 			)
 		}
 		return nil
+	}
+}
+
+func WithRemoteRef(name string) ObjAction {
+	remoteRef := &cloudcontrolv1beta1.RemoteRef{
+		Name:      name,
+		Namespace: DefaultSkrNamespace,
+	}
+	return &objAction{
+		f: func(obj client.Object) {
+			if x, ok := obj.(*cloudcontrolv1beta1.NfsInstance); ok {
+				x.Spec.RemoteRef = *remoteRef
+				return
+			}
+			if x, ok := obj.(*cloudcontrolv1beta1.RedisInstance); ok {
+				x.Spec.RemoteRef = *remoteRef
+				return
+			}
+			panic("unhandled type in WithRemoteRef")
+		},
+	}
+}
+
+func WithInstanceScope(scopeName string) ObjAction {
+	return &objAction{
+		f: func(obj client.Object) {
+			if x, ok := obj.(*cloudcontrolv1beta1.NfsInstance); ok {
+				x.Spec.Scope.Name = scopeName
+				return
+			}
+			if x, ok := obj.(*cloudcontrolv1beta1.RedisInstance); ok {
+				x.Spec.Scope.Name = scopeName
+				return
+			}
+			panic("unhandled type in WithInstanceScope")
+		},
 	}
 }

--- a/pkg/testinfra/dsl/commonIpRange.go
+++ b/pkg/testinfra/dsl/commonIpRange.go
@@ -3,6 +3,7 @@ package dsl
 import (
 	"fmt"
 
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -10,6 +11,7 @@ import (
 func WithIpRange(ipRangeName string) ObjAction {
 	return &objAction{
 		f: func(obj client.Object) {
+			// SKR
 			if x, ok := obj.(*cloudresourcesv1beta1.AwsNfsVolume); ok {
 				if x.Spec.IpRange.Name == "" {
 					x.Spec.IpRange.Name = ipRangeName
@@ -28,6 +30,21 @@ func WithIpRange(ipRangeName string) ObjAction {
 				}
 				return
 			}
+
+			// KCP
+			if x, ok := obj.(*cloudcontrolv1beta1.NfsInstance); ok {
+				if x.Spec.IpRange.Name == "" {
+					x.Spec.IpRange.Name = ipRangeName
+				}
+				return
+			}
+			if x, ok := obj.(*cloudcontrolv1beta1.RedisInstance); ok {
+				if x.Spec.IpRange.Name == "" {
+					x.Spec.IpRange.Name = ipRangeName
+				}
+				return
+			}
+
 			panic(fmt.Errorf("unhandled type %T in WithIpRange", obj))
 		},
 	}

--- a/pkg/testinfra/dsl/nfsInstance.go
+++ b/pkg/testinfra/dsl/nfsInstance.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -64,34 +65,6 @@ func WithNfsInstanceIpRange(ipRangeName string) ObjAction {
 				return
 			}
 			panic("unhandled type in WithNfsInstanceIpRange")
-		},
-	}
-}
-
-func WithNfsInstanceScope(scopeName string) ObjAction {
-	return &objAction{
-		f: func(obj client.Object) {
-			if x, ok := obj.(*cloudcontrolv1beta1.NfsInstance); ok {
-				x.Spec.Scope.Name = scopeName
-				return
-			}
-			panic("unhandled type in WithNfsInstanceScope")
-		},
-	}
-}
-
-func WithRemoteRef(name string) ObjAction {
-	remoteRef := &cloudcontrolv1beta1.RemoteRef{
-		Name:      name,
-		Namespace: DefaultSkrNamespace,
-	}
-	return &objAction{
-		f: func(obj client.Object) {
-			if x, ok := obj.(*cloudcontrolv1beta1.NfsInstance); ok {
-				x.Spec.RemoteRef = *remoteRef
-				return
-			}
-			panic("unhandled type in WithNfsInstanceScope")
 		},
 	}
 }

--- a/pkg/testinfra/dsl/nfsInstance.go
+++ b/pkg/testinfra/dsl/nfsInstance.go
@@ -57,18 +57,6 @@ func WithNfsInstanceGcp(location string) ObjAction {
 	}
 }
 
-func WithNfsInstanceIpRange(ipRangeName string) ObjAction {
-	return &objAction{
-		f: func(obj client.Object) {
-			if x, ok := obj.(*cloudcontrolv1beta1.NfsInstance); ok {
-				x.Spec.IpRange.Name = ipRangeName
-				return
-			}
-			panic("unhandled type in WithNfsInstanceIpRange")
-		},
-	}
-}
-
 func CreateNfsInstance(ctx context.Context, clnt client.Client, obj *cloudcontrolv1beta1.NfsInstance, opts ...ObjAction) error {
 	if obj == nil {
 		obj = &cloudcontrolv1beta1.NfsInstance{}

--- a/pkg/testinfra/dsl/redisInstance.go
+++ b/pkg/testinfra/dsl/redisInstance.go
@@ -1,6 +1,10 @@
 package dsl
 
 import (
+	"context"
+	"errors"
+	"fmt"
+
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -31,6 +35,83 @@ func WithRedisInstanceAuthString(authString string) ObjStatusAction {
 			if redisInstance, ok := obj.(*cloudcontrolv1beta1.RedisInstance); ok {
 				redisInstance.Status.AuthString = authString
 			}
+		},
+	}
+}
+
+func HavingRedisInstanceStatusId() ObjAssertion {
+	return func(obj client.Object) error {
+		x, ok := obj.(*cloudcontrolv1beta1.RedisInstance)
+		if !ok {
+			return fmt.Errorf("the object %T is not KCP RedisInstance", obj)
+		}
+		if x.Status.Id == "" {
+			return errors.New("the KCP RedisInstance .status.id not set")
+		}
+		return nil
+	}
+}
+
+func CreateRedisInstance(ctx context.Context, clnt client.Client, obj *cloudcontrolv1beta1.RedisInstance, opts ...ObjAction) error {
+	if obj == nil {
+		obj = &cloudcontrolv1beta1.RedisInstance{}
+	}
+	NewObjActions(opts...).
+		Append(
+			WithNamespace(DefaultKcpNamespace),
+		).
+		ApplyOnObject(obj)
+
+	if obj.Name == "" {
+		return errors.New("the KCP RedisInstance must have name set")
+	}
+
+	err := clnt.Create(ctx, obj)
+	return err
+}
+
+func WithRedisInstanceGcp() ObjAction {
+	return &objAction{
+		f: func(obj client.Object) {
+			if x, ok := obj.(*cloudcontrolv1beta1.RedisInstance); ok {
+				x.Spec.Instance.Gcp = &cloudcontrolv1beta1.RedisInstanceGcp{}
+			}
+		},
+	}
+}
+
+func WithKcpGcpRedisInstanceTier(tier string) ObjAction {
+	return &objAction{
+		f: func(obj client.Object) {
+			if gcpRedisInstance, ok := obj.(*cloudcontrolv1beta1.RedisInstance); ok {
+				gcpRedisInstance.Spec.Instance.Gcp.Tier = tier
+				return
+			}
+			panic(fmt.Errorf("unhandled type %T in WithKcpGcpRedisInstanceTier", obj))
+		},
+	}
+}
+
+func WithKcpGcpRedisInstanceMemorySizeGb(memorySizeGb int32) ObjAction {
+	return &objAction{
+		f: func(obj client.Object) {
+			if gcpRedisInstance, ok := obj.(*cloudcontrolv1beta1.RedisInstance); ok {
+				gcpRedisInstance.Spec.Instance.Gcp.MemorySizeGb = memorySizeGb
+				return
+			}
+			panic(fmt.Errorf("unhandled type %T in WithKcpGcpRedisInstanceMemorySizeGb", obj))
+		},
+	}
+}
+
+func WithKcpGcpRedisInstanceRedisVersion(redisVersion string) ObjAction {
+	return &objAction{
+		f: func(obj client.Object) {
+			if gcpRedisInstance, ok := obj.(*cloudcontrolv1beta1.RedisInstance); ok {
+				gcpRedisInstance.Spec.Instance.Gcp.RedisVersion = redisVersion
+				return
+			}
+			panic(fmt.Errorf("unhandled type %T in WithKcpGcpRedisInstanceRedisVersion", obj))
 		},
 	}
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- add scenario test for KCP RedisInstance
- move `.status.id` update in KCP RedisInstance reconciler from `updateStatus` action to `updateStatusId` action that happens before GCP MemoryStore Redis instance is ready
- use common newly intorduced `WithIpRange` `ObjAction` in NfsInstance test

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
