### PR TITLE
fix(IpRange): change GCP IpRange naming strategy

### DIFF
--- a/api/cloud-control/v1beta1/iprange_types.go
+++ b/api/cloud-control/v1beta1/iprange_types.go
@@ -153,7 +153,7 @@ func (in IpRangeSubnets) SubnetByZone(zone string) *IpRangeSubnet {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="Cidr",type="string",JSONPath=".spec.cidr"
+// +kubebuilder:printcolumn:name="Cidr",type="string",JSONPath=".status.cidr"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
 
 // IpRange is the Schema for the ipranges API

--- a/api/cloud-control/v1beta1/iprange_types.go
+++ b/api/cloud-control/v1beta1/iprange_types.go
@@ -118,6 +118,10 @@ type IpRangeStatus struct {
 	// Operation Identifier to track the Hyperscaler Operation
 	// +optional
 	OpIdentifier string `json:"opIdentifier,omitempty"`
+
+	// Id to track the Hyperscaler IpRange identifier
+	// +optional
+	Id string `json:"id,omitempty"`
 }
 
 type IpRangeSubnets []IpRangeSubnet

--- a/api/cloud-control/v1beta1/iprange_types.go
+++ b/api/cloud-control/v1beta1/iprange_types.go
@@ -152,6 +152,9 @@ func (in IpRangeSubnets) SubnetByZone(zone string) *IpRangeSubnet {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Cidr",type="string",JSONPath=".spec.cidr"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
 
 // IpRange is the Schema for the ipranges API
 type IpRange struct {

--- a/config/crd/bases/cloud-control.kyma-project.io_ipranges.yaml
+++ b/config/crd/bases/cloud-control.kyma-project.io_ipranges.yaml
@@ -18,7 +18,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .spec.cidr
+    - jsonPath: .status.cidr
       name: Cidr
       type: string
     - jsonPath: .status.state

--- a/config/crd/bases/cloud-control.kyma-project.io_ipranges.yaml
+++ b/config/crd/bases/cloud-control.kyma-project.io_ipranges.yaml
@@ -163,6 +163,9 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              id:
+                description: Id to track the Hyperscaler IpRange identifier
+                type: string
               opIdentifier:
                 description: Operation Identifier to track the Hyperscaler Operation
                 type: string

--- a/config/crd/bases/cloud-control.kyma-project.io_ipranges.yaml
+++ b/config/crd/bases/cloud-control.kyma-project.io_ipranges.yaml
@@ -14,7 +14,17 @@ spec:
     singular: iprange
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.cidr
+      name: Cidr
+      type: string
+    - jsonPath: .status.state
+      name: State
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: IpRange is the Schema for the ipranges API

--- a/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_ipranges.yaml
+++ b/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_ipranges.yaml
@@ -18,7 +18,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .spec.cidr
+    - jsonPath: .status.cidr
       name: Cidr
       type: string
     - jsonPath: .status.state

--- a/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_ipranges.yaml
+++ b/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_ipranges.yaml
@@ -163,6 +163,9 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              id:
+                description: Id to track the Hyperscaler IpRange identifier
+                type: string
               opIdentifier:
                 description: Operation Identifier to track the Hyperscaler Operation
                 type: string

--- a/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_ipranges.yaml
+++ b/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_ipranges.yaml
@@ -14,7 +14,17 @@ spec:
     singular: iprange
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.cidr
+      name: Cidr
+      type: string
+    - jsonPath: .status.state
+      name: State
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: IpRange is the Schema for the ipranges API

--- a/pkg/kcp/provider/gcp/iprange/v2/compareStates_test.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/compareStates_test.go
@@ -87,7 +87,7 @@ func (suite *compareStatesSuite) TestWhenDeletingAndAddressExistsAndNoConnection
 	//Set Address
 	address := &compute.Address{
 		Address: ipAddr,
-		Name:    gcpIpRange.Spec.RemoteRef.Name,
+		Name:    GetIpRangeName(gcpIpRange.Name),
 	}
 	state.address = address
 
@@ -130,7 +130,7 @@ func (suite *compareStatesSuite) TestWhenDeletingAndNoAddressExistsAndConnection
 
 	//Set Connection
 	connection := &servicenetworking.Connection{
-		ReservedPeeringRanges: []string{ipRange.Spec.RemoteRef.Name},
+		ReservedPeeringRanges: []string{GetIpRangeName(ipRange.Name)},
 	}
 	state.serviceConnection = connection
 
@@ -140,10 +140,10 @@ func (suite *compareStatesSuite) TestWhenDeletingAndNoAddressExistsAndConnection
 	assert.Nil(suite.T(), resCtx)
 
 	//Validate state attributes
-	assert.Equal(suite.T(), client.DeletePsaConnection, state.curState)
-	assert.Equal(suite.T(), client.DELETE, state.connectionOp)
+	assert.Equal(suite.T(), client.Deleted, state.curState)
+	assert.Equal(suite.T(), client.NONE, state.connectionOp)
 	assert.Equal(suite.T(), client.NONE, state.addressOp)
-	assert.False(suite.T(), state.inSync)
+	assert.True(suite.T(), state.inSync)
 }
 
 func (suite *compareStatesSuite) TestWhenDeletingAndBothAddressAndConnectionExists() {
@@ -174,13 +174,13 @@ func (suite *compareStatesSuite) TestWhenDeletingAndBothAddressAndConnectionExis
 	//Set Address
 	address := &compute.Address{
 		Address: ipAddr,
-		Name:    gcpIpRange.Spec.RemoteRef.Name,
+		Name:    GetIpRangeName(gcpIpRange.Name),
 	}
 	state.address = address
 
 	//Set Connection
 	connection := &servicenetworking.Connection{
-		ReservedPeeringRanges: []string{ipRange.Spec.RemoteRef.Name, "test"},
+		ReservedPeeringRanges: []string{GetIpRangeName(ipRange.Name), "test"},
 	}
 	state.serviceConnection = connection
 
@@ -225,7 +225,7 @@ func (suite *compareStatesSuite) TestWhenNotDeleting_NoAddressOrConnectionExists
 
 	//Validate state attributes
 	assert.Equal(suite.T(), client.SyncAddress, state.curState)
-	assert.Equal(suite.T(), client.ADD, state.connectionOp)
+	assert.Equal(suite.T(), client.NONE, state.connectionOp)
 	assert.Equal(suite.T(), client.ADD, state.addressOp)
 	assert.False(suite.T(), state.inSync)
 }
@@ -256,7 +256,7 @@ func (suite *compareStatesSuite) TestWhenNotDeleting_AddressExistsAndNoConnectio
 	address := &compute.Address{
 		Address:      ipAddr,
 		PrefixLength: int64(prefix),
-		Name:         gcpIpRange.Spec.RemoteRef.Name,
+		Name:         GetIpRangeName(gcpIpRange.Name),
 		Network:      state.Scope().Spec.Scope.Gcp.VpcNetwork,
 	}
 	state.address = address
@@ -301,7 +301,7 @@ func (suite *compareStatesSuite) TestWhenNotDeleting_AddressNotMatches() {
 	address := &compute.Address{
 		Address:      ipAddr,
 		PrefixLength: int64(prefix),
-		Name:         gcpIpRange.Spec.RemoteRef.Name,
+		Name:         GetIpRangeName(gcpIpRange.Name),
 	}
 	state.address = address
 	state.ipAddress = ipAddr
@@ -345,7 +345,7 @@ func (suite *compareStatesSuite) TestWhenNotDeleting_AddressExistsAndConnectionN
 	address := &compute.Address{
 		Address:      ipAddr,
 		PrefixLength: int64(prefix),
-		Name:         gcpIpRange.Spec.RemoteRef.Name,
+		Name:         GetIpRangeName(gcpIpRange.Name),
 		Network:      state.Scope().Spec.Scope.Gcp.VpcNetwork,
 	}
 	state.address = address
@@ -396,7 +396,7 @@ func (suite *compareStatesSuite) TestWhenNotDeleting_BothAddressAndConnectionExi
 	address := &compute.Address{
 		Address:      ipAddr,
 		PrefixLength: int64(prefix),
-		Name:         gcpIpRange.Spec.RemoteRef.Name,
+		Name:         GetIpRangeName(gcpIpRange.Name),
 		Network:      state.Scope().Spec.Scope.Gcp.VpcNetwork,
 	}
 	state.address = address
@@ -405,7 +405,7 @@ func (suite *compareStatesSuite) TestWhenNotDeleting_BothAddressAndConnectionExi
 
 	//Set Connection
 	connection := &servicenetworking.Connection{
-		ReservedPeeringRanges: []string{gcpIpRange.Spec.RemoteRef.Name},
+		ReservedPeeringRanges: []string{GetIpRangeName(gcpIpRange.Name)},
 	}
 	state.serviceConnection = connection
 

--- a/pkg/kcp/provider/gcp/iprange/v2/loadAddress.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/loadAddress.go
@@ -29,7 +29,7 @@ func loadAddress(ctx context.Context, st composed.State) (error, context.Context
 	if gcpmeta.IsNotFound(err) {
 		// fallback to old name (backwards compatibility)
 		logger.Info("New IpRange not found, checking the old name")
-		fallbackAddr, err2 := state.computeClient.GetIpRange(ctx, project, name)
+		fallbackAddr, err2 := state.computeClient.GetIpRange(ctx, project, ipRange.GetName())
 
 		if gcpmeta.IsNotFound(err2) {
 			logger.Info("Fallback IpRange name not found, proceeding")

--- a/pkg/kcp/provider/gcp/iprange/v2/loadAddress.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/loadAddress.go
@@ -23,7 +23,7 @@ func loadAddress(ctx context.Context, st composed.State) (error, context.Context
 	project := gcpScope.Project
 	vpcName := gcpScope.VpcNetwork
 	remoteName := GetIpRangeName(ipRange.GetName())
-	remoteFallbackName := ipRange.GetName()
+	remoteFallbackName := ipRange.Spec.RemoteRef.Name
 	logger = logger.WithValues(
 		"ipRange", ipRange.Name,
 		"ipRangeRemoteName", remoteName,

--- a/pkg/kcp/provider/gcp/iprange/v2/loadAddress.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/loadAddress.go
@@ -30,7 +30,7 @@ func loadAddress(ctx context.Context, st composed.State) (error, context.Context
 		"ipRangeRemoteFallbackName", remoteFallbackName,
 	)
 
-	logger.Info("Loading GCP Address")
+	logger.Info("Loading GCP Address (V2)")
 
 	addr, err := state.computeClient.GetIpRange(ctx, project, remoteName)
 

--- a/pkg/kcp/provider/gcp/iprange/v2/loadAddress_test.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/loadAddress_test.go
@@ -2,227 +2,279 @@ package v2
 
 import (
 	"context"
-	"encoding/json"
-	"github.com/go-logr/logr"
-	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
-	"github.com/kyma-project/cloud-manager/pkg/composed"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
-	"google.golang.org/api/compute/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/http"
-	"net/http/httptest"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
+	"errors"
+	"fmt"
+	"sync"
 	"testing"
+
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/common/actions/focal"
+	composed "github.com/kyma-project/cloud-manager/pkg/composed"
+	ipRangeClient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/iprange/client"
+	spy "github.com/kyma-project/cloud-manager/pkg/testinfra/clientspy"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-type loadAddressSuite struct {
-	suite.Suite
-	ctx context.Context
+type testState struct {
+	focal.State
 }
 
-func (suite *loadAddressSuite) SetupTest() {
-	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+func (s *testState) ObjAsIpRange() *cloudcontrolv1beta1.IpRange {
+	return s.Obj().(*cloudcontrolv1beta1.IpRange)
 }
 
-func (suite *loadAddressSuite) TestWhenNotFound() {
-	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodGet:
-			if strings.HasSuffix(r.URL.Path, getUrlCompute) {
-				//Return 404
-				http.Error(w, "Not Found", http.StatusNotFound)
-			} else {
-				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
-			}
-		default:
-			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
-		}
-	}))
-	defer fakeHttpServer.Close()
-
-	factory, err := newTestStateFactory(fakeHttpServer)
-	assert.Nil(suite.T(), err)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	//Get state object with ipRange
-	ipRange := gcpIpRange.DeepCopy()
-
-	state, err := factory.newStateWith(ctx, ipRange)
-	assert.Nil(suite.T(), err)
-
-	//Invoke the function under test
-	err, resCtx := loadAddress(ctx, state)
-	assert.Nil(suite.T(), err)
-	assert.Nil(suite.T(), resCtx)
-
-	//Load updated object
-	err = state.LoadObj(ctx)
-	assert.Nil(suite.T(), err)
-	ipRange = state.ObjAsIpRange()
-
-	// check error condition in status
-	assert.Len(suite.T(), ipRange.Status.Conditions, 0)
+type computeClientStubUtils interface {
+	ReturnOnFirstCall(address *compute.Address, err error)
+	ReturnOnSecondCall(address *compute.Address, err error)
 }
 
-func (suite *loadAddressSuite) TestWhenErrorResponse() {
-	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodGet:
-			if strings.HasSuffix(r.URL.Path, getUrlCompute) {
-				//Return 404
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			} else {
-				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
-			}
-		default:
-			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
-		}
-	}))
-	defer fakeHttpServer.Close()
-
-	factory, err := newTestStateFactory(fakeHttpServer)
-	assert.Nil(suite.T(), err)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	//Get state object with ipRange
-	ipRange := gcpIpRange.DeepCopy()
-
-	state, err := factory.newStateWith(ctx, ipRange)
-	assert.Nil(suite.T(), err)
-
-	//Invoke the function under test
-	err, _ = loadAddress(ctx, state)
-	assert.Equal(suite.T(), composed.StopWithRequeue, err)
-
-	//Load updated object
-	err = state.LoadObj(ctx)
-	assert.Nil(suite.T(), err)
-	ipRange = state.ObjAsIpRange()
-
-	// check error condition in status
-	assert.Equal(suite.T(), v1beta1.ConditionTypeError, ipRange.Status.Conditions[0].Type)
-	assert.Equal(suite.T(), metav1.ConditionTrue, ipRange.Status.Conditions[0].Status)
-	assert.Equal(suite.T(), v1beta1.ReasonGcpError, ipRange.Status.Conditions[0].Reason)
+type computeClientStub struct {
+	firstCallAddress  *compute.Address
+	firstCallErr      error
+	secondCallAddress *compute.Address
+	secondCallErr     error
+	call              int32
+	mutex             *sync.Mutex
 }
 
-func (suite *loadAddressSuite) TestWhenGcpAddressHasWrongVPC() {
-	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var resp *compute.Address
-		switch r.Method {
-		case http.MethodGet:
-			if strings.HasSuffix(r.URL.Path, getUrlCompute) {
-				resp = &compute.Address{
-					Address:      ipAddr,
-					Name:         gcpIpRange.Spec.RemoteRef.Name,
-					Network:      "not-matching-vpc",
-					PrefixLength: int64(prefix),
-				}
-			} else {
-				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
-			}
-		default:
-			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
-		}
-		b, err := json.Marshal(resp)
-		if err != nil {
-			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
-		}
-		_, err = w.Write(b)
-		if err != nil {
-			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
-		}
-	}))
-	defer fakeHttpServer.Close()
-
-	factory, err := newTestStateFactory(fakeHttpServer)
-	assert.Nil(suite.T(), err)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	//Get state object with ipRange
-	ipRange := gcpIpRange.DeepCopy()
-
-	state, err := factory.newStateWith(ctx, ipRange)
-	assert.Nil(suite.T(), err)
-
-	//Invoke the function under test
-	err, _ = loadAddress(ctx, state)
-	assert.Equal(suite.T(), composed.StopWithRequeue, err)
-
-	//Load updated object
-	err = state.LoadObj(ctx)
-	assert.Nil(suite.T(), err)
-	ipRange = state.ObjAsIpRange()
-
-	// check error condition in status
-	assert.Equal(suite.T(), v1beta1.ConditionTypeError, ipRange.Status.Conditions[0].Type)
-	assert.Equal(suite.T(), metav1.ConditionTrue, ipRange.Status.Conditions[0].Status)
-	assert.Equal(suite.T(), v1beta1.ReasonGcpError, ipRange.Status.Conditions[0].Reason)
+func (c *computeClientStub) ReturnOnFirstCall(address *compute.Address, err error) {
+	c.firstCallAddress = address
+	c.firstCallErr = err
 }
 
-func (suite *loadAddressSuite) TestWhenGcpAddressHasCorrectVPC() {
-	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var resp *compute.Address
-		switch r.Method {
-		case http.MethodGet:
-			if strings.HasSuffix(r.URL.Path, getUrlCompute) {
-				resp = &compute.Address{
-					Address:      ipAddr,
-					Name:         gcpIpRange.Spec.RemoteRef.Name,
-					Network:      "test-vpc",
-					PrefixLength: int64(prefix),
-				}
-			} else {
-				assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
-			}
-		default:
-			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
-		}
-		b, err := json.Marshal(resp)
-		if err != nil {
-			assert.Fail(suite.T(), "unable to marshal request: "+err.Error())
-		}
-		_, err = w.Write(b)
-		if err != nil {
-			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
-		}
-	}))
-	defer fakeHttpServer.Close()
+func (c *computeClientStub) ReturnOnSecondCall(address *compute.Address, err error) {
+	c.secondCallAddress = address
+	c.secondCallErr = err
+}
 
-	factory, err := newTestStateFactory(fakeHttpServer)
-	assert.Nil(suite.T(), err)
+func (c *computeClientStub) CreatePscIpRange(ctx context.Context, projectId string, vpcName string, name string, description string, address string, prefixLength int64) (*compute.Operation, error) {
+	panic("unimplemented")
+}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+func (c *computeClientStub) DeleteIpRange(ctx context.Context, projectId string, name string) (*compute.Operation, error) {
+	panic("unimplemented")
+}
 
-	//Get state object with ipRange
-	ipRange := gcpIpRange.DeepCopy()
+func (c *computeClientStub) GetGlobalOperation(ctx context.Context, projectId string, operationName string) (*compute.Operation, error) {
+	panic("unimplemented")
+}
 
-	state, err := factory.newStateWith(ctx, ipRange)
-	assert.Nil(suite.T(), err)
+func (c *computeClientStub) GetIpRange(ctx context.Context, projectId string, name string) (*compute.Address, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 
-	//Invoke the function under test
-	err, resCtx := loadAddress(ctx, state)
-	assert.Nil(suite.T(), err)
-	assert.Nil(suite.T(), resCtx)
+	c.call = c.call + 1
+	if c.call == 1 {
+		return c.firstCallAddress, c.firstCallErr
+	}
+	if c.call == 2 {
+		return c.secondCallAddress, c.secondCallErr
+	}
 
-	//Load updated object
-	err = state.LoadObj(ctx)
-	assert.Nil(suite.T(), err)
-	ipRange = state.ObjAsIpRange()
+	panic("unexpected call")
+}
 
-	// check error condition in status
-	assert.Len(suite.T(), ipRange.Status.Conditions, 0)
-	assert.NotNil(suite.T(), state.address)
+func (c *computeClientStub) ListGlobalAddresses(ctx context.Context, projectId string, vpc string) (*compute.AddressList, error) {
+	panic("unimplemented")
+}
+
+func newComputeClientStub() ipRangeClient.ComputeClient {
+	return &computeClientStub{
+		call:  0,
+		mutex: &sync.Mutex{},
+	}
 }
 
 func TestLoadAddress(t *testing.T) {
-	suite.Run(t, new(loadAddressSuite))
+
+	t.Run("loadAddress", func(t *testing.T) {
+
+		notFoundError := &googleapi.Error{Code: 404}
+		var ipRange *cloudcontrolv1beta1.IpRange
+		var state *State
+		var scope *cloudcontrolv1beta1.Scope
+		var k8sClient client.WithWatch
+		var address *compute.Address
+		var computeClient ipRangeClient.ComputeClient
+
+		createEmptyGcpIpRangeState := func(k8sClient client.WithWatch, gcpNfsVolume *cloudcontrolv1beta1.IpRange) *State {
+			cluster := composed.NewStateCluster(k8sClient, k8sClient, nil, k8sClient.Scheme())
+
+			focalState := focal.NewStateFactory().NewState(
+				composed.NewStateFactory(cluster).NewState(types.NamespacedName{}, gcpNfsVolume),
+			)
+			focalState.SetScope(scope)
+
+			return &State{
+				State:         &testState{State: focalState},
+				computeClient: computeClient,
+			}
+		}
+
+		setupTest := func() {
+			scope = &cloudcontrolv1beta1.Scope{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "gcp-test",
+					Namespace: "kcp-system",
+				},
+				Spec: cloudcontrolv1beta1.ScopeSpec{
+					KymaName:  "8ed7960c-7596-4039-8143-485df5312725",
+					ShootName: "a34d2ac1-81f5-4dd1-9288-9cfac0151c4f",
+					Region:    "us-east-1",
+					Provider:  cloudcontrolv1beta1.ProviderGCP,
+					Scope: cloudcontrolv1beta1.ScopeInfo{
+						Gcp: &cloudcontrolv1beta1.GcpScope{
+							Project:    "non-existant-test-proj",
+							VpcNetwork: "test-vpc",
+						},
+					},
+				},
+			}
+
+			ipRange = &cloudcontrolv1beta1.IpRange{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "3abd9b3c-1125-42e2-9157-72a3758b1b59",
+					Namespace: "kcp-system",
+				},
+				Spec: cloudcontrolv1beta1.IpRangeSpec{
+					RemoteRef: cloudcontrolv1beta1.RemoteRef{
+						Name: "default",
+					},
+					Scope: cloudcontrolv1beta1.ScopeRef{
+						Name: scope.GetName(),
+					},
+				},
+			}
+
+			scheme := runtime.NewScheme()
+			utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+			utilruntime.Must(cloudcontrolv1beta1.AddToScheme(scheme))
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build()
+
+			k8sClient = spy.NewClientSpy(fakeClient)
+
+			computeClient = newComputeClientStub()
+
+			state = createEmptyGcpIpRangeState(k8sClient, ipRange)
+		}
+
+		t.Run("Should: load IpRange (new name)", func(t *testing.T) {
+			setupTest()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			address = &compute.Address{
+				Network: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/networks/%s", scope.Spec.Scope.Gcp.Project, scope.Spec.Scope.Gcp.VpcNetwork),
+			}
+			computeClient.(computeClientStubUtils).ReturnOnFirstCall(address, nil)
+
+			err, res := loadAddress(ctx, state)
+
+			assert.Nil(t, res, "should return nil res")
+			assert.Nil(t, err, "should return nil err")
+			assert.Equal(t, state.address, address)
+		})
+
+		t.Run("Should: fallback and load IpRange with old name", func(t *testing.T) {
+			setupTest()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			address = &compute.Address{
+				Network: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/networks/%s", scope.Spec.Scope.Gcp.Project, scope.Spec.Scope.Gcp.VpcNetwork),
+			}
+			computeClient.(computeClientStubUtils).ReturnOnFirstCall(nil, notFoundError)
+			computeClient.(computeClientStubUtils).ReturnOnSecondCall(address, nil)
+
+			err, res := loadAddress(ctx, state)
+
+			assert.Nil(t, res, "should return nil res")
+			assert.Nil(t, err, "should return nil err")
+			assert.Equal(t, state.address, address)
+		})
+
+		t.Run("Should: skip loaded fallback IpRange if it belongs to other VPC", func(t *testing.T) {
+			setupTest()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			address = &compute.Address{
+				Network: "some-other-network",
+			}
+			computeClient.(computeClientStubUtils).ReturnOnFirstCall(nil, notFoundError)
+			computeClient.(computeClientStubUtils).ReturnOnSecondCall(address, nil)
+
+			err, res := loadAddress(ctx, state)
+
+			assert.Nil(t, res, "should return nil res")
+			assert.Nil(t, err, "should return nil err")
+			assert.Nilf(t, state.address, "address should be unset")
+		})
+
+		t.Run("Should: do nothing if IpRange doesnt exist (new or old name)", func(t *testing.T) {
+			setupTest()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			computeClient.(computeClientStubUtils).ReturnOnFirstCall(nil, notFoundError)
+			computeClient.(computeClientStubUtils).ReturnOnSecondCall(nil, notFoundError)
+
+			err, res := loadAddress(ctx, state)
+
+			assert.Nil(t, res, "should return nil res")
+			assert.Nil(t, err, "should return nil err")
+			assert.Nilf(t, state.address, "address should be unset")
+		})
+
+		t.Run("Should: set error if obtained IpRange (new name) belongs to another VPC", func(t *testing.T) {
+			setupTest()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			address = &compute.Address{
+				Network: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/networks/another-%s", scope.Spec.Scope.Gcp.Project, scope.Spec.Scope.Gcp.VpcNetwork), // note: VPC name is different, but has same suffix
+			}
+			computeClient.(computeClientStubUtils).ReturnOnFirstCall(address, nil)
+
+			err, res := loadAddress(ctx, state)
+
+			assert.NotNil(t, res, "should return non-nil res")
+			assert.NotNil(t, err, "should return non-nil err")
+			assert.Nilf(t, state.address, "address should be unset")
+		})
+
+		t.Run("Should: set error if its unable to get IpRange (new name)", func(t *testing.T) {
+			setupTest()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			computeClient.(computeClientStubUtils).ReturnOnFirstCall(nil, errors.New("Random error"))
+
+			err, res := loadAddress(ctx, state)
+
+			assert.NotNil(t, res, "should return non-nil res")
+			assert.NotNil(t, err, "should return non-nil err")
+			assert.Nilf(t, state.address, "address should be unset")
+		})
+
+		t.Run("Should: set error if its unable to get IpRange (fallback name)", func(t *testing.T) {
+			setupTest()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			computeClient.(computeClientStubUtils).ReturnOnFirstCall(nil, notFoundError)
+			computeClient.(computeClientStubUtils).ReturnOnSecondCall(nil, errors.New("Random error"))
+
+			err, res := loadAddress(ctx, state)
+
+			assert.NotNil(t, res, "should return non-nil res")
+			assert.NotNil(t, err, "should return non-nil err")
+			assert.Nilf(t, state.address, "address should be unset")
+		})
+	})
 }

--- a/pkg/kcp/provider/gcp/iprange/v2/new.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/new.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+
 	"github.com/kyma-project/cloud-manager/pkg/kcp/iprange/types"
 	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,6 +38,7 @@ func New(stateFactory StateFactory) composed.Action {
 			actions.AddFinalizer,
 			checkGcpOperation,
 			loadAddress,
+			updateStatusId,
 			loadPsaConnection,
 			compareStates,
 			updateState,

--- a/pkg/kcp/provider/gcp/iprange/v2/state.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/state.go
@@ -95,10 +95,12 @@ func (s State) doesConnectionIncludeRange() int {
 	if s.serviceConnection == nil {
 		return -1
 	}
+	if s.address == nil {
+		return -1
+	}
 
-	rangeName := s.ObjAsIpRange().Spec.RemoteRef.Name
 	for i, name := range s.serviceConnection.ReservedPeeringRanges {
-		if rangeName == name {
+		if s.address.Name == name {
 			return i
 		}
 	}

--- a/pkg/kcp/provider/gcp/iprange/v2/state_test.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/state_test.go
@@ -161,6 +161,9 @@ var gcpIpRange = cloudcontrolv1beta1.IpRange{
 			},
 		},
 	},
+	Status: cloudcontrolv1beta1.IpRangeStatus{
+		Id: "cm-test-ip-range",
+	},
 }
 
 var gcpScope = &cloudcontrolv1beta1.Scope{

--- a/pkg/kcp/provider/gcp/iprange/v2/state_test.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/state_test.go
@@ -3,6 +3,8 @@ package v2
 import (
 	"context"
 	"fmt"
+	"net/http/httptest"
+
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
 	"github.com/kyma-project/cloud-manager/pkg/common/actions/focal"
@@ -20,7 +22,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
-	"net/http/httptest"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -141,16 +142,14 @@ var gcpIpRange = cloudcontrolv1beta1.IpRange{
 		Name:      "test-ip-range",
 		Namespace: kymaRef.Namespace,
 		Labels: map[string]string{
-			cloudcontrolv1beta1.LabelKymaName:        kymaRef.Name,
-			cloudcontrolv1beta1.LabelRemoteName:      "test-gcp-ip-range",
-			cloudcontrolv1beta1.LabelRemoteNamespace: "test",
+			cloudcontrolv1beta1.LabelKymaName:   kymaRef.Name,
+			cloudcontrolv1beta1.LabelRemoteName: "test-gcp-ip-range",
 		},
 		Finalizers: []string{cloudcontrolv1beta1.FinalizerName},
 	},
 	Spec: cloudcontrolv1beta1.IpRangeSpec{
 		RemoteRef: cloudcontrolv1beta1.RemoteRef{
-			Namespace: "test",
-			Name:      "test-gcp-ip-range",
+			Name: "test-gcp-ip-range",
 		},
 		Scope: cloudcontrolv1beta1.ScopeRef{
 			Name: kymaRef.Name,
@@ -182,7 +181,7 @@ var gcpScope = &cloudcontrolv1beta1.Scope{
 
 var opIdentifier = "/projects/test-project/locations/us-west1/operations/create-operation"
 var urlGlobalAddress = "/projects/test-project/global/addresses"
-var getUrlCompute = fmt.Sprintf("%s/%s", urlGlobalAddress, gcpIpRange.Spec.RemoteRef.Name)
+var getUrlCompute = fmt.Sprintf("%s/%s", urlGlobalAddress, "test-ip-range")
 
 var urlSvcNetworking = "services/servicenetworking.googleapis.com/connections"
 var getUrlSvcNw = fmt.Sprintf("%s/%s", urlSvcNetworking, client.PsaPeeringName)

--- a/pkg/kcp/provider/gcp/iprange/v2/syncAddress.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/syncAddress.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"context"
 	"fmt"
+
 	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -21,18 +22,18 @@ func syncAddress(ctx context.Context, st composed.State) (error, context.Context
 	gcpScope := state.Scope().Spec.Scope.Gcp
 	project := gcpScope.Project
 	vpc := gcpScope.VpcNetwork
-	name := ipRange.Spec.RemoteRef.Name
+	name := GetIpRangeName(ipRange.GetName())
 
 	var operation *compute.Operation
 	var err error
 	switch state.addressOp {
 	case client.ADD:
-		operation, err = state.computeClient.CreatePscIpRange(ctx, project, vpc, name, name, state.ipAddress, int64(state.prefix))
+		operation, err = state.computeClient.CreatePscIpRange(ctx, project, vpc, name, "Kyma cloud-manager IP Range", state.ipAddress, int64(state.prefix))
 	case client.MODIFY:
 		logger.WithValues("ipRange :", ipRange.Name).Info("IpRange update not supported.")
 		return composed.StopAndForget, nil
 	case client.DELETE:
-		operation, err = state.computeClient.DeleteIpRange(ctx, project, name)
+		operation, err = state.computeClient.DeleteIpRange(ctx, project, state.address.Name)
 	default:
 		logger.WithValues("ipRange :", ipRange.Name).Info("Unknown Operation.")
 	}

--- a/pkg/kcp/provider/gcp/iprange/v2/syncAddress_test.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/syncAddress_test.go
@@ -3,6 +3,11 @@ package v2
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
 	"github.com/go-logr/logr"
 	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
@@ -11,11 +16,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/api/compute/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/http"
-	"net/http/httptest"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
-	"testing"
 )
 
 type syncAddressSuite struct {
@@ -185,6 +186,9 @@ func (suite *syncAddressSuite) TestDeleteSuccess() {
 	state, err := factory.newStateWith(ctx, ipRange)
 	assert.Nil(suite.T(), err)
 	state.addressOp = client.DELETE
+	state.address = &compute.Address{
+		Name: "test-ip-range",
+	}
 
 	//Invoke the function under test
 	err, _ = syncAddress(ctx, state)
@@ -235,6 +239,9 @@ func (suite *syncAddressSuite) TestDeleteFailure() {
 	state, err := factory.newStateWith(ctx, ipRange)
 	assert.Nil(suite.T(), err)
 	state.addressOp = client.DELETE
+	state.address = &compute.Address{
+		Name: "test-ip-range",
+	}
 
 	//Invoke the function under test
 	err, _ = syncAddress(ctx, state)

--- a/pkg/kcp/provider/gcp/iprange/v2/updateStatusId.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/updateStatusId.go
@@ -26,7 +26,7 @@ func updateStatusId(ctx context.Context, st composed.State) (error, context.Cont
 		return nil, nil
 	}
 
-	ipRange.Status.Id = state.address.Address
+	ipRange.Status.Id = state.address.Name
 	logger.Info("Updating .status.id with gcp iprange identifier")
 	return composed.UpdateStatus(ipRange).
 		SuccessError(composed.StopWithRequeue).

--- a/pkg/kcp/provider/gcp/iprange/v2/updateStatusId.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/updateStatusId.go
@@ -1,0 +1,34 @@
+package v2
+
+import (
+	"context"
+
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+)
+
+func updateStatusId(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+
+	ipRange := state.ObjAsIpRange()
+	logger := composed.LoggerFromCtx(ctx).WithValues("ipRange", ipRange.Name)
+
+	if composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
+
+	if state.address == nil {
+		logger.Info("Address is not created yet")
+		return nil, nil
+	}
+
+	if ipRange.Status.Id != "" {
+		logger.Info("Field .status.id is already set")
+		return nil, nil
+	}
+
+	ipRange.Status.Id = state.address.Address
+	logger.Info("Updating .status.id with gcp iprange identifier")
+	return composed.UpdateStatus(ipRange).
+		SuccessError(composed.StopWithRequeue).
+		Run(ctx, state)
+}

--- a/pkg/kcp/provider/gcp/iprange/v2/util.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/util.go
@@ -1,0 +1,7 @@
+package v2
+
+import "fmt"
+
+func GetIpRangeName(kcpResourceName string) string {
+	return fmt.Sprintf("cm-%s", kcpResourceName)
+}

--- a/pkg/kcp/provider/gcp/iprange/v2/validateCidr.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/validateCidr.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
@@ -14,7 +15,7 @@ func validateCidr(ctx context.Context, st composed.State) (error, context.Contex
 	logger := composed.LoggerFromCtx(ctx)
 
 	ipRange := state.ObjAsIpRange()
-	logger.WithValues("ipRange :", ipRange.Name).Info("Loading GCP Address")
+	logger.WithValues("ipRange", ipRange.Name).Info("Validating CIDR")
 	if len(ipRange.Status.Cidr) == 0 {
 		return composed.UpdateStatus(ipRange).
 			SetExclusiveConditions(metav1.Condition{

--- a/pkg/kcp/provider/gcp/meta/metadata.go
+++ b/pkg/kcp/provider/gcp/meta/metadata.go
@@ -1,0 +1,22 @@
+package meta
+
+import (
+	"errors"
+
+	"google.golang.org/api/googleapi"
+)
+
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var e *googleapi.Error
+	if ok := errors.As(err, &e); ok {
+		if e.Code == 404 {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/kcp/provider/gcp/nfsinstance/state.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/state.go
@@ -2,6 +2,7 @@ package nfsinstance
 
 import (
 	"context"
+
 	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
 	"github.com/kyma-project/cloud-manager/pkg/kcp/nfsinstance/types"
@@ -100,7 +101,7 @@ func (s State) toInstance() *file.Instance {
 			{
 				Network:         client2.GetVPCPath(project, vpc),
 				ConnectMode:     string(gcpOptions.ConnectMode),
-				ReservedIpRange: s.IpRange().Spec.RemoteRef.Name,
+				ReservedIpRange: s.IpRange().Status.Id,
 			},
 		},
 	}

--- a/pkg/kcp/provider/gcp/redisinstance/createRedis.go
+++ b/pkg/kcp/provider/gcp/redisinstance/createRedis.go
@@ -31,7 +31,7 @@ func createRedis(ctx context.Context, st composed.State) (error, context.Context
 
 	redisInstanceOptions := client.CreateRedisInstanceOptions{
 		VPCNetworkFullName:    vpcNetworkFullName,
-		IPRangeName:           state.IpRange().Spec.RemoteRef.Name,
+		IPRangeName:           state.IpRange().Status.Id,
 		MemorySizeGb:          redisInstance.Spec.Instance.Gcp.MemorySizeGb,
 		Tier:                  redisInstance.Spec.Instance.Gcp.Tier,
 		RedisVersion:          redisInstance.Spec.Instance.Gcp.RedisVersion,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- IpRange that is allocated in GCP is now named by using KCP IpRange resource name (with `cm-` prefix)
- Handle backwards compatibility to still be able to load old name
- When delete range operation is called, name from loaded address is used

Within one GCP project, two different VPC Networks can not have IpRange with same name. This PR should solve the potential conflicts that can occur due to that fact.

**Related issue(s)**
Fixes https://github.com/kyma-project/cloud-manager/issues/372
