### PR TITLE
fix(GcpNfsVolumeBackup): Fix for GCP Filestore backup naming

### DIFF
--- a/api/cloud-resources/v1beta1/gcpnfsvolumebackup_types.go
+++ b/api/cloud-resources/v1beta1/gcpnfsvolumebackup_types.go
@@ -98,6 +98,9 @@ type GcpNfsVolumeBackupStatus struct {
 	// Operation Identifier to track the Hyperscaler Restore Operation
 	// +optional
 	OpIdentifier string `json:"opIdentifier,omitempty"`
+
+	// +optional
+	Id string `json:"id,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/cloud-resources.kyma-project.io_gcpnfsvolumebackups.yaml
+++ b/config/crd/bases/cloud-resources.kyma-project.io_gcpnfsvolumebackups.yaml
@@ -162,6 +162,8 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              id:
+                type: string
               opIdentifier:
                 description: Operation Identifier to track the Hyperscaler Restore
                   Operation

--- a/config/dist/skr/crd/bases/providers/gcp/cloud-resources.kyma-project.io_gcpnfsvolumebackups.yaml
+++ b/config/dist/skr/crd/bases/providers/gcp/cloud-resources.kyma-project.io_gcpnfsvolumebackups.yaml
@@ -162,6 +162,8 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              id:
+                type: string
               opIdentifier:
                 description: Operation Identifier to track the Hyperscaler Restore
                   Operation

--- a/pkg/skr/gcpnfsvolume/modifyKcpNfsInstance.go
+++ b/pkg/skr/gcpnfsvolume/modifyKcpNfsInstance.go
@@ -3,6 +3,7 @@ package gcpnfsvolume
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
@@ -36,7 +37,8 @@ func createKcpNfsInstance(ctx context.Context, state *State, logger logr.Logger)
 	location, err := getLocation(state, logger)
 	srcBackupFullPath := ""
 	if len(state.ObjAsGcpNfsVolume().Spec.SourceBackup.Name) > 0 {
-		srcBackupFullPath = client.GetFileBackupPath(state.Scope.Spec.Scope.Gcp.Project, state.GcpNfsVolumeBackup.Spec.Location, state.GcpNfsVolumeBackup.Name)
+		backupName := fmt.Sprintf("cm-%.60s", state.GcpNfsVolumeBackup.Status.Id)
+		srcBackupFullPath = client.GetFileBackupPath(state.Scope.Spec.Scope.Gcp.Project, state.GcpNfsVolumeBackup.Spec.Location, backupName)
 	}
 	if err != nil {
 		return composed.UpdateStatus(state.ObjAsGcpNfsVolume()).

--- a/pkg/skr/gcpnfsvolumebackup/createNfsBackup_test.go
+++ b/pkg/skr/gcpnfsvolumebackup/createNfsBackup_test.go
@@ -130,7 +130,7 @@ func (suite *createNfsBackupSuite) TestWhenCreateBackupSuccessful() {
 
 		case http.MethodPost:
 			fmt.Println(r.URL.Path)
-			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups") {
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups") && strings.Contains(r.URL.RawQuery, "backupId=cm-") {
 				//Return 200
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"name":"test-gcp-nfs-volume-backup-operation-id"}`))
@@ -160,7 +160,7 @@ func (suite *createNfsBackupSuite) TestWhenCreateBackupSuccessful() {
 	err, _ctx := createNfsBackup(ctx, state)
 
 	//validate expected return values
-	suite.Nil(err)
+	suite.Equal(composed.StopWithRequeueDelay(state.gcpConfig.GcpRetryWaitTime), err)
 	suite.NotNil(_ctx)
 
 	fromK8s := &v1beta1.GcpNfsVolumeBackup{}

--- a/pkg/skr/gcpnfsvolumebackup/deleteNfsBackup.go
+++ b/pkg/skr/gcpnfsvolumebackup/deleteNfsBackup.go
@@ -30,13 +30,13 @@ func deleteNfsBackup(ctx context.Context, st composed.State) (error, context.Con
 		return nil, nil
 	}
 
-	logger.WithValues("NfsBackup :", backup.Name).Info("Deleting GCP File Backup")
+	logger.WithValues("NfsBackup name", backup.Name, "NfsBackup namespace", backup.Namespace).Info("Deleting GCP File Backup")
 
 	//Get GCP details.
 	gcpScope := state.Scope.Spec.Scope.Gcp
 	project := gcpScope.Project
 	location := backup.Spec.Location
-	name := backup.Name
+	name := fmt.Sprintf("cm-%.60s", backup.Status.Id)
 
 	op, err := state.fileBackupClient.DeleteFileBackup(ctx, project, location, name)
 

--- a/pkg/skr/gcpnfsvolumebackup/deleteNfsBackup_test.go
+++ b/pkg/skr/gcpnfsvolumebackup/deleteNfsBackup_test.go
@@ -80,7 +80,7 @@ func (suite *deleteNfsBackupSuite) TestWhenDeleteBackupReturnsError() {
 
 		case http.MethodDelete:
 			fmt.Println(r.URL.Path)
-			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups/test-gcp-nfs-volume-restore") {
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups/cm-cffd6896-0127-48a1-8a64-e07f6ad5c912") {
 				//Return 500
 				http.Error(w, "Internal error", http.StatusInternalServerError)
 			} else {
@@ -132,7 +132,7 @@ func (suite *deleteNfsBackupSuite) TestWhenDeleteBackupSuccessful() {
 
 		case http.MethodDelete:
 			fmt.Println(r.URL.Path)
-			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups/test-gcp-nfs-volume-restore") {
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups/cm-cffd6896-0127-48a1-8a64-e07f6ad5c912") {
 				//Return 200
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"name":"test-gcp-nfs-volume-backup-operation-id"}`))

--- a/pkg/skr/gcpnfsvolumebackup/loadNfsBackup.go
+++ b/pkg/skr/gcpnfsvolumebackup/loadNfsBackup.go
@@ -19,11 +19,16 @@ func loadNfsBackup(ctx context.Context, st composed.State) (error, context.Conte
 	backup := state.ObjAsGcpNfsVolumeBackup()
 	logger.WithValues("nfsBackup :", backup.Name).Info("Loading GCP FileBackup")
 
+	if backup.Status.Id == "" {
+		// Backup is not created yet.
+		return nil, nil
+	}
+
 	//Get GCP details.
 	gcpScope := state.Scope.Spec.Scope.Gcp
 	project := gcpScope.Project
 	location := backup.Spec.Location
-	name := backup.Name
+	name := fmt.Sprintf("cm-%.60s", backup.Status.Id)
 
 	bkup, err := state.fileBackupClient.GetFileBackup(ctx, project, location, name)
 	if err != nil {

--- a/pkg/skr/gcpnfsvolumebackup/loadNfsBackup_test.go
+++ b/pkg/skr/gcpnfsvolumebackup/loadNfsBackup_test.go
@@ -27,7 +27,7 @@ func (suite *loadGcpNfsVolumeBackupSuite) TestVolumeBackupNotFound() {
 
 		case http.MethodGet:
 			fmt.Println(r.URL.Path)
-			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups/test-gcp-nfs-volume-backup") {
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups/cm-cffd6896-0127-48a1-8a64-e07f6ad5c912") {
 				//Return 404
 				http.Error(w, "Not Found", http.StatusNotFound)
 			} else {
@@ -64,7 +64,7 @@ func (suite *loadGcpNfsVolumeBackupSuite) TestVolumeBackupOtherError() {
 
 		case http.MethodGet:
 			fmt.Println(r.URL.Path)
-			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups/test-gcp-nfs-volume-backup") {
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups/cm-cffd6896-0127-48a1-8a64-e07f6ad5c912") {
 				//Return 500
 				http.Error(w, "Internal error", http.StatusInternalServerError)
 			} else {
@@ -99,7 +99,7 @@ func (suite *loadGcpNfsVolumeBackupSuite) TestVolumeBackupReady() {
 	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups/test-gcp-nfs-volume-backup") {
+			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups/cm-cffd6896-0127-48a1-8a64-e07f6ad5c912") {
 				//Return 200
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"name":"test-gcp-nfs-volume-backup"}`))

--- a/pkg/skr/gcpnfsvolumebackup/state_test.go
+++ b/pkg/skr/gcpnfsvolumebackup/state_test.go
@@ -96,6 +96,7 @@ var gcpNfsVolumeBackup = cloudresourcesv1beta1.GcpNfsVolumeBackup{
 				Message:            "NFS backup is ready",
 			},
 		},
+		Id: "cffd6896-0127-48a1-8a64-e07f6ad5c912",
 	},
 }
 
@@ -114,6 +115,19 @@ var deletingGpNfsVolumeBackup = cloudresourcesv1beta1.GcpNfsVolumeBackup{
 				Namespace: "test",
 			},
 		},
+	},
+	Status: cloudresourcesv1beta1.GcpNfsVolumeBackupStatus{
+		State: "Ready",
+		Conditions: []v1.Condition{
+			{
+				Type:               "Ready",
+				Status:             "True",
+				LastTransitionTime: v1.Time{Time: time.Now()},
+				Reason:             "Ready",
+				Message:            "NFS backup is ready",
+			},
+		},
+		Id: "cffd6896-0127-48a1-8a64-e07f6ad5c912",
 	},
 }
 

--- a/pkg/skr/gcpnfsvolumerestore/addFinalizer.go
+++ b/pkg/skr/gcpnfsvolumerestore/addFinalizer.go
@@ -8,6 +8,7 @@ import (
 )
 
 func addFinalizer(ctx context.Context, st composed.State) (error, context.Context) {
+	//If deleting, continue with next steps.
 	if composed.MarkedForDeletionPredicate(ctx, st) {
 		return nil, nil
 	}

--- a/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolume.go
+++ b/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolume.go
@@ -13,6 +13,10 @@ import (
 )
 
 func loadGcpNfsVolume(ctx context.Context, st composed.State) (error, context.Context) {
+	//If deleting, continue with next steps.
+	if composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
 	state := st.(*State)
 	logger := composed.LoggerFromCtx(ctx)
 

--- a/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolumeBackup.go
+++ b/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolumeBackup.go
@@ -11,6 +11,10 @@ import (
 )
 
 func loadGcpNfsVolumeBackup(ctx context.Context, st composed.State) (error, context.Context) {
+	//If deleting, continue with next steps.
+	if composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
 	// implement similar to loadGcpNfsVolume
 	// loadGcpNfsVolumeBackup loads the GcpNfsVolumeBackup object from the restore.Spec.Source.Backup value.
 	// If the object is not found, the function returns an error.

--- a/pkg/skr/gcpnfsvolumerestore/state_test.go
+++ b/pkg/skr/gcpnfsvolumerestore/state_test.go
@@ -95,6 +95,7 @@ var gcpNfsVolumeBackup = cloudresourcesv1beta1.GcpNfsVolumeBackup{
 				Message:            "NFS backup is ready",
 			},
 		},
+		Id: "cffd6896-0127-48a1-8a64-e07f6ad5c912",
 	},
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Change the naming of backup in the backend (Gcp Filestore Backup) to cm-<uuid>
- Making sure that GcpNfsVolume, GcpNfsVolumeBackup and GcpNfsVolumeRestore can be deleted independently
- Updating unit tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #462 