### PR TITLE
feat: adding reasonable timeout to GCP API calls for google-api-go-cl…

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,6 +12,7 @@ configMapGenerator:
   - GCP_CLIENT_RENEW_DURATION=5m
   - GCP_RETRY_WAIT_DURATION=5s
   - GCP_OPERATION_WAIT_DURATION=5s
+  - GCP_API_TIMEOUT_DURATION=3s
   name: manager-env
 
 secretGenerator:

--- a/internal/controller/cloud-control/suite_test.go
+++ b/internal/controller/cloud-control/suite_test.go
@@ -72,6 +72,7 @@ var _ = BeforeSuite(func() {
 		"GCP_SA_JSON_KEY_PATH":        "test",
 		"GCP_RETRY_WAIT_DURATION":     "300ms",
 		"GCP_OPERATION_WAIT_DURATION": "300ms",
+		"GCP_API_TIMEOUT_DURATION":    "300ms",
 	})
 
 	// Setup controllers

--- a/internal/controller/cloud-resources/suite_test.go
+++ b/internal/controller/cloud-resources/suite_test.go
@@ -84,6 +84,7 @@ var _ = BeforeSuite(func() {
 		"GCP_SA_JSON_KEY_PATH":        "test",
 		"GCP_RETRY_WAIT_DURATION":     "300ms",
 		"GCP_OPERATION_WAIT_DURATION": "300ms",
+		"GCP_API_TIMEOUT_DURATION":    "300ms",
 	})
 
 	testSetupLog := ctrl.Log.WithName("testSetup")

--- a/pkg/kcp/provider/gcp/client/gcpConstants.go
+++ b/pkg/kcp/provider/gcp/client/gcpConstants.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"regexp"
 	"time"
 
 	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
@@ -21,16 +20,19 @@ const fileBackupPattern = "projects/%s/locations/%s/backups/%s"
 
 const GcpRetryWaitTime = time.Second * 3
 const GcpOperationWaitTime = time.Second * 5
+const GcpApiTimeout = time.Second * 3
 
 type GcpConfig struct {
 	GcpRetryWaitTime     time.Duration
 	GcpOperationWaitTime time.Duration
+	GcpApiTimeout        time.Duration
 }
 
 func GetGcpConfig(env abstractions.Environment) *GcpConfig {
 	return &GcpConfig{
 		GcpRetryWaitTime:     GetConfigDuration(env, "GCP_RETRY_WAIT_DURATION", GcpRetryWaitTime),
 		GcpOperationWaitTime: GetConfigDuration(env, "GCP_OPERATION_WAIT_DURATION", GcpOperationWaitTime),
+		GcpApiTimeout:        GetConfigDuration(env, "GCP_API_TIMEOUT_DURATION", GcpApiTimeout),
 	}
 }
 
@@ -41,8 +43,6 @@ func GetConfigDuration(env abstractions.Environment, key string, defaultValue ti
 	}
 	return duration
 }
-
-var FilestoreInstanceRegEx *regexp.Regexp = regexp.MustCompile(`^projects\/([^/]+)\/locations\/([^/]+)\/instances\/([^/]+)$`)
 
 func GetVPCPath(projectId, vpcId string) string {
 	return fmt.Sprintf(vPCPathPattern, projectId, vpcId)
@@ -64,39 +64,16 @@ func GetFileBackupPath(projectId, location, name string) string {
 	return fmt.Sprintf(fileBackupPattern, projectId, location, name)
 }
 
-type networkTier string
-
-const (
-	NetworkTierPremium  networkTier = "PREMIUM"
-	NetworkTierStandard networkTier = "STANDARD"
-)
-
-type ipVersion string
-
-const (
-	IpVersionIpV4 ipVersion = "IPV4"
-	IpVersionIpV6 ipVersion = "IPV6"
-)
-
 type addressType string
 
 const (
-	AddressTypeExternal addressType = "EXTERNAL"
 	AddressTypeInternal addressType = "INTERNAL"
 )
 
 type ipRangePurpose string
 
 const (
-	IpRangePurposeVPCPeering            ipRangePurpose = "VPC_PEERING"
-	IpRangePurposePrivateServiceConnect ipRangePurpose = "PRIVATE_SERVICE_CONNECT"
-)
-
-type ipv6EndpointType string
-
-const (
-	Ipv6EndpointTypeVm    ipv6EndpointType = "VM"
-	Ipv6EndpointTypeNetlb ipv6EndpointType = "NETLB"
+	IpRangePurposeVPCPeering ipRangePurpose = "VPC_PEERING"
 )
 
 const (
@@ -116,16 +93,8 @@ const (
 type FilestoreState string
 
 const (
-	CREATING   FilestoreState = "CREATING"
-	READY      FilestoreState = "READY"
-	REPAIRING  FilestoreState = "REPAIRING"
-	DELETING   FilestoreState = "DELETING"
-	ERROR      FilestoreState = "ERROR"
-	RESTORING  FilestoreState = "RESTORING"
-	SUSPENDED  FilestoreState = "SUSPENDED"
-	SUSPENDING FilestoreState = "SUSPENDING"
-	RESUMING   FilestoreState = "RESUMING"
-	REVERTING  FilestoreState = "REVERTING"
+	READY    FilestoreState = "READY"
+	DELETING FilestoreState = "DELETING"
 )
 
 type OperationType int

--- a/pkg/kcp/provider/gcp/client/provider.go
+++ b/pkg/kcp/provider/gcp/client/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/kyma-project/cloud-manager/pkg/metrics"
 	"google.golang.org/api/cloudresourcemanager/v1"
@@ -121,6 +122,7 @@ func newHttpClient(ctx context.Context, saJsonKeyPath string) (*http.Client, err
 		return nil, fmt.Errorf("error obtaining GCP HTTP client: [%w]", err)
 	}
 	CheckGcpAuthentication(ctx, saJsonKeyPath)
+	client.Timeout = GetGcpConfig(abstractions.NewOSEnvironment()).GcpApiTimeout
 	return client, nil
 }
 

--- a/pkg/kcp/provider/gcp/cloudclient/provider.go
+++ b/pkg/kcp/provider/gcp/cloudclient/provider.go
@@ -10,16 +10,19 @@ type ClientProvider[T any] func(ctx context.Context, saJsonKeyPath string) (T, e
 
 const GcpRetryWaitTime = time.Second * 3
 const GcpOperationWaitTime = time.Second * 5
+const GcpApiTimeout = time.Second * 3
 
 type GcpConfig struct {
 	GcpRetryWaitTime     time.Duration
 	GcpOperationWaitTime time.Duration
+	GcpApiTimeout        time.Duration
 }
 
 func GetGcpConfig(env abstractions.Environment) *GcpConfig {
 	return &GcpConfig{
 		GcpRetryWaitTime:     GetConfigDuration(env, "GCP_RETRY_WAIT_DURATION", GcpRetryWaitTime),
 		GcpOperationWaitTime: GetConfigDuration(env, "GCP_OPERATION_WAIT_DURATION", GcpOperationWaitTime),
+		GcpApiTimeout:        GetConfigDuration(env, "GCP_API_TIMEOUT_DURATION", GcpApiTimeout),
 	}
 }
 

--- a/pkg/kcp/provider/gcp/iprange/v1/state_test.go
+++ b/pkg/kcp/provider/gcp/iprange/v1/state_test.go
@@ -79,7 +79,8 @@ func newTestStateFactory(fakeHttpServer *httptest.Server) (*testStateFactory, er
 	env := abstractions.NewMockedEnvironment(map[string]string{
 		"GCP_SA_JSON_KEY_PATH":        "test",
 		"GCP_RETRY_WAIT_DURATION":     "100ms",
-		"GCP_OPERATION_WAIT_DURATION": "100ms"})
+		"GCP_OPERATION_WAIT_DURATION": "100ms",
+		"GCP_API_TIMEOUT_DURATION":    "100ms"})
 
 	factory := NewStateFactory(svcNwClientProvider, computeClientProvider, env)
 

--- a/pkg/kcp/provider/gcp/iprange/v2/state_test.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/state_test.go
@@ -80,7 +80,8 @@ func newTestStateFactory(fakeHttpServer *httptest.Server) (*testStateFactory, er
 	env := abstractions.NewMockedEnvironment(map[string]string{
 		"GCP_SA_JSON_KEY_PATH":        "test",
 		"GCP_RETRY_WAIT_DURATION":     "100ms",
-		"GCP_OPERATION_WAIT_DURATION": "100ms"})
+		"GCP_OPERATION_WAIT_DURATION": "100ms",
+		"GCP_API_TIMEOUT_DURATION":    "100ms"})
 
 	factory := NewStateFactory(svcNwClientProvider, computeClientProvider, env)
 


### PR DESCRIPTION
…ient

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Adding 3 seconds configurable timeout to GCP HTTP client to be applied to all api calls to prevent context timeout by blocking api call
- Fixing some warnings reported by linter

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #527 