### PR TITLE
feat(GcpRedisInstance): swap gcp redis instance name prefix to 'cm'

### DIFF
--- a/pkg/kcp/provider/gcp/mock/memoryStoreClientFake.go
+++ b/pkg/kcp/provider/gcp/mock/memoryStoreClientFake.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	redis "cloud.google.com/go/redis/apiv1"
@@ -39,7 +38,7 @@ func (memoryStoreClientFake *memoryStoreClientFake) CreateRedisInstance(ctx cont
 	memoryStoreClientFake.mutex.Lock()
 	defer memoryStoreClientFake.mutex.Unlock()
 
-	name := fmt.Sprintf("projects/%s/locations/%s/%s", projectId, locationId, instanceId)
+	name := memoryStoreClient.GetGcpMemoryStoreRedisName(projectId, locationId, instanceId)
 	redisInstance := &redispb.Instance{
 		Name:             name,
 		State:            redispb.Instance_CREATING,
@@ -50,16 +49,6 @@ func (memoryStoreClientFake *memoryStoreClientFake) CreateRedisInstance(ctx cont
 	}
 	memoryStoreClientFake.redisInstances[name] = redisInstance
 
-	// go func() {
-	// 	time.Sleep(1 * time.Second)
-	// 	memoryStoreClientFake.mutex.Lock()
-	// 	defer memoryStoreClientFake.mutex.Unlock()
-
-	// 	if instance, ok := memoryStoreClientFake.redisInstances[name]; ok {
-	// 		instance.State = redispb.Instance_READY
-	// 	}
-	// }()
-
 	return &redis.CreateInstanceOperation{}, nil // redis.CreateInstanceOperation is not used in actual code, so empty object is returned
 }
 
@@ -67,19 +56,11 @@ func (memoryStoreClientFake *memoryStoreClientFake) DeleteRedisInstance(ctx cont
 	memoryStoreClientFake.mutex.Lock()
 	defer memoryStoreClientFake.mutex.Unlock()
 
-	name := fmt.Sprintf("projects/%s/locations/%s/%s", projectId, locationId, instanceId)
+	name := memoryStoreClient.GetGcpMemoryStoreRedisName(projectId, locationId, instanceId)
 
 	if instance, ok := memoryStoreClientFake.redisInstances[name]; ok {
 		instance.State = redispb.Instance_DELETING
 	}
-
-	// go func() {
-	// 	time.Sleep(1 * time.Second)
-	// 	memoryStoreClientFake.mutex.Lock()
-	// 	defer memoryStoreClientFake.mutex.Unlock()
-
-	// 	delete(memoryStoreClientFake.redisInstances, name)
-	// }()
 
 	return nil
 }
@@ -88,7 +69,7 @@ func (memoryStoreClientFake *memoryStoreClientFake) GetRedisInstance(ctx context
 	memoryStoreClientFake.mutex.Lock()
 	defer memoryStoreClientFake.mutex.Unlock()
 
-	name := fmt.Sprintf("projects/%s/locations/%s/%s", projectId, locationId, instanceId)
+	name := memoryStoreClient.GetGcpMemoryStoreRedisName(projectId, locationId, instanceId)
 
 	instance := memoryStoreClientFake.redisInstances[name]
 

--- a/pkg/kcp/provider/gcp/redisinstance/client/memorystoreClient.go
+++ b/pkg/kcp/provider/gcp/redisinstance/client/memorystoreClient.go
@@ -53,9 +53,9 @@ func (memorystoreClient *memorystoreClient) CreateRedisInstance(ctx context.Cont
 	parent := fmt.Sprintf("projects/%s/locations/%s", projectId, locationId)
 	req := &redispb.CreateInstanceRequest{
 		Parent:     parent,
-		InstanceId: instanceId,
+		InstanceId: GetGcpMemoryStoreRedisInstanceId(instanceId),
 		Instance: &redispb.Instance{
-			Name:                  fmt.Sprintf("%s/%s", parent, instanceId),
+			Name:                  GetGcpMemoryStoreRedisName(projectId, locationId, instanceId),
 			MemorySizeGb:          options.MemorySizeGb,
 			Tier:                  redispb.Instance_Tier(redispb.Instance_Tier_value[options.Tier]),
 			RedisVersion:          options.RedisVersion,
@@ -86,7 +86,7 @@ func (memorystoreClient *memorystoreClient) GetRedisInstance(ctx context.Context
 	}
 	defer redisClient.Close()
 
-	name := fmt.Sprintf("projects/%s/locations/%s/instances/%s", projectId, locationId, instanceId)
+	name := GetGcpMemoryStoreRedisName(projectId, locationId, instanceId)
 	req := &redispb.GetInstanceRequest{
 		Name: name,
 	}
@@ -119,9 +119,8 @@ func (memorystoreClient *memorystoreClient) DeleteRedisInstance(ctx context.Cont
 	}
 	defer redisClient.Close()
 
-	name := fmt.Sprintf("projects/%s/locations/%s/instances/%s", projectId, locationId, instanceId)
 	req := &redispb.DeleteInstanceRequest{
-		Name: name,
+		Name: GetGcpMemoryStoreRedisName(projectId, locationId, instanceId),
 	}
 
 	_, err := redisClient.DeleteInstance(ctx, req)

--- a/pkg/kcp/provider/gcp/redisinstance/client/util.go
+++ b/pkg/kcp/provider/gcp/redisinstance/client/util.go
@@ -1,0 +1,11 @@
+package client
+
+import "fmt"
+
+func GetGcpMemoryStoreRedisName(projectId, locationId, instanceId string) string {
+	return fmt.Sprintf("projects/%s/locations/%s/instances/%s", projectId, locationId, GetGcpMemoryStoreRedisInstanceId(instanceId))
+}
+
+func GetGcpMemoryStoreRedisInstanceId(instanceId string) string {
+	return fmt.Sprintf("cm-%s", instanceId)
+}

--- a/pkg/skr/gcpredisinstance/updateId.go
+++ b/pkg/skr/gcpredisinstance/updateId.go
@@ -2,7 +2,6 @@ package gcpredisinstance
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/google/uuid"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
@@ -22,7 +21,7 @@ func updateId(ctx context.Context, st composed.State) (error, context.Context) {
 		return nil, nil
 	}
 
-	id := fmt.Sprintf("r-%s", uuid.NewString())
+	id := uuid.NewString()
 
 	state.ObjAsGcpRedisInstance().Status.Id = id
 	state.ObjAsGcpRedisInstance().Status.State = cloudresourcesv1beta1.StateProcessing


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- redis instance id in gcp memorystore is prefixed with `cm-` instead of `r-`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
