### PR TITLE
fix: GcpNfsVolume backup/restore to read the volume location from sta…

### DIFF
--- a/pkg/skr/gcpnfsvolumebackup/createNfsBackup.go
+++ b/pkg/skr/gcpnfsvolumebackup/createNfsBackup.go
@@ -45,7 +45,7 @@ func createNfsBackup(ctx context.Context, st composed.State) (error, context.Con
 
 	fileBackup := &file.Backup{
 		SourceFileShare:    state.GcpNfsVolume.Spec.FileShareName,
-		SourceInstance:     client.GetFilestoreInstancePath(project, state.GcpNfsVolume.Spec.Location, nfsInstanceName),
+		SourceInstance:     client.GetFilestoreInstancePath(project, state.GcpNfsVolume.Status.Location, nfsInstanceName),
 		SourceInstanceTier: string(state.GcpNfsVolume.Spec.Tier),
 	}
 	op, err := state.fileBackupClient.CreateFileBackup(ctx, project, location, name, fileBackup)

--- a/pkg/skr/gcpnfsvolumerestore/runNfsRestore.go
+++ b/pkg/skr/gcpnfsvolumerestore/runNfsRestore.go
@@ -37,7 +37,7 @@ func runNfsRestore(ctx context.Context, st composed.State) (error, context.Conte
 	gcpScope := state.Scope.Spec.Scope.Gcp
 	project := gcpScope.Project
 	srcLocation := state.GcpNfsVolumeBackup.Spec.Location
-	dstLocation := state.GcpNfsVolume.Spec.Location
+	dstLocation := state.GcpNfsVolume.Status.Location
 	backupName := fmt.Sprintf("cm-%.60s", state.GcpNfsVolumeBackup.Status.Id)
 
 	nfsInstanceName := fmt.Sprintf("cm-%.60s", state.GcpNfsVolume.Status.Id)


### PR DESCRIPTION
…tus vs spec

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- GcpNfsVolumeBackup and GcpNfsVolumeRestore to read the location of volume from status vs spec

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #497 