### PR TITLE
feat(IpRange): forbid IpRange delete if RedisInstance is using it

### DIFF
--- a/internal/controller/cloud-resources/iprange_controller.go
+++ b/internal/controller/cloud-resources/iprange_controller.go
@@ -18,6 +18,7 @@ package cloudresources
 
 import (
 	"context"
+
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/skr/iprange"
 	skrruntime "github.com/kyma-project/cloud-manager/pkg/skr/runtime"
@@ -73,6 +74,20 @@ func SetupIpRangeReconciler(reg skrruntime.SkrRegistry) error {
 			return []string{"default"}
 		}
 		return []string{nfsVol.Spec.IpRange.Name}
+	})
+	reg.IndexField(&cloudresourcesv1beta1.GcpRedisInstance{}, cloudresourcesv1beta1.IpRangeField, func(object client.Object) []string {
+		redisInstance := object.(*cloudresourcesv1beta1.GcpRedisInstance)
+		if redisInstance.Spec.IpRange.Name == "" {
+			return []string{"default"}
+		}
+		return []string{redisInstance.Spec.IpRange.Name}
+	})
+	reg.IndexField(&cloudresourcesv1beta1.AwsRedisInstance{}, cloudresourcesv1beta1.IpRangeField, func(object client.Object) []string {
+		redisInstance := object.(*cloudresourcesv1beta1.AwsRedisInstance)
+		if redisInstance.Spec.IpRange.Name == "" {
+			return []string{"default"}
+		}
+		return []string{redisInstance.Spec.IpRange.Name}
 	})
 
 	return reg.Register().

--- a/internal/controller/cloud-resources/iprange_test.go
+++ b/internal/controller/cloud-resources/iprange_test.go
@@ -9,6 +9,8 @@ import (
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/feature"
 	"github.com/kyma-project/cloud-manager/pkg/skr/awsnfsvolume"
+	"github.com/kyma-project/cloud-manager/pkg/skr/awsredisinstance"
+	"github.com/kyma-project/cloud-manager/pkg/skr/gcpredisinstance"
 	skriprange "github.com/kyma-project/cloud-manager/pkg/skr/iprange"
 	. "github.com/kyma-project/cloud-manager/pkg/testinfra/dsl"
 	. "github.com/onsi/ginkgo/v2"
@@ -250,7 +252,7 @@ var _ = Describe("Feature: SKR IpRange", func() {
 						NewObjActions(),
 						HavingConditionTrue(cloudresourcesv1beta1.ConditionTypeReady),
 					).
-					Should(Succeed(), "exepcted SKR IpRange to get Ready condition, but it did not")
+					Should(Succeed(), "expected SKR IpRange to get Ready condition, but it did not")
 			})
 
 			By("When SKR IpRange is deleted", func() {
@@ -581,7 +583,7 @@ var _ = Describe("Feature: SKR IpRange", func() {
 					NewObjActions(),
 					HavingConditionTrue(cloudresourcesv1beta1.ConditionTypeReady),
 				).
-				Should(Succeed(), "exepcted SKR IpRange to get Ready condition, but it did not")
+				Should(Succeed(), "expected SKR IpRange to get Ready condition, but it did not")
 		})
 
 		By("And Given AwsNfsVolume exists", func() {
@@ -788,6 +790,230 @@ var _ = Describe("Feature: SKR IpRange", func() {
 					NewObjActions(WithName(skrIpRange.Status.Id)),
 				).
 				Should(Succeed(), "expected KCP IpRange to exists, but none found")
+		})
+
+	})
+
+	It("Scenario: SKR IpRange can not be deleted if used by AwsRedisInstance", func() {
+		const (
+			skrIpRangeName = "de648eb4-bab8-484a-a13f-fd8258787de3"
+			awsRedisName   = "b1411011-ee5e-4ddd-ba7c-b20509e81bf6"
+		)
+		skrIpRange := &cloudresourcesv1beta1.IpRange{}
+		kcpIpRange := &cloudcontrolv1beta1.IpRange{}
+		skrAwsRedisInstance := &cloudresourcesv1beta1.AwsRedisInstance{}
+
+		By("Given SKR IpRange exists", func() {
+			Eventually(CreateSkrIpRange).
+				WithArguments(
+					infra.Ctx(), infra.SKR().Client(), skrIpRange,
+					WithName(skrIpRangeName),
+					WithSkrIpRangeSpecCidr(addressSpace.MustAllocate(24)),
+				).
+				Should(Succeed(), "failed creating SKR IpRange")
+
+		})
+
+		By("And Given SKR IpRange has Ready condition", func() {
+			// load SKR IpRange to get ID
+			Eventually(LoadAndCheck).
+				WithArguments(
+					infra.Ctx(),
+					infra.SKR().Client(),
+					skrIpRange,
+					NewObjActions(),
+					AssertSkrIpRangeHasId(),
+				).
+				Should(Succeed(), "expected SKR IpRange to get status.id, but it didn't")
+
+			// KCP IpRange is created by manager
+			Eventually(LoadAndCheck).
+				WithArguments(
+					infra.Ctx(),
+					infra.KCP().Client(),
+					kcpIpRange,
+					NewObjActions(WithName(skrIpRange.Status.Id)),
+				).
+				Should(Succeed(), "expected SKR IpRange to be created, but none found")
+
+			// When Kcp IpRange gets Ready condition
+			Eventually(UpdateStatus).
+				WithArguments(
+					infra.Ctx(),
+					infra.KCP().Client(),
+					kcpIpRange,
+					WithConditions(KcpReadyCondition()),
+				).
+				Should(Succeed(), "failed updating KCP IpRange status")
+
+			// And when SKR IpRange gets Ready condition by manager
+			Eventually(LoadAndCheck).
+				WithArguments(
+					infra.Ctx(),
+					infra.SKR().Client(),
+					skrIpRange,
+					NewObjActions(),
+					HavingConditionTrue(cloudresourcesv1beta1.ConditionTypeReady),
+				).
+				Should(Succeed(), "expected SKR IpRange to get Ready condition, but it did not")
+		})
+
+		By("And Given AwsRedisInstance exists", func() {
+			// tell AwsRedisInstance reconciler to ignore this AwsRedisInstance
+			awsredisinstance.Ignore.AddName(awsRedisName)
+
+			Eventually(CreateAwsRedisInstance).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), skrAwsRedisInstance,
+					WithName(awsRedisName),
+					WithIpRange(skrIpRange.Name),
+					WithAwsRedisInstanceDefautSpecs(),
+				).
+				Should(Succeed(), "failed creating AwsRedisInstance")
+
+			time.Sleep(50 * time.Millisecond)
+		})
+
+		By("When SKR IpRange is deleted", func() {
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), skrIpRange).
+				Should(Succeed(), "failed deleting SKR IpRange")
+		})
+
+		By("Then SKR IpRange has Warning condition", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), skrIpRange, NewObjActions(), HavingConditionTrue(cloudresourcesv1beta1.ConditionTypeWarning)).
+				Should(Succeed(), "expected SKR IpRange to have Warning condition")
+		})
+
+		By("And Then SKR IpRange has DeleteWhileUsed reason", func() {
+			cond := meta.FindStatusCondition(skrIpRange.Status.Conditions, cloudresourcesv1beta1.ConditionTypeWarning)
+			Expect(cond.Reason).To(Equal(cloudresourcesv1beta1.ConditionTypeDeleteWhileUsed))
+			Expect(cond.Message).To(Equal(fmt.Sprintf("Can not be deleted while used by: [%s/%s]", skrAwsRedisInstance.Namespace, skrAwsRedisInstance.Name)))
+		})
+
+		By(fmt.Sprintf("// cleanup: delete SKR AwsRedisInstance %s", skrAwsRedisInstance.Name), func() {
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), skrAwsRedisInstance).
+				Should(Succeed(), "failed deleting SKR AwsRedisInstance to clean up")
+		})
+
+		By(fmt.Sprintf("// cleanup: delete SKR IpRange %s", skrIpRange.Name), func() {
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), skrIpRange).
+				Should(Succeed(), "failed deleting SKR IpRange to clean up")
+		})
+
+	})
+
+	It("Scenario: SKR IpRange can not be deleted if used by GcpRedisInstance", func() {
+		const (
+			skrIpRangeName = "d776bc88-801e-4125-a549-8ecf6a2b6f23"
+			gcpRedisName   = "95d238db-a29a-4285-ae6c-041efd156f8a"
+		)
+		skrIpRange := &cloudresourcesv1beta1.IpRange{}
+		kcpIpRange := &cloudcontrolv1beta1.IpRange{}
+		skrGcpRedisInstance := &cloudresourcesv1beta1.GcpRedisInstance{}
+
+		By("Given SKR IpRange exists", func() {
+			Eventually(CreateSkrIpRange).
+				WithArguments(
+					infra.Ctx(), infra.SKR().Client(), skrIpRange,
+					WithName(skrIpRangeName),
+					WithSkrIpRangeSpecCidr(addressSpace.MustAllocate(24)),
+				).
+				Should(Succeed(), "failed creating SKR IpRange")
+
+		})
+
+		By("And Given SKR IpRange has Ready condition", func() {
+			// load SKR IpRange to get ID
+			Eventually(LoadAndCheck).
+				WithArguments(
+					infra.Ctx(),
+					infra.SKR().Client(),
+					skrIpRange,
+					NewObjActions(),
+					AssertSkrIpRangeHasId(),
+				).
+				Should(Succeed(), "expected SKR IpRange to get status.id, but it didn't")
+
+			// KCP IpRange is created by manager
+			Eventually(LoadAndCheck).
+				WithArguments(
+					infra.Ctx(),
+					infra.KCP().Client(),
+					kcpIpRange,
+					NewObjActions(WithName(skrIpRange.Status.Id)),
+				).
+				Should(Succeed(), "expected SKR IpRange to be created, but none found")
+
+			// When Kcp IpRange gets Ready condition
+			Eventually(UpdateStatus).
+				WithArguments(
+					infra.Ctx(),
+					infra.KCP().Client(),
+					kcpIpRange,
+					WithConditions(KcpReadyCondition()),
+				).
+				Should(Succeed(), "failed updating KCP IpRange status")
+
+			// And when SKR IpRange gets Ready condition by manager
+			Eventually(LoadAndCheck).
+				WithArguments(
+					infra.Ctx(),
+					infra.SKR().Client(),
+					skrIpRange,
+					NewObjActions(),
+					HavingConditionTrue(cloudresourcesv1beta1.ConditionTypeReady),
+				).
+				Should(Succeed(), "expected SKR IpRange to get Ready condition, but it did not")
+		})
+
+		By("And Given GcpRedisInstance exists", func() {
+			// tell GcpRedisInstance reconciler to ignore this GcpRedisInstance
+			gcpredisinstance.Ignore.AddName(gcpRedisName)
+
+			Eventually(CreateGcpRedisInstance).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), skrGcpRedisInstance,
+					WithName(gcpRedisName),
+					WithIpRange(skrIpRange.Name),
+					WithGcpRedisInstanceMemorySizeGb(5),
+					WithGcpRedisInstanceTier("BASIC"),
+					WithGcpRedisInstanceRedisVersion("REDIS_7_0"),
+				).
+				Should(Succeed(), "failed creating GcpRedisInstance")
+
+			time.Sleep(50 * time.Millisecond)
+		})
+
+		By("When SKR IpRange is deleted", func() {
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), skrIpRange).
+				Should(Succeed(), "failed deleting SKR IpRange")
+		})
+
+		By("Then SKR IpRange has Warning condition", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), skrIpRange, NewObjActions(), HavingConditionTrue(cloudresourcesv1beta1.ConditionTypeWarning)).
+				Should(Succeed(), "expected SKR IpRange to have Warning condition")
+		})
+
+		By("And Then SKR IpRange has DeleteWhileUsed reason", func() {
+			cond := meta.FindStatusCondition(skrIpRange.Status.Conditions, cloudresourcesv1beta1.ConditionTypeWarning)
+			Expect(cond.Reason).To(Equal(cloudresourcesv1beta1.ConditionTypeDeleteWhileUsed))
+			Expect(cond.Message).To(Equal(fmt.Sprintf("Can not be deleted while used by: [%s/%s]", skrGcpRedisInstance.Namespace, skrGcpRedisInstance.Name)))
+		})
+
+		By(fmt.Sprintf("// cleanup: delete SKR GcpRedisInstance %s", skrGcpRedisInstance.Name), func() {
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), skrGcpRedisInstance).
+				Should(Succeed(), "failed deleting SKR GcpRedisInstance to clean up")
+		})
+
+		By(fmt.Sprintf("// cleanup: delete SKR IpRange %s", skrIpRange.Name), func() {
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), skrIpRange).
+				Should(Succeed(), "failed deleting SKR IpRange to clean up")
 		})
 
 	})

--- a/pkg/skr/awsredisinstance/ignorant.go
+++ b/pkg/skr/awsredisinstance/ignorant.go
@@ -1,0 +1,5 @@
+package awsredisinstance
+
+import "github.com/kyma-project/cloud-manager/pkg/common/ignorant"
+
+var Ignore = ignorant.New()

--- a/pkg/skr/gcpredisinstance/ignorant.go
+++ b/pkg/skr/gcpredisinstance/ignorant.go
@@ -1,0 +1,5 @@
+package gcpredisinstance
+
+import "github.com/kyma-project/cloud-manager/pkg/common/ignorant"
+
+var Ignore = ignorant.New()

--- a/pkg/skr/iprange/preventDeleteOnAwsRedisInstanceUsage.go
+++ b/pkg/skr/iprange/preventDeleteOnAwsRedisInstanceUsage.go
@@ -1,0 +1,66 @@
+package iprange
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/elliotchance/pie/v2"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func preventDeleteOnAwsRedisInstanceUsage(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	if !composed.MarkedForDeletionPredicate(ctx, st) {
+		// SKR IpRange is NOT marked for deletion, do not delete mirror in KCP
+		return nil, nil
+	}
+	if state.Provider != nil && *state.Provider != cloudcontrolv1beta1.ProviderAws {
+		// SKR IpRange is NOT AWS, skip check for AwsRedisInstance usage
+		logger.WithValues("provider", state.Provider).Info("Skipping preventDeleteOnAwsRedisInstanceUsage.")
+		return nil, nil
+	}
+	awsRedisInstancesUsingThisIpRange := &cloudresourcesv1beta1.AwsRedisInstanceList{}
+	listOps := &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(cloudresourcesv1beta1.IpRangeField, st.Name().Name),
+	}
+	err := state.Cluster().K8sClient().List(ctx, awsRedisInstancesUsingThisIpRange, listOps)
+	if meta.IsNoMatchError(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error listing AwsRedisInstances using IpRange", composed.StopWithRequeue, ctx)
+	}
+
+	if len(awsRedisInstancesUsingThisIpRange.Items) == 0 {
+		return nil, nil
+	}
+
+	usedByAwsRedisInstances := fmt.Sprintf("%v", pie.Map(awsRedisInstancesUsingThisIpRange.Items, func(x cloudresourcesv1beta1.AwsRedisInstance) string {
+		return fmt.Sprintf("%s/%s", x.Namespace, x.Name)
+	}))
+
+	logger.
+		WithValues("usedByAwsRedisInstances", usedByAwsRedisInstances).
+		Info("IpRange marked for deleting used by AwsRedisInstance")
+
+	return composed.UpdateStatus(state.ObjAsIpRange()).
+		SetExclusiveConditions(metav1.Condition{
+			Type:    cloudresourcesv1beta1.ConditionTypeWarning,
+			Status:  metav1.ConditionTrue,
+			Reason:  cloudresourcesv1beta1.ConditionTypeDeleteWhileUsed,
+			Message: fmt.Sprintf("Can not be deleted while used by: %s", usedByAwsRedisInstances),
+		}).
+		DeriveStateFromConditions(state.MapConditionToState()).
+		ErrorLogMessage("Error updating IpRange status with Warning condition for delete while in use").
+		SuccessLogMsg("Forgetting SKR IpRange marked for deleting that is in use").
+		SuccessError(composed.StopAndForget).
+		Run(ctx, state)
+}

--- a/pkg/skr/iprange/preventDeleteOnGcpRedisInstanceUsage.go
+++ b/pkg/skr/iprange/preventDeleteOnGcpRedisInstanceUsage.go
@@ -1,0 +1,66 @@
+package iprange
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/elliotchance/pie/v2"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func preventDeleteOnGcpRedisInstanceUsage(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	if !composed.MarkedForDeletionPredicate(ctx, st) {
+		// SKR IpRange is NOT marked for deletion, do not delete mirror in KCP
+		return nil, nil
+	}
+	if state.Provider != nil && *state.Provider != cloudcontrolv1beta1.ProviderGCP {
+		// SKR IpRange is NOT GCP, skip check for GcpRedisInstance usage
+		logger.WithValues("provider", state.Provider).Info("Skipping preventDeleteOnGcpRedisInstanceUsage.")
+		return nil, nil
+	}
+	gcpRedisInstancesUsingThisIpRange := &cloudresourcesv1beta1.GcpRedisInstanceList{}
+	listOps := &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(cloudresourcesv1beta1.IpRangeField, st.Name().Name),
+	}
+	err := state.Cluster().K8sClient().List(ctx, gcpRedisInstancesUsingThisIpRange, listOps)
+	if meta.IsNoMatchError(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error listing GcpRedisInstances using IpRange", composed.StopWithRequeue, ctx)
+	}
+
+	if len(gcpRedisInstancesUsingThisIpRange.Items) == 0 {
+		return nil, nil
+	}
+
+	usedByGcpRedisInstances := fmt.Sprintf("%v", pie.Map(gcpRedisInstancesUsingThisIpRange.Items, func(x cloudresourcesv1beta1.GcpRedisInstance) string {
+		return fmt.Sprintf("%s/%s", x.Namespace, x.Name)
+	}))
+
+	logger.
+		WithValues("usedByGcpRedisInstances", usedByGcpRedisInstances).
+		Info("IpRange marked for deleting used by GcpRedisInstance")
+
+	return composed.UpdateStatus(state.ObjAsIpRange()).
+		SetExclusiveConditions(metav1.Condition{
+			Type:    cloudresourcesv1beta1.ConditionTypeWarning,
+			Status:  metav1.ConditionTrue,
+			Reason:  cloudresourcesv1beta1.ConditionTypeDeleteWhileUsed,
+			Message: fmt.Sprintf("Can not be deleted while used by: %s", usedByGcpRedisInstances),
+		}).
+		DeriveStateFromConditions(state.MapConditionToState()).
+		ErrorLogMessage("Error updating IpRange status with Warning condition for delete while in use").
+		SuccessLogMsg("Forgetting SKR IpRange marked for deleting that is in use").
+		SuccessError(composed.StopAndForget).
+		Run(ctx, state)
+}

--- a/pkg/skr/iprange/reconciler.go
+++ b/pkg/skr/iprange/reconciler.go
@@ -2,6 +2,7 @@ package iprange
 
 import (
 	"context"
+
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/kyma-project/cloud-manager/pkg/feature"
@@ -60,6 +61,8 @@ func (r *reconciler) newAction() composed.Action {
 		setProcessingStateForDeletion,
 		preventDeleteOnAwsNfsVolumeUsage,
 		preventDeleteOnGcpNfsVolumeUsage,
+		preventDeleteOnAwsRedisInstanceUsage,
+		preventDeleteOnGcpRedisInstanceUsage,
 		deleteKcpIpRange,
 		removeFinalizer,
 		updateStatus,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- IpRange cant be deleted if there is an existing GcpRedisInstance using it
- IpRange cant be deleted if there is an existing AwsRedisInstance using it
- Scenario tests for the above
- Out of scope, but added: Scenario test: IpRange cant be deleted if there is an existing GcpNfsInstance using it

**Related issue(s)**
https://github.com/kyma-project/cloud-manager/issues/543
