### PR TITLE
chore: feature from unstructured crd and busola cm

### DIFF
--- a/api/cloud-resources/v1beta1/nfsbackupschedule_types.go
+++ b/api/cloud-resources/v1beta1/nfsbackupschedule_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	featuretypes "github.com/kyma-project/cloud-manager/pkg/feature/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -104,6 +105,14 @@ type NfsBackupSchedule struct {
 
 	Spec   NfsBackupScheduleSpec   `json:"spec,omitempty"`
 	Status NfsBackupScheduleStatus `json:"status,omitempty"`
+}
+
+func (in *NfsBackupSchedule) SpecificToProviders() []string {
+	return nil
+}
+
+func (in *NfsBackupSchedule) SpecificToFeature() featuretypes.FeatureName {
+	return featuretypes.FeatureNfsBackup
 }
 
 //+kubebuilder:object:root=true

--- a/pkg/feature/object2feature.go
+++ b/pkg/feature/object2feature.go
@@ -1,75 +1,31 @@
 package feature
 
 import (
-	"context"
 	"github.com/kyma-project/cloud-manager/pkg/feature/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-/*
-All feature determination implementation in this file is used only in case
-object does not implement types.FeatureAwareObject interface
-*/
-
-type featureDeterminator func(mi *manifestInfo) (bool, types.FeatureName)
-
-type manifestInfo struct {
-	obj             client.Object
-	name            string
-	namespace       string
-	objKindGroup    string
-	labels          map[string]string
-	annotations     map[string]string
-	crdKindGroup    string
-	busolaKindGroup string
-}
-
-var featureDeterminators = []featureDeterminator{
-	featureDeterminatorByKindGroup,
-	featureDeterminatorByCrdKindGroup,
-	featureDeterminatorByBusolaKindGroup,
-}
-
-var featuresByKindGroup = map[string]types.FeatureName{
-	// Please respect the order of the filenames in config/crd/bases
-	// and list items here in the same order as files in that dir are.
-
-	// KCP ==============================================================
-	// scope has no feature defined
-	"scope.cloud-control.kyma-project.io": "",
-	// iprange atm is for nfs feature only, but in the future other features might include it as well,
-	// so we will define iprange feature from start as undefined
-	"iprange.cloud-control.kyma-project.io":     "",
-	"nfsinstance.cloud-control.kyma-project.io": types.FeatureNfs,
-	"vpcpeering.cloud-control.kyma-project.io":  types.FeaturePeering,
-
-	// SKR ==============================================================
-
-	"awsnfsvolumebackup.cloud-resources.kyma-project.io": types.FeatureNfsBackup,
-	"awsnfsvolume.cloud-resources.kyma-project.io":       types.FeatureNfs,
-	// cloudresouces module CR has no feature
-	"cloudresouces.cloud-control.kyma-project.io":         "",
-	"gcpnfsvolumebackup.cloud-resources.kyma-project.io":  types.FeatureNfsBackup,
-	"gcpnfsvolumerestore.cloud-resources.kyma-project.io": types.FeatureNfsBackup,
-	"gcpnfsvolume.cloud-resources.kyma-project.io":        types.FeatureNfs,
-	// iprange has no feature, see comment from KCP about it
-	"iprange.cloud-resources.kyma-project.io": "",
-}
-
-func featureDeterminatorByKindGroup(mi *manifestInfo) (bool, types.FeatureName) {
-	f, ok := featuresByKindGroup[mi.objKindGroup]
-	return ok, f
-}
-
-func featureDeterminatorByCrdKindGroup(mi *manifestInfo) (bool, types.FeatureName) {
-	f, ok := featuresByKindGroup[mi.crdKindGroup]
-	return ok, f
-}
-
-func featureDeterminatorByBusolaKindGroup(mi *manifestInfo) (bool, types.FeatureName) {
-	f, ok := featuresByKindGroup[mi.busolaKindGroup]
-	return ok, f
+func tryFeatureAwareOnGK(gk schema.GroupKind, scheme *runtime.Scheme) (types.FeatureName, bool) {
+	versions := scheme.VersionsForGroupKind(schema.GroupKind{
+		Group: gk.Group,
+		Kind:  gk.Kind,
+	})
+	for _, version := range versions {
+		x, err := scheme.New(schema.GroupVersionKind{
+			Group:   version.Group,
+			Version: version.Version,
+			Kind:    gk.Kind,
+		})
+		if err == nil {
+			if fa, ok := x.(types.FeatureAwareObject); ok {
+				return fa.SpecificToFeature(), true
+			}
+		}
+	}
+	return "", false
 }
 
 // ObjectToFeature returns FeatureName specific to the object. It can return empty string
@@ -81,38 +37,29 @@ func ObjectToFeature(obj client.Object, scheme *runtime.Scheme) types.FeatureNam
 	if fa, ok := obj.(types.FeatureAwareObject); ok {
 		return fa.SpecificToFeature()
 	}
-	return objectToFeaturePredetermined(obj, scheme)
-}
 
-func objectToFeaturePredetermined(obj client.Object, scheme *runtime.Scheme) types.FeatureName {
-	ffCtx := ContextBuilderFromCtx(context.Background()).
-		KindsFromObject(obj, scheme).
-		FFCtx()
-
-	intfToString := func(x interface{}) string {
-		if x == nil {
-			return ""
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		x, err := scheme.New(u.GroupVersionKind())
+		if err == nil {
+			if ufa, ok := x.(types.FeatureAwareObject); ok {
+				return ufa.SpecificToFeature()
+			}
 		}
-		return x.(string)
 	}
 
-	mi := &manifestInfo{
-		obj:             obj,
-		name:            obj.GetName(),
-		namespace:       obj.GetNamespace(),
-		objKindGroup:    intfToString(ffCtx.GetCustom()[types.KeyObjKindGroup]),
-		labels:          obj.GetLabels(),
-		annotations:     obj.GetAnnotations(),
-		crdKindGroup:    intfToString(ffCtx.GetCustom()[types.KeyCrdKindGroup]),
-		busolaKindGroup: intfToString(ffCtx.GetCustom()[types.KeyBusolaKindGroup]),
-	}
+	kindInfo := ObjectKinds(obj, scheme)
 
-	for _, det := range featureDeterminators {
-		ok, f := det(mi)
-		if ok {
+	if kindInfo.CrdOK {
+		if f, ok := tryFeatureAwareOnGK(kindInfo.CrdGK, scheme); ok {
 			return f
 		}
 	}
 
-	return ""
+	if kindInfo.BusolaOK {
+		if f, ok := tryFeatureAwareOnGK(kindInfo.BusolaGK, scheme); ok {
+			return f
+		}
+	}
+
+	return types.FeatureUnknown
 }

--- a/pkg/feature/objectKinds.go
+++ b/pkg/feature/objectKinds.go
@@ -1,0 +1,87 @@
+package feature
+
+import (
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"strings"
+)
+
+type ObjectKindsInfo struct {
+	ObjOK    bool
+	ObjGK    schema.GroupKind
+	CrdOK    bool
+	CrdGK    schema.GroupKind
+	BusolaOK bool
+	BusolaGK schema.GroupKind
+}
+
+func ObjectKinds(obj client.Object, scheme *runtime.Scheme) (result ObjectKindsInfo) {
+	result.ObjGK = obj.GetObjectKind().GroupVersionKind().GroupKind()
+	if result.ObjGK.Kind == "" {
+		gvk, err := apiutil.GVKForObject(obj, scheme)
+		if err != nil {
+			return
+		}
+		result.ObjGK = gvk.GroupKind()
+	}
+	result.ObjOK = true
+
+	kg := strings.ToLower(result.ObjGK.String())
+	if kg == "customresourcedefinition.apiextensions.k8s.io" {
+		if u, ok := obj.(*unstructured.Unstructured); ok {
+			crdGroup, groupFound, groupErr := unstructured.NestedString(u.Object, "spec", "group")
+			crdKind, kindFound, kindErr := unstructured.NestedString(u.Object, "spec", "names", "kind")
+			if groupFound && kindFound && groupErr == nil && kindErr == nil {
+				result.CrdGK.Group = crdGroup
+				result.CrdGK.Kind = crdKind
+				result.CrdOK = true
+			}
+		}
+		if crd, ok := obj.(*apiextensions.CustomResourceDefinition); ok {
+			crdGroup := crd.Spec.Group
+			crdKind := crd.Spec.Names.Kind
+			result.CrdGK.Group = crdGroup
+			result.CrdGK.Kind = crdKind
+			result.CrdOK = true
+		}
+	}
+
+	if kg == "configmap" &&
+		obj.GetLabels() != nil && obj.GetLabels()["busola.io/extension"] != "" {
+
+		var general string
+		if cm, ok := obj.(*unstructured.Unstructured); ok {
+			gen, found, err := unstructured.NestedString(cm.Object, "data", "general")
+			if found && err == nil {
+				general = gen
+			}
+		}
+		if cm, ok := obj.(*corev1.ConfigMap); ok {
+			gen, found := cm.Data["general"]
+			if found {
+				general = gen
+			}
+		}
+
+		if len(general) > 0 {
+			obj := map[string]interface{}{}
+			if err := yaml.Unmarshal([]byte(general), &obj); err == nil {
+				cmGroup, groupFound, groupErr := unstructured.NestedString(obj, "resource", "group")
+				cmKind, kindFound, kindErr := unstructured.NestedString(obj, "resource", "kind")
+				if groupFound && kindFound && groupErr == nil && kindErr == nil {
+					result.BusolaGK.Group = cmGroup
+					result.BusolaGK.Kind = cmKind
+					result.BusolaOK = true
+				}
+			}
+		}
+	}
+
+	return
+}

--- a/pkg/feature/objectKinds_test.go
+++ b/pkg/feature/objectKinds_test.go
@@ -1,0 +1,184 @@
+package feature
+
+import (
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/feature/types"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"regexp"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+var schemeIgnoreRegex *regexp.Regexp
+
+func init() {
+	schemeIgnoreRegex = regexp.MustCompile("^CreateOptions|GetOptions|ListOptions|WatchOptions|PatchOptions|DeleteOptions|UpdateOptions|WatchEvent.*|.*List$")
+}
+
+func TestCloudResourcesObjectsImplementFeatureAwareObject(t *testing.T) {
+	skrScheme := runtime.NewScheme()
+	utilruntime.Must(scheme.AddToScheme(skrScheme))
+	utilruntime.Must(cloudresourcesv1beta1.AddToScheme(skrScheme))
+	utilruntime.Must(apiextensions.AddToScheme(skrScheme))
+
+	for gvk := range skrScheme.AllKnownTypes() {
+		if gvk.Group == cloudresourcesv1beta1.GroupVersion.Group {
+			if schemeIgnoreRegex.Match([]byte(gvk.Kind)) {
+				continue
+			}
+
+			t.Run(gvk.Kind, func(t *testing.T) {
+				obj, err := skrScheme.New(gvk)
+				assert.NoError(t, err)
+				assert.Implements(t, (*types.FeatureAwareObject)(nil), obj, "does not implement FeatureAwareObject")
+			})
+		}
+	}
+}
+
+func TestCloudResourcesObjectsImplementProviderAwareObject(t *testing.T) {
+	skrScheme := runtime.NewScheme()
+	utilruntime.Must(scheme.AddToScheme(skrScheme))
+	utilruntime.Must(cloudresourcesv1beta1.AddToScheme(skrScheme))
+	utilruntime.Must(apiextensions.AddToScheme(skrScheme))
+
+	for gvk := range skrScheme.AllKnownTypes() {
+		if gvk.Group == cloudresourcesv1beta1.GroupVersion.Group {
+			if schemeIgnoreRegex.Match([]byte(gvk.Kind)) {
+				continue
+			}
+
+			t.Run(gvk.Kind, func(t *testing.T) {
+				obj, err := skrScheme.New(gvk)
+				assert.NoError(t, err)
+				assert.Implements(t, (*types.ProviderAwareObject)(nil), obj, "does not implement ProviderAwareObject")
+			})
+		}
+	}
+}
+
+func TestObjectGroupVersionInfo(t *testing.T) {
+	skrScheme := runtime.NewScheme()
+	utilruntime.Must(scheme.AddToScheme(skrScheme))
+	utilruntime.Must(cloudresourcesv1beta1.AddToScheme(skrScheme))
+	utilruntime.Must(apiextensions.AddToScheme(skrScheme))
+
+	baseCrdTyped := &apiextensions.CustomResourceDefinition{}
+
+	gCrd := "apiextensions.k8s.io"
+	kCrd := "CustomResourceDefinition"
+	baseCrdUnstructured := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	baseCrdUnstructured.SetAPIVersion(gCrd + "/v1")
+	baseCrdUnstructured.SetKind(kCrd)
+
+	gCm := ""
+	kCm := "ConfigMap"
+
+	g := cloudresourcesv1beta1.GroupVersion.Group
+	v := cloudresourcesv1beta1.GroupVersion.Version
+
+	objList := []struct {
+		title    string
+		obj      client.Object
+		objGK    schema.GroupKind
+		crdGK    schema.GroupKind
+		busolaGK schema.GroupKind
+	}{
+		{"typed AwsNfsVolume", &cloudresourcesv1beta1.AwsNfsVolume{}, schema.GroupKind{Group: g, Kind: "AwsNfsVolume"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"typed AwsNfsVolumeBackup", &cloudresourcesv1beta1.AwsNfsVolumeBackup{}, schema.GroupKind{Group: g, Kind: "AwsNfsVolumeBackup"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"typed AwsVpcPeering", &cloudresourcesv1beta1.AwsVpcPeering{}, schema.GroupKind{Group: g, Kind: "AwsVpcPeering"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"typed AzureVpcPeering", &cloudresourcesv1beta1.AzureVpcPeering{}, schema.GroupKind{Group: g, Kind: "AzureVpcPeering"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"typed CloudResources", &cloudresourcesv1beta1.CloudResources{}, schema.GroupKind{Group: g, Kind: "CloudResources"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"typed GcpNfsVolumeBackup", &cloudresourcesv1beta1.GcpNfsVolumeBackup{}, schema.GroupKind{Group: g, Kind: "GcpNfsVolumeBackup"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"typed GcpNfsVolumeRestore", &cloudresourcesv1beta1.GcpNfsVolumeRestore{}, schema.GroupKind{Group: g, Kind: "GcpNfsVolumeRestore"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"typed GcpNfsVolume", &cloudresourcesv1beta1.GcpNfsVolume{}, schema.GroupKind{Group: g, Kind: "GcpNfsVolume"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"typed GcpRedisInstance", &cloudresourcesv1beta1.GcpRedisInstance{}, schema.GroupKind{Group: g, Kind: "GcpRedisInstance"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"typed GcpVpcPeering", &cloudresourcesv1beta1.GcpVpcPeering{}, schema.GroupKind{Group: g, Kind: "GcpVpcPeering"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"typed IpRange", &cloudresourcesv1beta1.IpRange{}, schema.GroupKind{Group: g, Kind: "IpRange"}, schema.GroupKind{}, schema.GroupKind{}},
+
+		{"unstructured AwsNfsVolume", newUnstructuredWithGVK(g, v, "AwsNfsVolume"), schema.GroupKind{Group: g, Kind: "AwsNfsVolume"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"unstructured AwsNfsVolumeBackup", newUnstructuredWithGVK(g, v, "AwsNfsVolumeBackup"), schema.GroupKind{Group: g, Kind: "AwsNfsVolumeBackup"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"unstructured AwsVpcPeering", newUnstructuredWithGVK(g, v, "AwsVpcPeering"), schema.GroupKind{Group: g, Kind: "AwsVpcPeering"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"unstructured AzureVpcPeering", newUnstructuredWithGVK(g, v, "AzureVpcPeering"), schema.GroupKind{Group: g, Kind: "AzureVpcPeering"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"unstructured CloudResources", newUnstructuredWithGVK(g, v, "CloudResources"), schema.GroupKind{Group: g, Kind: "CloudResources"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"unstructured GcpNfsVolumeBackup", newUnstructuredWithGVK(g, v, "GcpNfsVolumeBackup"), schema.GroupKind{Group: g, Kind: "GcpNfsVolumeBackup"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"unstructured GcpNfsVolumeRestore", newUnstructuredWithGVK(g, v, "GcpNfsVolumeRestore"), schema.GroupKind{Group: g, Kind: "GcpNfsVolumeRestore"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"unstructured GcpNfsVolume", newUnstructuredWithGVK(g, v, "GcpNfsVolume"), schema.GroupKind{Group: g, Kind: "GcpNfsVolume"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"unstructured GcpRedisInstance", newUnstructuredWithGVK(g, v, "GcpRedisInstance"), schema.GroupKind{Group: g, Kind: "GcpRedisInstance"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"unstructured GcpVpcPeering", newUnstructuredWithGVK(g, v, "GcpVpcPeering"), schema.GroupKind{Group: g, Kind: "GcpVpcPeering"}, schema.GroupKind{}, schema.GroupKind{}},
+		{"unstructured IpRange", newUnstructuredWithGVK(g, v, "IpRange"), schema.GroupKind{Group: g, Kind: "IpRange"}, schema.GroupKind{}, schema.GroupKind{}},
+
+		{"crdTyped AwsNfsVolume", crdTypedWithKindGroup(t, baseCrdTyped, "AwsNfsVolume", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "AwsNfsVolume"}, schema.GroupKind{}},
+		{"crdTyped AwsNfsVolumeBackup", crdTypedWithKindGroup(t, baseCrdTyped, "AwsNfsVolumeBackup", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "AwsNfsVolumeBackup"}, schema.GroupKind{}},
+		{"crdTyped AwsVpcPeering", crdTypedWithKindGroup(t, baseCrdTyped, "AwsVpcPeering", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "AwsVpcPeering"}, schema.GroupKind{}},
+		{"crdTyped AzureVpcPeering", crdTypedWithKindGroup(t, baseCrdTyped, "AzureVpcPeering", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "AzureVpcPeering"}, schema.GroupKind{}},
+		{"crdTyped CloudResources", crdTypedWithKindGroup(t, baseCrdTyped, "CloudResources", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "CloudResources"}, schema.GroupKind{}},
+		{"crdTyped GcpNfsVolumeBackup", crdTypedWithKindGroup(t, baseCrdTyped, "GcpNfsVolumeBackup", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "GcpNfsVolumeBackup"}, schema.GroupKind{}},
+		{"crdTyped GcpNfsVolumeRestore", crdTypedWithKindGroup(t, baseCrdTyped, "GcpNfsVolumeRestore", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "GcpNfsVolumeRestore"}, schema.GroupKind{}},
+		{"crdTyped GcpNfsVolume", crdTypedWithKindGroup(t, baseCrdTyped, "GcpNfsVolume", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "GcpNfsVolume"}, schema.GroupKind{}},
+		{"crdTyped GcpRedisInstance", crdTypedWithKindGroup(t, baseCrdTyped, "GcpRedisInstance", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "GcpRedisInstance"}, schema.GroupKind{}},
+		{"crdTyped GcpVpcPeering", crdTypedWithKindGroup(t, baseCrdTyped, "GcpVpcPeering", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "GcpVpcPeering"}, schema.GroupKind{}},
+		{"crdTyped IpRange", crdTypedWithKindGroup(t, baseCrdTyped, "IpRange", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "IpRange"}, schema.GroupKind{}},
+
+		{"crdUnstructured AwsNfsVolume", crdUnstructuredWithKindGroup(t, baseCrdUnstructured, "AwsNfsVolume", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "AwsNfsVolume"}, schema.GroupKind{}},
+		{"crdUnstructured AwsNfsVolumeBackup", crdUnstructuredWithKindGroup(t, baseCrdUnstructured, "AwsNfsVolumeBackup", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "AwsNfsVolumeBackup"}, schema.GroupKind{}},
+		{"crdUnstructured AwsVpcPeering", crdUnstructuredWithKindGroup(t, baseCrdUnstructured, "AwsVpcPeering", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "AwsVpcPeering"}, schema.GroupKind{}},
+		{"crdUnstructured AzureVpcPeering", crdUnstructuredWithKindGroup(t, baseCrdUnstructured, "AzureVpcPeering", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "AzureVpcPeering"}, schema.GroupKind{}},
+		{"crdUnstructured CloudResources", crdUnstructuredWithKindGroup(t, baseCrdUnstructured, "CloudResources", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "CloudResources"}, schema.GroupKind{}},
+		{"crdUnstructured GcpNfsVolumeBackup", crdUnstructuredWithKindGroup(t, baseCrdUnstructured, "GcpNfsVolumeBackup", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "GcpNfsVolumeBackup"}, schema.GroupKind{}},
+		{"crdUnstructured GcpNfsVolumeRestore", crdUnstructuredWithKindGroup(t, baseCrdUnstructured, "GcpNfsVolumeRestore", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "GcpNfsVolumeRestore"}, schema.GroupKind{}},
+		{"crdUnstructured GcpNfsVolume", crdUnstructuredWithKindGroup(t, baseCrdUnstructured, "GcpNfsVolume", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "GcpNfsVolume"}, schema.GroupKind{}},
+		{"crdUnstructured GcpRedisInstance", crdUnstructuredWithKindGroup(t, baseCrdUnstructured, "GcpRedisInstance", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "GcpRedisInstance"}, schema.GroupKind{}},
+		{"crdUnstructured GcpVpcPeering", crdUnstructuredWithKindGroup(t, baseCrdUnstructured, "GcpVpcPeering", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "GcpVpcPeering"}, schema.GroupKind{}},
+		{"crdUnstructured IpRange", crdUnstructuredWithKindGroup(t, baseCrdUnstructured, "IpRange", g), schema.GroupKind{Group: gCrd, Kind: kCrd}, schema.GroupKind{Group: g, Kind: "IpRange"}, schema.GroupKind{}},
+
+		{"busolaTyped AwsNfsVolume", busolaCmTypedKindGroup(t, "AwsNfsVolume"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "AwsNfsVolume"}},
+		{"busolaTyped AwsNfsVolumeBackup", busolaCmTypedKindGroup(t, "AwsNfsVolumeBackup"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "AwsNfsVolumeBackup"}},
+		{"busolaTyped AwsVpcPeering", busolaCmTypedKindGroup(t, "AwsVpcPeering"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "AwsVpcPeering"}},
+		{"busolaTyped AzureVpcPeering", busolaCmTypedKindGroup(t, "AzureVpcPeering"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "AzureVpcPeering"}},
+		{"busolaTyped CloudResources", busolaCmTypedKindGroup(t, "CloudResources"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "CloudResources"}},
+		{"busolaTyped GcpNfsVolumeBackup", busolaCmTypedKindGroup(t, "GcpNfsVolumeBackup"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "GcpNfsVolumeBackup"}},
+		{"busolaTyped GcpNfsVolumeRestore", busolaCmTypedKindGroup(t, "GcpNfsVolumeRestore"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "GcpNfsVolumeRestore"}},
+		{"busolaTyped GcpNfsVolume", busolaCmTypedKindGroup(t, "GcpNfsVolume"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "GcpNfsVolume"}},
+		{"busolaTyped GcpRedisInstance", busolaCmTypedKindGroup(t, "GcpRedisInstance"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "GcpRedisInstance"}},
+		{"busolaTyped GcpVpcPeering", busolaCmTypedKindGroup(t, "GcpVpcPeering"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "GcpVpcPeering"}},
+		{"busolaTyped IpRange", busolaCmTypedKindGroup(t, "IpRange"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "IpRange"}},
+
+		{"busolaUnstructured AwsNfsVolume", busolaCmUnstructuredKindGroup(t, "AwsNfsVolume"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "AwsNfsVolume"}},
+		{"busolaUnstructured AwsNfsVolumeBackup", busolaCmUnstructuredKindGroup(t, "AwsNfsVolumeBackup"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "AwsNfsVolumeBackup"}},
+		{"busolaUnstructured AwsVpcPeering", busolaCmUnstructuredKindGroup(t, "AwsVpcPeering"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "AwsVpcPeering"}},
+		{"busolaUnstructured AzureVpcPeering", busolaCmUnstructuredKindGroup(t, "AzureVpcPeering"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "AzureVpcPeering"}},
+		{"busolaUnstructured CloudResources", busolaCmUnstructuredKindGroup(t, "CloudResources"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "CloudResources"}},
+		{"busolaUnstructured GcpNfsVolumeBackup", busolaCmUnstructuredKindGroup(t, "GcpNfsVolumeBackup"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "GcpNfsVolumeBackup"}},
+		{"busolaUnstructured GcpNfsVolumeRestore", busolaCmUnstructuredKindGroup(t, "GcpNfsVolumeRestore"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "GcpNfsVolumeRestore"}},
+		{"busolaUnstructured GcpNfsVolume", busolaCmUnstructuredKindGroup(t, "GcpNfsVolume"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "GcpNfsVolume"}},
+		{"busolaUnstructured GcpRedisInstance", busolaCmUnstructuredKindGroup(t, "GcpRedisInstance"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "GcpRedisInstance"}},
+		{"busolaUnstructured GcpVpcPeering", busolaCmUnstructuredKindGroup(t, "GcpVpcPeering"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "GcpVpcPeering"}},
+		{"busolaUnstructured IpRange", busolaCmUnstructuredKindGroup(t, "IpRange"), schema.GroupKind{Group: gCm, Kind: kCm}, schema.GroupKind{}, schema.GroupKind{Group: g, Kind: "IpRange"}},
+	}
+
+	for _, expected := range objList {
+		t.Run(expected.title, func(t *testing.T) {
+			actual := ObjectKinds(expected.obj, skrScheme)
+			assert.Equal(t, expected.objGK.String(), actual.ObjGK.String(), "unexpected ObjGK")
+			assert.Equal(t, expected.crdGK.String(), actual.CrdGK.String(), "unexpected CrdGK")
+			assert.Equal(t, expected.busolaGK.String(), actual.BusolaGK.String(), "unexpected BusolaGK")
+			if len(expected.crdGK.Kind) == 0 {
+				assert.False(t, actual.CrdOK, "unexpected CrdOK")
+			} else {
+				assert.True(t, actual.CrdOK, "unexpected CrdOK")
+			}
+			if len(expected.busolaGK.Kind) == 0 {
+				assert.False(t, actual.BusolaOK, "unexpected BusolaOK")
+			} else {
+				assert.True(t, actual.BusolaOK, "unexpected BusolaOK")
+			}
+		})
+	}
+}

--- a/pkg/feature/types/types.go
+++ b/pkg/feature/types/types.go
@@ -26,6 +26,8 @@ const (
 type FeatureName = string
 
 const (
+	FeatureUnknown FeatureName = "unknown"
+
 	FeatureNfs       FeatureName = "nfs"
 	FeatureNfsBackup FeatureName = "nfsBackup"
 	FeaturePeering   FeatureName = "peering"
@@ -64,10 +66,14 @@ type Feature[T any] interface {
 
 type FeatureAwareObject interface {
 	client.Object
+	// SpecificToFeature returns FeatureName this resource belongs too. If not specific to certain feature
+	// it should return empty string
 	SpecificToFeature() FeatureName
 }
 
 type ProviderAwareObject interface {
 	client.Object
+	// SpecificToProviders returns slice of supported providers as defined in the Shoot resource
+	// if not specific to certain providers and can work with all providers it should return nil
 	SpecificToProviders() []string
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- added universal `ObjectKinds()` to find obj, crd and busola kind - extracted from `ContextBuilder.KindsFromObject()`
- modified `ContextBuilder.KindsFromObject()` to use new `ObjectKinds()`
- added in `ObjectToFeature()` feature  extraction from unstructured crd and busola cm and switched kinds detection to added `ObjectKinds()`
- added unit tests for feature detection on unstrctured crd and busola cm
- added unit tests to check if all cloud-resources resources implement `FeatureAwareObject` and `ProviderAwareObject`
- removed deprecated `objectToFeaturePredetermined()` that was detecting feature based on hard coded maps

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
