### PR TITLE
fix: #382 Google JWT error

### DIFF
--- a/pkg/kcp/provider/gcp/client/provider.go
+++ b/pkg/kcp/provider/gcp/client/provider.go
@@ -114,7 +114,7 @@ func renewCachedHttpClientPeriodically(ctx context.Context, saJsonKeyPath, durat
 				logger.Error(err, "error renewing GCP HTTP client")
 			} else {
 				clientMutex.Lock()
-				gcpClient = client
+				*gcpClient = *client
 				clientMutex.Unlock()
 				logger.Info("GCP HTTP client renewed")
 			}

--- a/pkg/skr/gcpnfsvolume/reconciler.go
+++ b/pkg/skr/gcpnfsvolume/reconciler.go
@@ -2,7 +2,6 @@ package gcpnfsvolume
 
 import (
 	"context"
-
 	"github.com/kyma-project/cloud-manager/pkg/skr/common/defaultiprange"
 
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"

--- a/pkg/skr/gcpnfsvolume/reconciler.go
+++ b/pkg/skr/gcpnfsvolume/reconciler.go
@@ -2,6 +2,7 @@ package gcpnfsvolume
 
 import (
 	"context"
+
 	"github.com/kyma-project/cloud-manager/pkg/skr/common/defaultiprange"
 
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"


### PR DESCRIPTION
**Description**
     Currently, the GCP provider has logic to periodically poll (every 5 minutes) the credential files and create a new httpClient. But the GCP Services still use the httpClient that they were initialized with as they have the reference to the old pointer variable. Fixed it by dereferencing the old pointer and updating it with the new httpClient. 

**Related issue(s)**
https://github.com/kyma-project/cloud-manager/issues/382