### PR TITLE
feat(GCPVpcPeering) Short shootName on peering challenge

### DIFF
--- a/api/cloud-resources/v1beta1/gcpvpcpeering_types.go
+++ b/api/cloud-resources/v1beta1/gcpvpcpeering_types.go
@@ -24,6 +24,8 @@ type GcpVpcPeeringSpec struct {
 }
 
 type GcpVpcPeeringStatus struct {
+	// +optional
+	Id string `json:"id,omitempty"`
 	// List of status conditions to indicate the Peering status.
 	// +optional
 	// +listType=map

--- a/config/crd/bases/cloud-resources.kyma-project.io_gcpvpcpeerings.yaml
+++ b/config/crd/bases/cloud-resources.kyma-project.io_gcpvpcpeerings.yaml
@@ -133,6 +133,8 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              id:
+                type: string
             type: object
         type: object
     served: true

--- a/config/dist/skr/crd/bases/providers/gcp/cloud-resources.kyma-project.io_gcpvpcpeerings.yaml
+++ b/config/dist/skr/crd/bases/providers/gcp/cloud-resources.kyma-project.io_gcpvpcpeerings.yaml
@@ -133,6 +133,8 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              id:
+                type: string
             type: object
         type: object
     served: true

--- a/pkg/kcp/provider/gcp/vpcpeering/state.go
+++ b/pkg/kcp/provider/gcp/vpcpeering/state.go
@@ -50,7 +50,7 @@ func NewStateFactory(skrProvider gcpclient.ClientProvider[vpcpeeringclient.VpcPe
 func (f *stateFactory) NewState(ctx context.Context, vpcPeeringState vpcpeeringtypes.State, logger logr.Logger) (*State, error) {
 	c, err := f.skrProvider(
 		ctx,
-		f.env.Get("GCP_SA_JSON_KEY_PATH"),
+		f.env.Get(vpcpeeringclient.GcpVpcPeeringPath),
 	)
 
 	if err != nil {

--- a/pkg/skr/gcpvpcpeering/loadKcpGcpVpcPeering.go
+++ b/pkg/skr/gcpvpcpeering/loadKcpGcpVpcPeering.go
@@ -15,7 +15,7 @@ func loadKcpGcpVpcPeering(ctx context.Context, st composed.State) (error, contex
 	kcpVpcPeering := &cloudcontrolv1beta1.VpcPeering{}
 	err := state.KcpCluster.K8sClient().Get(ctx, types.NamespacedName{
 		Namespace: state.KymaRef.Namespace,
-		Name:      state.ObjAsGcpVpcPeering().Name,
+		Name:      state.ObjAsGcpVpcPeering().Status.Id,
 	}, kcpVpcPeering)
 
 	if apierrors.IsNotFound(err) {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Using the short shootName on the peering challenge i.e: abc1234.
- Using another environment variable which will be used to store the auth details of the service account that will execute the peering operations and it won't be the same used by cloud-manager.

