### PR TITLE
fix(GcpNfsVolume): Fix for blocking legacy filestore tiers

### DIFF
--- a/api/cloud-resources/v1beta1/gcpnfsvolume_types.go
+++ b/api/cloud-resources/v1beta1/gcpnfsvolume_types.go
@@ -58,6 +58,7 @@ const (
 	ConditionReasonPVCNameInvalid          = "PVCNameInvalid"
 	ConditionReasonNoWorkerZones           = "NoWorkerZones"
 	ConditionReasonLocationInvalid         = "LocationInvalid"
+	ConditionReasonTierLegacy              = "LegacyTier"
 )
 
 // GcpNfsVolumeSpec defines the desired state of GcpNfsVolume

--- a/pkg/skr/gcpnfsvolume/reconciler.go
+++ b/pkg/skr/gcpnfsvolume/reconciler.go
@@ -56,6 +56,12 @@ func (r *Reconciler) newAction() composed.Action {
 				loadGcpNfsVolumeBackup),
 			nil,
 		),
+		composed.IfElse(
+			// If nfsInstance already exists, do not validate legacy tiers
+			composed.All(composed.Not(composed.MarkedForDeletionPredicate), NoKcpNfsInstancePredicate()),
+			validateTier,
+			nil,
+		),
 		loadPersistenceVolume,
 		sanitizeReleasedVolume,
 		loadPersistentVolumeClaim,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Preventing legacy filestore tiers from getting created
- Fixing the nfs capacity validation to cover the capacity limitations based on increments for regional and zonal filestores
- Fixing unit tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #464 