### PR TITLE
refactor(GcpRedisInstance, AwsRedisInstance): track secret ownership via parent .status.id label

### DIFF
--- a/api/cloud-resources/v1beta1/labels.go
+++ b/api/cloud-resources/v1beta1/labels.go
@@ -7,6 +7,6 @@ const (
 	LabelNfsVolNS        = "cloud-resources.kyma-project.io/nfsVolumeNamespace"
 	LabelStorageCapacity = "cloud-resources.kyma-project.io/nfsVolumeStorageCapacity"
 
-	LabelRedisInstanceName      = "cloud-resources.kyma-project.io/redisInstanceName"
+	LabelRedisInstanceId        = "cloud-resources.kyma-project.io/redisInstanceUid"
 	LabelRedisInstanceNamespace = "cloud-resources.kyma-project.io/redisInstanceNamespace"
 )

--- a/internal/controller/cloud-resources/awsredisinstance_test.go
+++ b/internal/controller/cloud-resources/awsredisinstance_test.go
@@ -181,6 +181,9 @@ var _ = Describe("Feature: SKR AwsRedisInstance", func() {
 			Expect(authSecret.Labels[util.WellKnownK8sLabelPartOf]).ToNot(BeNil())
 			Expect(authSecret.Labels[util.WellKnownK8sLabelManagedBy]).ToNot(BeNil())
 
+			By("And it has defined ownmership label")
+			Expect(authSecret.Labels[cloudresourcesv1beta1.LabelRedisInstanceId]).To(Equal(awsRedisInstance.Status.Id))
+
 			By("And it has user defined custom labels")
 			for k, v := range authSecretLabels {
 				Expect(authSecret.Labels).To(HaveKeyWithValue(k, v), fmt.Sprintf("expected auth Secret to have label %s=%s", k, v))

--- a/internal/controller/cloud-resources/gcpredisinstance_test.go
+++ b/internal/controller/cloud-resources/gcpredisinstance_test.go
@@ -196,6 +196,9 @@ var _ = Describe("Feature: SKR GcpRedisInstance", func() {
 			Expect(authSecret.Labels[util.WellKnownK8sLabelPartOf]).ToNot(BeNil())
 			Expect(authSecret.Labels[util.WellKnownK8sLabelManagedBy]).ToNot(BeNil())
 
+			By("And it has defined ownmership label")
+			Expect(authSecret.Labels[cloudresourcesv1beta1.LabelRedisInstanceId]).To(Equal(gcpRedisInstance.Status.Id))
+
 			By("And it has user defined custom labels")
 			for k, v := range authSecretLabels {
 				Expect(authSecret.Labels).To(HaveKeyWithValue(k, v), fmt.Sprintf("expected auth Secret to have label %s=%s", k, v))

--- a/pkg/skr/awsredisinstance/deleteAuthSecret.go
+++ b/pkg/skr/awsredisinstance/deleteAuthSecret.go
@@ -26,7 +26,7 @@ func deleteAuthSecret(ctx context.Context, st composed.State) (error, context.Co
 			Type:    cloudresourcesv1beta1.ConditionTypeDeleting,
 			Status:  metav1.ConditionTrue,
 			Reason:  cloudresourcesv1beta1.ConditionReasonDeletingAuthSecret,
-			Message: fmt.Sprintf("Deleting PersistentVolumeClaim %s", state.AuthSecret.Name),
+			Message: fmt.Sprintf("Deleting Auth Secret %s", state.AuthSecret.Name),
 		}).
 		ErrorLogMessage("Error setting ConditionReasonDeletingAuthSecret condition on AwsRedisInstance").
 		SuccessErrorNil().

--- a/pkg/skr/awsredisinstance/loadAuthSecret.go
+++ b/pkg/skr/awsredisinstance/loadAuthSecret.go
@@ -2,6 +2,7 @@ package awsredisinstance
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
@@ -32,6 +33,9 @@ func loadAuthSecret(ctx context.Context, st composed.State) (error, context.Cont
 	if secret.Labels[cloudresourcesv1beta1.LabelRedisInstanceId] != awsRedisInstance.Status.Id {
 		awsRedisInstance.Status.State = cloudresourcesv1beta1.StateError
 		errMsg := fmt.Sprintf("Auth secret %s belongs to another resource", authSecretName)
+		logger := composed.LoggerFromCtx(ctx)
+		logger.Error(errors.New("auth secret error"), errMsg)
+
 		return composed.UpdateStatus(awsRedisInstance).
 			SetCondition(metav1.Condition{
 				Type:    cloudresourcesv1beta1.ConditionTypeError,

--- a/pkg/skr/awsredisinstance/loadAuthSecret.go
+++ b/pkg/skr/awsredisinstance/loadAuthSecret.go
@@ -2,28 +2,51 @@ package awsredisinstance
 
 import (
 	"context"
+	"fmt"
 
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func loadAuthSecret(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
+	awsRedisInstance := state.ObjAsAwsRedisInstance()
 
 	secret := &corev1.Secret{}
+	authSecretName := getAuthSecretName(state.ObjAsAwsRedisInstance())
 	err := state.Cluster().K8sClient().Get(ctx, types.NamespacedName{
 		Namespace: state.Obj().GetNamespace(),
-		Name:      getAuthSecretName(state.ObjAsAwsRedisInstance()),
+		Name:      authSecretName,
 	}, secret)
-	if client.IgnoreNotFound(err) != nil {
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			return nil, nil
+		}
 		return composed.LogErrorAndReturn(err, "Error getting Secret by getAuthSecretName()", composed.StopWithRequeue, ctx)
 	}
 
-	if err == nil {
-		state.AuthSecret = secret
+	if secret.Labels[cloudresourcesv1beta1.LabelRedisInstanceId] != awsRedisInstance.Status.Id {
+		awsRedisInstance.Status.State = cloudresourcesv1beta1.StateError
+		errMsg := fmt.Sprintf("Auth secret %s belongs to another resource", authSecretName)
+		return composed.UpdateStatus(awsRedisInstance).
+			SetCondition(metav1.Condition{
+				Type:    cloudresourcesv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  cloudresourcesv1beta1.ConditionReasonError,
+				Message: errMsg,
+			}).
+			RemoveConditions(cloudresourcesv1beta1.ConditionTypeReady).
+			ErrorLogMessage(errMsg).
+			SuccessLogMsg("Updated and forgot SKR AwsRedisInstance status with Error condition").
+			SuccessError(composed.StopAndForget).
+			Run(ctx, state)
 	}
+
+	state.AuthSecret = secret
 
 	return nil, nil
 }

--- a/pkg/skr/awsredisinstance/util.go
+++ b/pkg/skr/awsredisinstance/util.go
@@ -23,7 +23,7 @@ func getAuthSecretLabels(awsRedis *cloudresourcesv1beta1.AwsRedisInstance) map[s
 		}
 	}
 
-	labelsBuilder.WithCustomLabel(cloudresourcesv1beta1.LabelRedisInstanceName, awsRedis.Name)
+	labelsBuilder.WithCustomLabel(cloudresourcesv1beta1.LabelRedisInstanceId, awsRedis.Status.Id)
 	labelsBuilder.WithCustomLabel(cloudresourcesv1beta1.LabelRedisInstanceNamespace, awsRedis.Namespace)
 	labelsBuilder.WithCustomLabel(cloudresourcesv1beta1.LabelCloudManaged, "true")
 	labelsBuilder.WithCloudManagerDefaults()

--- a/pkg/skr/gcpredisinstance/deleteAuthSecret.go
+++ b/pkg/skr/gcpredisinstance/deleteAuthSecret.go
@@ -26,7 +26,7 @@ func deleteAuthSecret(ctx context.Context, st composed.State) (error, context.Co
 			Type:    cloudresourcesv1beta1.ConditionTypeDeleting,
 			Status:  metav1.ConditionTrue,
 			Reason:  cloudresourcesv1beta1.ConditionReasonDeletingAuthSecret,
-			Message: fmt.Sprintf("Deleting PersistentVolumeClaim %s", state.AuthSecret.Name),
+			Message: fmt.Sprintf("Deleting Auth Secret %s", state.AuthSecret.Name),
 		}).
 		ErrorLogMessage("Error setting ConditionReasonDeletingAuthSecret condition on GcpRedisInstance").
 		SuccessErrorNil().

--- a/pkg/skr/gcpredisinstance/loadAuthSecret.go
+++ b/pkg/skr/gcpredisinstance/loadAuthSecret.go
@@ -2,28 +2,52 @@ package gcpredisinstance
 
 import (
 	"context"
+	"fmt"
 
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func loadAuthSecret(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
+	gcpRedisInstance := state.ObjAsGcpRedisInstance()
 
 	secret := &corev1.Secret{}
+	authSecretName := getAuthSecretName(state.ObjAsGcpRedisInstance())
 	err := state.Cluster().K8sClient().Get(ctx, types.NamespacedName{
 		Namespace: state.Obj().GetNamespace(),
-		Name:      getAuthSecretName(state.ObjAsGcpRedisInstance()),
+		Name:      authSecretName,
 	}, secret)
-	if client.IgnoreNotFound(err) != nil {
+
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			return nil, nil
+		}
 		return composed.LogErrorAndReturn(err, "Error getting Secret by getAuthSecretName()", composed.StopWithRequeue, ctx)
 	}
 
-	if err == nil {
-		state.AuthSecret = secret
+	if secret.Labels[cloudresourcesv1beta1.LabelRedisInstanceId] != gcpRedisInstance.Status.Id {
+		gcpRedisInstance.Status.State = cloudresourcesv1beta1.StateError
+		errMsg := fmt.Sprintf("Auth secret %s belongs to another resource", authSecretName)
+		return composed.UpdateStatus(gcpRedisInstance).
+			SetCondition(metav1.Condition{
+				Type:    cloudresourcesv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  cloudresourcesv1beta1.ConditionReasonError,
+				Message: errMsg,
+			}).
+			RemoveConditions(cloudresourcesv1beta1.ConditionTypeReady).
+			ErrorLogMessage(errMsg).
+			SuccessLogMsg("Updated and forgot SKR GcpRedisInstance status with Error condition").
+			SuccessError(composed.StopAndForget).
+			Run(ctx, state)
 	}
+
+	state.AuthSecret = secret
 
 	return nil, nil
 }

--- a/pkg/skr/gcpredisinstance/loadAuthSecret.go
+++ b/pkg/skr/gcpredisinstance/loadAuthSecret.go
@@ -2,6 +2,7 @@ package gcpredisinstance
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
@@ -33,6 +34,8 @@ func loadAuthSecret(ctx context.Context, st composed.State) (error, context.Cont
 	if secret.Labels[cloudresourcesv1beta1.LabelRedisInstanceId] != gcpRedisInstance.Status.Id {
 		gcpRedisInstance.Status.State = cloudresourcesv1beta1.StateError
 		errMsg := fmt.Sprintf("Auth secret %s belongs to another resource", authSecretName)
+		logger := composed.LoggerFromCtx(ctx)
+		logger.Error(errors.New("auth secret error"), errMsg)
 		return composed.UpdateStatus(gcpRedisInstance).
 			SetCondition(metav1.Condition{
 				Type:    cloudresourcesv1beta1.ConditionTypeError,

--- a/pkg/skr/gcpredisinstance/util.go
+++ b/pkg/skr/gcpredisinstance/util.go
@@ -23,7 +23,7 @@ func getAuthSecretLabels(gcpRedis *cloudresourcesv1beta1.GcpRedisInstance) map[s
 		}
 	}
 
-	labelsBuilder.WithCustomLabel(cloudresourcesv1beta1.LabelRedisInstanceName, gcpRedis.Name)
+	labelsBuilder.WithCustomLabel(cloudresourcesv1beta1.LabelRedisInstanceId, gcpRedis.Status.Id)
 	labelsBuilder.WithCustomLabel(cloudresourcesv1beta1.LabelRedisInstanceNamespace, gcpRedis.Namespace)
 	labelsBuilder.WithCustomLabel(cloudresourcesv1beta1.LabelCloudManaged, "true")
 	labelsBuilder.WithCloudManagerDefaults()


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Labels cant hold more than 63 characters, while .metadata.name can be 255. Thats why .status.id is used
- This is a breaking change that is not backwards compatible (but its ok, because redis resource is not GA yet)


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
