### PR TITLE
chore(AzureVpcPeering): use util.Timing

### DIFF
--- a/internal/controller/cloud-control/vpcpeering_azure_test.go
+++ b/internal/controller/cloud-control/vpcpeering_azure_test.go
@@ -65,7 +65,9 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 				Should(Succeed())
 		})
 
-		infra.AzureMock().SetPeeringStateConnected(subscriptionId, resourceGroupName, virtualNetworkName, vpcpeeringName)
+		By("When Azure VPC Peering state is Connected", func() {
+			infra.AzureMock().SetPeeringStateConnected(subscriptionId, resourceGroupName, virtualNetworkName, vpcpeeringName)
+		})
 
 		By("Then KCP VpcPeering has Ready condition", func() {
 			Eventually(LoadAndCheck).

--- a/pkg/kcp/provider/azure/vpcpeering/createVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/createVpcPeering.go
@@ -5,9 +5,9 @@ import (
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	azuremeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/meta"
+	"github.com/kyma-project/cloud-manager/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-	"time"
 )
 
 func createVpcPeering(ctx context.Context, st composed.State) (error, context.Context) {
@@ -44,7 +44,7 @@ func createVpcPeering(ctx context.Context, st composed.State) (error, context.Co
 			}).
 			ErrorLogMessage("Error updating VpcPeering status due to failed creating vpc peering connection").
 			FailedError(composed.StopWithRequeue).
-			SuccessError(composed.StopWithRequeueDelay(time.Minute)).
+			SuccessError(composed.StopWithRequeueDelay(util.Timing.T60000ms())).
 			Run(ctx, state)
 	}
 

--- a/pkg/kcp/provider/azure/vpcpeering/loadRemoteVpc.go
+++ b/pkg/kcp/provider/azure/vpcpeering/loadRemoteVpc.go
@@ -6,9 +6,9 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	azureconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/config"
 	azuremeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/meta"
-	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/util"
+	azureutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/util"
+	"github.com/kyma-project/cloud-manager/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 func loadRemoteVpc(ctx context.Context, st composed.State) (error, context.Context) {
@@ -24,7 +24,7 @@ func loadRemoteVpc(ctx context.Context, st composed.State) (error, context.Conte
 	clientSecret := azureconfig.AzureConfig.PeeringCreds.ClientSecret
 	tenantId := state.tenantId
 
-	remote, err := util.ParseResourceID(obj.Spec.VpcPeering.Azure.RemoteVnet)
+	remote, err := azureutil.ParseResourceID(obj.Spec.VpcPeering.Azure.RemoteVnet)
 
 	if err != nil {
 		logger.Error(err, "Error parsing remoteVnet")
@@ -46,7 +46,7 @@ func loadRemoteVpc(ctx context.Context, st composed.State) (error, context.Conte
 
 		message := azuremeta.GetErrorMessage(err)
 
-		successError := composed.StopWithRequeueDelay(time.Minute)
+		successError := composed.StopWithRequeueDelay(util.Timing.T60000ms())
 
 		// If VpcNetwork is not found user can not recover from this error without updating the resource so, we are doing
 		// stop and forget.

--- a/pkg/kcp/provider/azure/vpcpeering/waitNetworkTag.go
+++ b/pkg/kcp/provider/azure/vpcpeering/waitNetworkTag.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 func waitNetworkTag(ctx context.Context, st composed.State) (error, context.Context) {
@@ -40,7 +40,7 @@ func waitNetworkTag(ctx context.Context, st composed.State) (error, context.Cont
 			}).
 			ErrorLogMessage("Error updating VpcPeering status due to remote vpc network tag mismatch").
 			FailedError(composed.StopWithRequeue).
-			SuccessError(composed.StopWithRequeueDelay(time.Minute)).
+			SuccessError(composed.StopWithRequeueDelay(util.Timing.T60000ms())).
 			Run(ctx, state)
 	}
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use util.Timing so that tests can run faster