### PR TITLE
fix(AwsRedisInstance): prefix resources with '-cm'

### DIFF
--- a/pkg/kcp/provider/aws/redisinstance/createElastiCacheCluster.go
+++ b/pkg/kcp/provider/aws/redisinstance/createElastiCacheCluster.go
@@ -49,7 +49,7 @@ func createElastiCacheCluster(ctx context.Context, st composed.State) (error, co
 			Value: ptr.To(state.Scope().Spec.ShootName),
 		},
 	}, client.CreateElastiCacheClusterOptions{
-		Name:            state.Obj().GetName(),
+		Name:            GetAwsElastiCacheClusterName(state.Obj().GetName()),
 		SubnetGroupName: ptr.Deref(state.subnetGroup.CacheSubnetGroupName, ""),
 	})
 

--- a/pkg/kcp/provider/aws/redisinstance/createSubnetGroup.go
+++ b/pkg/kcp/provider/aws/redisinstance/createSubnetGroup.go
@@ -26,7 +26,7 @@ func createSubnetGroup(ctx context.Context, st composed.State) (error, context.C
 		return subnet.Id
 	})
 
-	out, err := state.awsClient.CreateElastiCacheSubnetGroup(ctx, state.Obj().GetName(), subnetIds, []elasticacheTypes.Tag{
+	out, err := state.awsClient.CreateElastiCacheSubnetGroup(ctx, GetAwsElastiCacheSubnetGroupName(state.Obj().GetName()), subnetIds, []elasticacheTypes.Tag{
 		{
 			Key:   ptr.To(common.TagCloudManagerRemoteName),
 			Value: ptr.To(redisInstance.Spec.RemoteRef.String()),

--- a/pkg/kcp/provider/aws/redisinstance/loadElastiCacheCluster.go
+++ b/pkg/kcp/provider/aws/redisinstance/loadElastiCacheCluster.go
@@ -16,7 +16,7 @@ func loadElastiCacheCluster(ctx context.Context, st composed.State) (error, cont
 
 	logger := composed.LoggerFromCtx(ctx)
 
-	list, err := state.awsClient.DescribeElastiCacheCluster(ctx, state.Obj().GetName())
+	list, err := state.awsClient.DescribeElastiCacheCluster(ctx, GetAwsElastiCacheClusterName(state.Obj().GetName()))
 	if err != nil {
 		return awsmeta.LogErrorAndReturn(err, "Error listing elasticache clusters", ctx)
 	}

--- a/pkg/kcp/provider/aws/redisinstance/loadSubnetGroup.go
+++ b/pkg/kcp/provider/aws/redisinstance/loadSubnetGroup.go
@@ -16,7 +16,7 @@ func loadSubnetGroup(ctx context.Context, st composed.State) (error, context.Con
 
 	logger := composed.LoggerFromCtx(ctx)
 
-	list, err := state.awsClient.DescribeElastiCacheSubnetGroup(ctx, state.Obj().GetName())
+	list, err := state.awsClient.DescribeElastiCacheSubnetGroup(ctx, GetAwsElastiCacheSubnetGroupName(state.Obj().GetName()))
 	if err != nil {
 		return awsmeta.LogErrorAndReturn(err, "Error listing subnet groups", ctx)
 	}

--- a/pkg/kcp/provider/aws/redisinstance/util.go
+++ b/pkg/kcp/provider/aws/redisinstance/util.go
@@ -1,0 +1,11 @@
+package redisinstance
+
+import "fmt"
+
+func GetAwsElastiCacheSubnetGroupName(name string) string {
+	return fmt.Sprintf("cm-%s", name)
+}
+
+func GetAwsElastiCacheClusterName(name string) string {
+	return fmt.Sprintf("cm-%s", name)
+}

--- a/pkg/skr/awsredisinstance/waitKcpRedisInstanceDeleted.go
+++ b/pkg/skr/awsredisinstance/waitKcpRedisInstanceDeleted.go
@@ -39,6 +39,6 @@ func waitKcpRedisInstanceDeleted(ctx context.Context, st composed.State) (error,
 			Run(ctx, state)
 	}
 
-	logger.Info("Waiting for Kcp NfsInstance to be deleted")
+	logger.Info("Waiting for Kcp RedisInstance to be deleted")
 	return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 }

--- a/pkg/skr/gcpredisinstance/loadKcpRedisInstance.go
+++ b/pkg/skr/gcpredisinstance/loadKcpRedisInstance.go
@@ -23,11 +23,11 @@ func loadKcpRedisInstance(ctx context.Context, st composed.State) (error, contex
 		)
 	}
 
-	kcpNfsInstnace := &cloudcontrolv1beta1.RedisInstance{}
+	kcpRedisInstnace := &cloudcontrolv1beta1.RedisInstance{}
 	err := state.KcpCluster.K8sClient().Get(ctx, types.NamespacedName{
 		Namespace: state.KymaRef.Namespace,
 		Name:      state.ObjAsGcpRedisInstance().Status.Id,
-	}, kcpNfsInstnace)
+	}, kcpRedisInstnace)
 	if apierrors.IsNotFound(err) {
 		state.KcpRedisInstance = nil
 		logger.Info("KCP RedisInstance does not exist")
@@ -37,7 +37,7 @@ func loadKcpRedisInstance(ctx context.Context, st composed.State) (error, contex
 		return composed.LogErrorAndReturn(err, "Error loading KCP RedisInstance", composed.StopWithRequeue, ctx)
 	}
 
-	state.KcpRedisInstance = kcpNfsInstnace
+	state.KcpRedisInstance = kcpRedisInstnace
 
 	return nil, nil
 }

--- a/pkg/skr/gcpredisinstance/reconciler.go
+++ b/pkg/skr/gcpredisinstance/reconciler.go
@@ -43,7 +43,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 func (r *reconciler) newAction() composed.Action {
 	return composed.ComposeActions(
 		"gcpRedisInstance",
-		feature.LoadFeatureContextFromObj(&cloudresourcesv1beta1.AwsNfsVolume{}),
+		feature.LoadFeatureContextFromObj(&cloudresourcesv1beta1.GcpRedisInstance{}),
 		composed.LoadObj,
 
 		defaultiprange.New(),

--- a/pkg/skr/gcpredisinstance/waitKcpRedisInstanceDeleted.go
+++ b/pkg/skr/gcpredisinstance/waitKcpRedisInstanceDeleted.go
@@ -18,7 +18,7 @@ func waitKcpRedisInstanceDeleted(ctx context.Context, st composed.State) (error,
 	gcpRedisInstance := state.ObjAsGcpRedisInstance()
 
 	if state.KcpRedisInstance == nil {
-		logger.Info("Kcp NfsInstance is deleted")
+		logger.Info("Kcp RedisInstance is deleted")
 		return nil, nil
 	}
 
@@ -39,6 +39,6 @@ func waitKcpRedisInstanceDeleted(ctx context.Context, st composed.State) (error,
 			Run(ctx, state)
 	}
 
-	logger.Info("Waiting for Kcp NfsInstance to be deleted")
+	logger.Info("Waiting for Kcp RedisInstance to be deleted")
 	return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Prefix AwsRedisInstance cloud provider resources with `cm-` to be compliant with their name requirement
- Refactor some logs

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
