### PR TITLE
feat(GCPVpcPeering) Changing the kyma network peering to be cm-{metadata.name}

### DIFF
--- a/pkg/kcp/provider/gcp/vpcpeering/createKymaVpcPeering.go
+++ b/pkg/kcp/provider/gcp/vpcpeering/createKymaVpcPeering.go
@@ -55,9 +55,9 @@ func createKymaVpcPeering(ctx context.Context, st composed.State) (error, contex
 			Run(ctx, state)
 	}
 
-	_, err = state.client.CreateKymaVpcPeering(
+	err = state.client.CreateKymaVpcPeering(
 		ctx,
-		state.remotePeeringName,
+		state.getKymaVpcPeeringName(),
 		state.remoteVpc,
 		state.remoteProject,
 		state.importCustomRoutes,

--- a/pkg/kcp/provider/gcp/vpcpeering/createRemoteVpcPeering.go
+++ b/pkg/kcp/provider/gcp/vpcpeering/createRemoteVpcPeering.go
@@ -34,7 +34,7 @@ func createRemoteVpcPeering(ctx context.Context, st composed.State) (error, cont
 	project := gcpScope.Project
 	vpc := gcpScope.VpcNetwork
 
-	_, err := state.client.CreateRemoteVpcPeering(
+	err := state.client.CreateRemoteVpcPeering(
 		ctx,
 		state.remotePeeringName,
 		state.remoteVpc,

--- a/pkg/kcp/provider/gcp/vpcpeering/deleteVpcPeering.go
+++ b/pkg/kcp/provider/gcp/vpcpeering/deleteVpcPeering.go
@@ -17,9 +17,9 @@ func deleteVpcPeering(ctx context.Context, st composed.State) (error, context.Co
 
 	logger.Info("Deleting GCP VPC Peering " + obj.Spec.VpcPeering.Gcp.RemotePeeringName)
 
-	_, err := state.client.DeleteVpcPeering(
+	err := state.client.DeleteVpcPeering(
 		ctx,
-		obj.Spec.VpcPeering.Gcp.RemotePeeringName,
+		state.getKymaVpcPeeringName(),
 		state.Scope().Spec.Scope.Gcp.Project,
 		state.Scope().Spec.Scope.Gcp.VpcNetwork,
 	)

--- a/pkg/kcp/provider/gcp/vpcpeering/loadKymaVpcPeering.go
+++ b/pkg/kcp/provider/gcp/vpcpeering/loadKymaVpcPeering.go
@@ -20,7 +20,9 @@ func loadKymaVpcPeering(ctx context.Context, st composed.State) (error, context.
 
 	logger.Info("Loading VPC Peering")
 
-	kymaVpcPeering, err := state.client.GetVpcPeering(ctx, state.remotePeeringName, state.Scope().Spec.Scope.Gcp.Project, state.Scope().Spec.Scope.Gcp.VpcNetwork)
+	//Using cm- prefix to make it clear it's a cloud manager resource
+	//Using obj name suffix as the peering name since it is unique within the kcp namespace
+	kymaVpcPeering, err := state.client.GetVpcPeering(ctx, state.getKymaVpcPeeringName(), state.Scope().Spec.Scope.Gcp.Project, state.Scope().Spec.Scope.Gcp.VpcNetwork)
 	if err != nil {
 		logger.Error(err, "Error loading Kyma Vpc Peering")
 		meta.SetStatusCondition(state.ObjAsVpcPeering().Conditions(), metav1.Condition{

--- a/pkg/kcp/provider/gcp/vpcpeering/state.go
+++ b/pkg/kcp/provider/gcp/vpcpeering/state.go
@@ -75,3 +75,9 @@ func newState(vpcPeeringState vpcpeeringtypes.State,
 		importCustomRoutes: vpcPeeringState.ObjAsVpcPeering().Spec.VpcPeering.Gcp.ImportCustomRoutes,
 	}
 }
+
+// Using cm- prefix to make it clear it's a cloud manager resource
+// Using obj name suffix as the peering name since it is unique within the kcp namespace
+func (s *State) getKymaVpcPeeringName() string {
+	return "cm-" + s.Obj().GetName()
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- The peering name on the kyma project now has the prefix cm- to identify as a cloud manager resource
- The peering name on the kyma project now has the metadata.name of the CRD as a suffix
