### PR TITLE
feat (AzureVpcPeering): adds XValidation rules to RemotePeeringName

### DIFF
--- a/api/cloud-resources/v1beta1/azurevpcpeering_types.go
+++ b/api/cloud-resources/v1beta1/azurevpcpeering_types.go
@@ -29,8 +29,8 @@ type AzureVpcPeeringSpec struct {
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:XValidation:rule=(self == oldSelf), message="RemotePeeringName is immutable."
-	// +kubebuilder:validation:Pattern="^[a-z][a-z0-9\\.-]*[a-z0-9]$"
-	// +kubebuilder:validation:MaxLength=80
+	// +kubebuilder:validation:XValidation:rule=(size(self) <= 80), message="RemotePeeringName can be up to 80 characters long."
+	// +kubebuilder:validation:XValidation:rule=(self.find('^[a-z0-9][a-z0-9-]*[a-z0-9]$') != ''), message="RemotePeeringName must begin with a word character, and it must end with a word character. RemotePeeringName may contain word characters or '-'."
 	RemotePeeringName string `json:"remotePeeringName,omitempty"`
 
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/cloud-resources.kyma-project.io_azurevpcpeerings.yaml
+++ b/config/crd/bases/cloud-resources.kyma-project.io_azurevpcpeerings.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
+    cloud-resources.kyma-project.io/version: v0.0.1
   name: azurevpcpeerings.cloud-resources.kyma-project.io
 spec:
   group: cloud-resources.kyma-project.io
@@ -14,134 +15,102 @@ spec:
     singular: azurevpcpeering
   scope: Cluster
   versions:
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: AzureVpcPeering is the Schema for the azurevpcpeerings API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AzureVpcPeeringSpec defines the desired state of AzureVpcPeering
-            properties:
-              allowVnetAccess:
-                type: boolean
-                x-kubernetes-validations:
-                - message: AllowVnetAccess is immutable.
-                  rule: (self == oldSelf)
-              remotePeeringName:
-                type: string
-                x-kubernetes-validations:
-                - message: RemotePeeringName is immutable.
-                  rule: (self == oldSelf)
-                - message: RemotePeeringName can be up to 80 characters long.
-                  rule: (size(self) <= 80)
-                - message: RemotePeeringName must begin with a word character, and
-                    it must end with a word character. RemotePeeringName may contain
-                    word characters or '-'.
-                  rule: (self.find('^[a-z0-9][a-z0-9-]*[a-z0-9]$') != '')
-              remoteResourceGroup:
-                type: string
-                x-kubernetes-validations:
-                - message: RemoteResourceGroup is immutable.
-                  rule: (self == oldSelf)
-              remoteVnet:
-                type: string
-                x-kubernetes-validations:
-                - message: RemoteVnet is immutable.
-                  rule: (self == oldSelf)
-            type: object
-          status:
-            description: AzureVpcPeeringStatus defines the observed state of AzureVpcPeering
-            properties:
-              conditions:
-                description: List of status conditions to indicate the status of a
-                  Peering.
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              id:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: AzureVpcPeering is the Schema for the azurevpcpeerings API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AzureVpcPeeringSpec defines the desired state of AzureVpcPeering
+              properties:
+                allowVnetAccess:
+                  type: boolean
+                  x-kubernetes-validations:
+                    - message: AllowVnetAccess is immutable.
+                      rule: (self == oldSelf)
+                remotePeeringName:
+                  type: string
+                  x-kubernetes-validations:
+                    - message: RemotePeeringName is immutable.
+                      rule: (self == oldSelf)
+                    - message: RemotePeeringName can be up to 80 characters long.
+                      rule: (size(self) <= 80)
+                    - message: RemotePeeringName must begin with a word character, and it must end with a word character. RemotePeeringName may contain word characters or '-'.
+                      rule: (self.find('^[a-z0-9][a-z0-9-]*[a-z0-9]$') != '')
+                remoteResourceGroup:
+                  type: string
+                  x-kubernetes-validations:
+                    - message: RemoteResourceGroup is immutable.
+                      rule: (self == oldSelf)
+                remoteVnet:
+                  type: string
+                  x-kubernetes-validations:
+                    - message: RemoteVnet is immutable.
+                      rule: (self == oldSelf)
+              type: object
+            status:
+              description: AzureVpcPeeringStatus defines the observed state of AzureVpcPeering
+              properties:
+                conditions:
+                  description: List of status conditions to indicate the status of a Peering.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                id:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/config/crd/bases/cloud-resources.kyma-project.io_azurevpcpeerings.yaml
+++ b/config/crd/bases/cloud-resources.kyma-project.io_azurevpcpeerings.yaml
@@ -40,12 +40,16 @@ spec:
                 - message: AllowVnetAccess is immutable.
                   rule: (self == oldSelf)
               remotePeeringName:
-                maxLength: 80
-                pattern: ^[a-z][a-z0-9\.-]*[a-z0-9]$
                 type: string
                 x-kubernetes-validations:
                 - message: RemotePeeringName is immutable.
                   rule: (self == oldSelf)
+                - message: RemotePeeringName can be up to 80 characters long.
+                  rule: (size(self) <= 80)
+                - message: RemotePeeringName must begin with a word character, and
+                    it must end with a word character. RemotePeeringName may contain
+                    word characters or '-'.
+                  rule: (self.find('^[a-z0-9][a-z0-9-]*[a-z0-9]$') != '')
               remoteResourceGroup:
                 type: string
                 x-kubernetes-validations:

--- a/config/dist/skr/crd/bases/providers/azure/cloud-resources.kyma-project.io_azurevpcpeerings.yaml
+++ b/config/dist/skr/crd/bases/providers/azure/cloud-resources.kyma-project.io_azurevpcpeerings.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
+    cloud-resources.kyma-project.io/version: v0.0.1
   name: azurevpcpeerings.cloud-resources.kyma-project.io
 spec:
   group: cloud-resources.kyma-project.io
@@ -14,134 +15,102 @@ spec:
     singular: azurevpcpeering
   scope: Cluster
   versions:
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: AzureVpcPeering is the Schema for the azurevpcpeerings API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AzureVpcPeeringSpec defines the desired state of AzureVpcPeering
-            properties:
-              allowVnetAccess:
-                type: boolean
-                x-kubernetes-validations:
-                - message: AllowVnetAccess is immutable.
-                  rule: (self == oldSelf)
-              remotePeeringName:
-                type: string
-                x-kubernetes-validations:
-                - message: RemotePeeringName is immutable.
-                  rule: (self == oldSelf)
-                - message: RemotePeeringName can be up to 80 characters long.
-                  rule: (size(self) <= 80)
-                - message: RemotePeeringName must begin with a word character, and
-                    it must end with a word character. RemotePeeringName may contain
-                    word characters or '-'.
-                  rule: (self.find('^[a-z0-9][a-z0-9-]*[a-z0-9]$') != '')
-              remoteResourceGroup:
-                type: string
-                x-kubernetes-validations:
-                - message: RemoteResourceGroup is immutable.
-                  rule: (self == oldSelf)
-              remoteVnet:
-                type: string
-                x-kubernetes-validations:
-                - message: RemoteVnet is immutable.
-                  rule: (self == oldSelf)
-            type: object
-          status:
-            description: AzureVpcPeeringStatus defines the observed state of AzureVpcPeering
-            properties:
-              conditions:
-                description: List of status conditions to indicate the status of a
-                  Peering.
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              id:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: AzureVpcPeering is the Schema for the azurevpcpeerings API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AzureVpcPeeringSpec defines the desired state of AzureVpcPeering
+              properties:
+                allowVnetAccess:
+                  type: boolean
+                  x-kubernetes-validations:
+                    - message: AllowVnetAccess is immutable.
+                      rule: (self == oldSelf)
+                remotePeeringName:
+                  type: string
+                  x-kubernetes-validations:
+                    - message: RemotePeeringName is immutable.
+                      rule: (self == oldSelf)
+                    - message: RemotePeeringName can be up to 80 characters long.
+                      rule: (size(self) <= 80)
+                    - message: RemotePeeringName must begin with a word character, and it must end with a word character. RemotePeeringName may contain word characters or '-'.
+                      rule: (self.find('^[a-z0-9][a-z0-9-]*[a-z0-9]$') != '')
+                remoteResourceGroup:
+                  type: string
+                  x-kubernetes-validations:
+                    - message: RemoteResourceGroup is immutable.
+                      rule: (self == oldSelf)
+                remoteVnet:
+                  type: string
+                  x-kubernetes-validations:
+                    - message: RemoteVnet is immutable.
+                      rule: (self == oldSelf)
+              type: object
+            status:
+              description: AzureVpcPeeringStatus defines the observed state of AzureVpcPeering
+              properties:
+                conditions:
+                  description: List of status conditions to indicate the status of a Peering.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                id:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/config/dist/skr/crd/bases/providers/azure/cloud-resources.kyma-project.io_azurevpcpeerings.yaml
+++ b/config/dist/skr/crd/bases/providers/azure/cloud-resources.kyma-project.io_azurevpcpeerings.yaml
@@ -40,12 +40,16 @@ spec:
                 - message: AllowVnetAccess is immutable.
                   rule: (self == oldSelf)
               remotePeeringName:
-                maxLength: 80
-                pattern: ^[a-z][a-z0-9\.-]*[a-z0-9]$
                 type: string
                 x-kubernetes-validations:
                 - message: RemotePeeringName is immutable.
                   rule: (self == oldSelf)
+                - message: RemotePeeringName can be up to 80 characters long.
+                  rule: (size(self) <= 80)
+                - message: RemotePeeringName must begin with a word character, and
+                    it must end with a word character. RemotePeeringName may contain
+                    word characters or '-'.
+                  rule: (self.find('^[a-z0-9][a-z0-9-]*[a-z0-9]$') != '')
               remoteResourceGroup:
                 type: string
                 x-kubernetes-validations:

--- a/config/patchAfterMakeManifests.sh
+++ b/config/patchAfterMakeManifests.sh
@@ -10,3 +10,4 @@ yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.2
 yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.3"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_awsredisinstances.yaml
 yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.3"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_gcpnfsvolumes.yaml
 yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.2"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_gcpredisinstances.yaml
+yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.1"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_azurevpcpeerings.yaml


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- MaxLength & Pattern Validations moved to XValidation rules
