### PR TITLE
fix(gcpnfsvolumerestore): preventing duplicate filestore restores

### DIFF
--- a/config/config/skrRuntime.yaml
+++ b/config/config/skrRuntime.yaml
@@ -1,1 +1,2 @@
 providersDir: config/dist/skr/crd/bases/providers
+lockingLeaseDuration: 10m

--- a/config/dist/kcp/crd/kustomization.yaml
+++ b/config/dist/kcp/crd/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
 - bases/cloud-control.kyma-project.io_vpcpeerings.yaml
 - bases/cloud-control.kyma-project.io_ipranges.yaml
 - bases/cloud-control.kyma-project.io_scopes.yaml
+- bases/cloud-control.kyma-project.io_redisinstances.yaml
+- bases/cloud-control.kyma-project.io_networks.yaml
 
 commonLabels:
   app.kubernetes.io/component: cloud-manager.kyma-project.io

--- a/pkg/kcp/provider/gcp/mock/nfsRestoreStore.go
+++ b/pkg/kcp/provider/gcp/mock/nfsRestoreStore.go
@@ -33,3 +33,13 @@ func (s *nfsRestoreStore) GetRestoreOperation(ctx context.Context, _, operationN
 	}
 	return &file.Operation{Name: operationName, Done: true}, nil
 }
+
+func (s *nfsRestoreStore) FindRestoreOperation(ctx context.Context, _, _, _ string) (*file.Operation, error) {
+	if s.restoreOperationError != nil {
+		return nil, s.restoreOperationError
+	}
+	if isContextCanceled(ctx) {
+		return nil, context.Canceled
+	}
+	return newOperation("", false), nil
+}

--- a/pkg/skr/common/leases/lease.go
+++ b/pkg/skr/common/leases/lease.go
@@ -1,0 +1,109 @@
+package leases
+
+import (
+	"context"
+	"fmt"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/skr/runtime/config"
+	v1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sync"
+	"time"
+)
+
+type LeaseResult int
+
+const (
+	RenewedLease  LeaseResult = iota
+	AcquiredLease LeaseResult = iota
+	LeasingFailed LeaseResult = iota
+	OtherLeased   LeaseResult = iota
+)
+
+var leaseMutex sync.Mutex
+
+func Acquire(ctx context.Context, cluster composed.StateCluster, resourceName, ownerName types.NamespacedName, prefix string) (LeaseResult, error) {
+	leaseMutex.Lock()
+	defer leaseMutex.Unlock()
+
+	leaseName := getLeaseName(resourceName, prefix)
+	leaseNamespace := resourceName.Namespace
+	holderName := getHolderName(ownerName)
+
+	lease := &v1.Lease{}
+	err := cluster.K8sClient().Get(ctx, types.NamespacedName{Name: leaseName, Namespace: leaseNamespace}, lease)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return LeasingFailed, err
+	}
+	leaseDuration := int32(config.SkrRuntimeConfig.SkrLockingLeaseDuration.Seconds())
+	if lease.Name == "" {
+		lease = &v1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      leaseName,
+				Namespace: leaseNamespace,
+			},
+			Spec: v1.LeaseSpec{
+				HolderIdentity:       &holderName,
+				LeaseDurationSeconds: &leaseDuration,
+				AcquireTime:          &metav1.MicroTime{Time: time.Now()},
+				RenewTime:            &metav1.MicroTime{Time: time.Now()},
+			},
+		}
+		err := cluster.K8sClient().Create(ctx, lease)
+		if err != nil {
+			return LeasingFailed, err
+		}
+		return AcquiredLease, nil
+	}
+	if ptr.Deref(lease.Spec.HolderIdentity, "") == holderName {
+		lease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
+		err := cluster.K8sClient().Update(ctx, lease)
+		if err != nil {
+			return LeasingFailed, err
+		}
+		return RenewedLease, nil
+	}
+	leaseDurationSeconds := ptr.Deref(lease.Spec.LeaseDurationSeconds, leaseDuration)
+	if lease.Spec.RenewTime == nil || lease.Spec.RenewTime.Time.Add(time.Second*time.Duration(leaseDurationSeconds)).Before(time.Now()) {
+		//lease expired
+		lease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
+		lease.Spec.HolderIdentity = &holderName
+		err := cluster.K8sClient().Update(ctx, lease)
+		if err != nil {
+			return LeasingFailed, err
+		}
+		return AcquiredLease, nil
+	}
+	return OtherLeased, nil
+}
+
+func Release(ctx context.Context, cluster composed.StateCluster, resourceName, ownerName types.NamespacedName, prefix string) error {
+	leaseMutex.Lock()
+	defer leaseMutex.Unlock()
+	leaseName := getLeaseName(resourceName, prefix)
+	leaseNamespace := resourceName.Namespace
+	holderName := getHolderName(ownerName)
+	lease := &v1.Lease{}
+	err := cluster.K8sClient().Get(ctx, types.NamespacedName{Name: leaseName, Namespace: leaseNamespace}, lease)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if lease.Name != "" && ptr.Deref(lease.Spec.HolderIdentity, "") == holderName {
+		err := cluster.K8sClient().Delete(ctx, lease)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getHolderName(ownerName types.NamespacedName) string {
+	return fmt.Sprintf("%s/%s", ownerName.Namespace, ownerName.Name)
+}
+
+func getLeaseName(resourceName types.NamespacedName, prefix string) string {
+	return fmt.Sprintf("%s-%s", prefix, resourceName.Name)
+}

--- a/pkg/skr/common/leases/lease_test.go
+++ b/pkg/skr/common/leases/lease_test.go
@@ -1,0 +1,76 @@
+package leases
+
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/config"
+	config2 "github.com/kyma-project/cloud-manager/pkg/skr/runtime/config"
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+type leaseSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *leaseSuite) SetupTest() {
+	suite.ctx = context.Background()
+	env := abstractions.NewMockedEnvironment(map[string]string{})
+	cfg := config.NewConfig(env)
+	config2.InitConfig(cfg)
+	cfg.Read()
+}
+
+func (suite *leaseSuite) TestAcquireAndRelease() {
+	fakeClient := fake.NewClientBuilder().Build()
+	skrScheme := runtime.NewScheme()
+	client := composed.NewStateCluster(fakeClient, fakeClient, nil, skrScheme)
+	resource := types.NamespacedName{Name: "test-resource", Namespace: "resource-namespace"}
+	owner := types.NamespacedName{Name: "test-owner", Namespace: "owner-namespace"}
+	prefix := "test-prefix"
+	res, err := Acquire(suite.ctx, client, resource, owner, prefix)
+	suite.NoError(err)
+	suite.Equal(AcquiredLease, res)
+	leaseName := getLeaseName(resource, prefix)
+	leaseNamespace := resource.Namespace
+	lease := &v1.Lease{}
+	err = fakeClient.Get(suite.ctx, types.NamespacedName{Name: leaseName, Namespace: leaseNamespace}, lease)
+	suite.NoError(err)
+	time1 := lease.Spec.RenewTime.Time
+	res, err = Acquire(suite.ctx, client, resource, owner, prefix)
+	suite.NoError(err)
+	err = fakeClient.Get(suite.ctx, types.NamespacedName{Name: leaseName, Namespace: leaseNamespace}, lease)
+	suite.NoError(err)
+	suite.Equal(RenewedLease, res)
+	time2 := lease.Spec.RenewTime.Time
+	// make sure time2 is greater than time1
+	suite.True(time2.After(time1))
+	res, err = Acquire(suite.ctx, client, resource, types.NamespacedName{Name: "test-owner", Namespace: "owner-namespace2"}, prefix)
+	suite.NoError(err)
+	suite.Equal(OtherLeased, res)
+	err = Release(suite.ctx, client, resource, types.NamespacedName{Name: "test-owner", Namespace: "owner-namespace2"}, prefix)
+	suite.NoError(err)
+	err = fakeClient.Get(suite.ctx, types.NamespacedName{Name: leaseName, Namespace: leaseNamespace}, lease)
+	suite.NoError(err)
+	suite.Equal(getHolderName(owner), *lease.Spec.HolderIdentity)
+	err = Release(suite.ctx, client, resource, owner, prefix)
+	suite.NoError(err)
+	err = fakeClient.Get(suite.ctx, types.NamespacedName{Name: leaseName, Namespace: leaseNamespace}, lease)
+	suite.Error(err)
+	suite.True(apierrors.IsNotFound(err))
+	err = Release(suite.ctx, client, resource, owner, prefix)
+	suite.NoError(err)
+	err = Release(suite.ctx, client, resource, owner, prefix)
+	suite.NoError(err)
+}
+
+func TestLeaseSuite(t *testing.T) {
+	suite.Run(t, new(leaseSuite))
+}

--- a/pkg/skr/gcpnfsvolumerestore/acquireLease.go
+++ b/pkg/skr/gcpnfsvolumerestore/acquireLease.go
@@ -1,0 +1,34 @@
+package gcpnfsvolumerestore
+
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/skr/common/leases"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func acquireLease(ctx context.Context, st composed.State) (error, context.Context) {
+	//If deleting, continue with next steps.
+	if composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+	restore := state.ObjAsGcpNfsVolumeRestore()
+	res, err := leases.Acquire(ctx, state.SkrCluster,
+		types.NamespacedName{Name: state.GcpNfsVolume.Name, Namespace: state.GcpNfsVolume.Namespace},
+		types.NamespacedName{Name: restore.Name, Namespace: restore.Namespace},
+		"restore")
+	switch res {
+	case leases.AcquiredLease, leases.RenewedLease:
+		return nil, nil
+	case leases.LeasingFailed:
+		return composed.LogErrorAndReturn(err, "Error acquiring lease", composed.StopWithRequeueDelay(util.Timing.T100ms()), ctx)
+	case leases.OtherLeased:
+		logger.Info("Another restore leased the filestore. Waiting for it to release the lease.")
+		return composed.StopWithRequeueDelay(util.Timing.T10000ms()), ctx
+	default:
+		return composed.LogErrorAndReturn(err, "Unknown lease result", composed.StopAndForget, ctx)
+	}
+}

--- a/pkg/skr/gcpnfsvolumerestore/acquireLease_test.go
+++ b/pkg/skr/gcpnfsvolumerestore/acquireLease_test.go
@@ -1,0 +1,153 @@
+package gcpnfsvolumerestore
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+	"time"
+)
+
+type acquireLeaseSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *acquireLeaseSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *acquireLeaseSuite) TestAcquireLease_Acquire() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	obj := gcpNfsVolumeRestore.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	state.GcpNfsVolume = gcpNfsVolume.DeepCopy()
+	assert.Nil(suite.T(), err)
+	err, _ = acquireLease(ctx, state)
+	assert.Nil(suite.T(), err)
+	lease := &v1.Lease{}
+	err = factory.skrCluster.K8sClient().Get(ctx, types.NamespacedName{Name: fmt.Sprintf("restore-%s", state.GcpNfsVolume.Name), Namespace: state.GcpNfsVolume.Namespace}, lease)
+	assert.Nil(suite.T(), err)
+	suite.Equal(*lease.Spec.HolderIdentity, fmt.Sprintf("%s/%s", obj.Namespace, obj.Name))
+}
+
+func (suite *acquireLeaseSuite) TestAcquireLease_Renew() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	obj := gcpNfsVolumeRestore.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	assert.Nil(suite.T(), err)
+	state.GcpNfsVolume = gcpNfsVolume.DeepCopy()
+	err, _ = acquireLease(ctx, state)
+	assert.Nil(suite.T(), err)
+	lease := &v1.Lease{}
+	err = factory.skrCluster.K8sClient().Get(ctx, types.NamespacedName{Name: fmt.Sprintf("restore-%s", state.GcpNfsVolume.Name), Namespace: state.GcpNfsVolume.Namespace}, lease)
+	assert.Nil(suite.T(), err)
+	suite.Equal(*lease.Spec.HolderIdentity, fmt.Sprintf("%s/%s", obj.Namespace, obj.Name))
+	time1 := lease.Spec.RenewTime.Time
+	err, _ = acquireLease(ctx, state)
+	assert.Nil(suite.T(), err)
+	err = factory.skrCluster.K8sClient().Get(ctx, types.NamespacedName{Name: fmt.Sprintf("restore-%s", state.GcpNfsVolume.Name), Namespace: state.GcpNfsVolume.Namespace}, lease)
+	assert.Nil(suite.T(), err)
+	time2 := lease.Spec.RenewTime.Time
+	suite.True(time2.After(time1))
+}
+
+func (suite *acquireLeaseSuite) TestAcquireLease_OtherLeased() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	obj := gcpNfsVolumeRestore.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	assert.Nil(suite.T(), err)
+	state.GcpNfsVolume = gcpNfsVolume.DeepCopy()
+	leaseDuration := new(int32)
+	*leaseDuration = 600
+	otherOwner := "otherns/other"
+	err = factory.skrCluster.K8sClient().Create(ctx, &v1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("restore-%s", state.GcpNfsVolume.Name),
+			Namespace: state.GcpNfsVolume.Namespace,
+		},
+		Spec: v1.LeaseSpec{
+			HolderIdentity:       &otherOwner,
+			LeaseDurationSeconds: leaseDuration,
+			AcquireTime:          &metav1.MicroTime{Time: time.Now()},
+			RenewTime:            &metav1.MicroTime{Time: time.Now()},
+		},
+	})
+	assert.Nil(suite.T(), err)
+	err, _ = acquireLease(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(util.Timing.T10000ms()), err)
+	lease := &v1.Lease{}
+	err = factory.skrCluster.K8sClient().Get(ctx, types.NamespacedName{Name: fmt.Sprintf("restore-%s", state.GcpNfsVolume.Name), Namespace: state.GcpNfsVolume.Namespace}, lease)
+	assert.Nil(suite.T(), err)
+	suite.Equal(*lease.Spec.HolderIdentity, otherOwner)
+}
+
+func (suite *acquireLeaseSuite) TestDoNotAcquireLeaseOnDeletingObject() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	obj := deletingGcpNfsVolumeRestore.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	assert.Nil(suite.T(), err)
+	state.GcpNfsVolume = gcpNfsVolume.DeepCopy()
+
+	err, _ = acquireLease(ctx, state)
+	assert.Nil(suite.T(), err)
+	lease := &v1.Lease{}
+	err = factory.skrCluster.K8sClient().Get(ctx, types.NamespacedName{Name: fmt.Sprintf("restore-%s", state.GcpNfsVolume.Name), Namespace: state.GcpNfsVolume.Namespace}, lease)
+	assert.NotNil(suite.T(), err)
+	assert.True(suite.T(), apierrors.IsNotFound(err))
+}
+
+func TestAcquireLease(t *testing.T) {
+	suite.Run(t, new(acquireLeaseSuite))
+}

--- a/pkg/skr/gcpnfsvolumerestore/addFinalizer_test.go
+++ b/pkg/skr/gcpnfsvolumerestore/addFinalizer_test.go
@@ -46,7 +46,7 @@ func (suite *addFinalizerSuite) TestDoNotAddFinalizerOnDeletingObject() {
 		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
 	}))
 	defer fakeHttpServer.Close()
-	deletingObj := deletingGpNfsVolumeRestore.DeepCopy()
+	deletingObj := deletingGcpNfsVolumeRestore.DeepCopy()
 	factory, err := newTestStateFactoryWithObj(fakeHttpServer, deletingObj)
 	assert.Nil(suite.T(), err)
 

--- a/pkg/skr/gcpnfsvolumerestore/checkRestoreOperation.go
+++ b/pkg/skr/gcpnfsvolumerestore/checkRestoreOperation.go
@@ -19,7 +19,7 @@ func checkRestoreOperation(ctx context.Context, st composed.State) (error, conte
 
 	restore := state.ObjAsGcpNfsVolumeRestore()
 	opName := restore.Status.OpIdentifier
-	logger.WithValues("Nfs Restore source:", restore.Spec.Source.Backup.ToNamespacedName(state.Obj().GetNamespace()),
+	logger.WithValues("nfsRestoreSource:", restore.Spec.Source.Backup.ToNamespacedName(state.Obj().GetNamespace()),
 		"destination:", restore.Spec.Destination.Volume.ToNamespacedName(state.Obj().GetNamespace())).Info("Checking GCP Restore Operation Status")
 
 	//If no OpIdentifier, then continue to next action.

--- a/pkg/skr/gcpnfsvolumerestore/findRestoreOperation.go
+++ b/pkg/skr/gcpnfsvolumerestore/findRestoreOperation.go
@@ -1,0 +1,62 @@
+package gcpnfsvolumerestore
+
+import (
+	"context"
+	"fmt"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/meta"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+)
+
+func findRestoreOperation(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	//If deleting, continue with next steps.
+	if composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
+
+	restore := state.ObjAsGcpNfsVolumeRestore()
+	opName := restore.Status.OpIdentifier
+	logger.WithValues("nfsRestoreSource:", restore.Spec.Source.Backup.ToNamespacedName(state.Obj().GetNamespace()),
+		"destination:", restore.Spec.Destination.Volume.ToNamespacedName(state.Obj().GetNamespace())).Info("Finding GCP Restore Operations")
+
+	//If no OpIdentifier, then continue to next action.
+	if opName != "" {
+		return nil, nil
+	}
+
+	project := state.Scope.Spec.Scope.Gcp.Project
+	dstLocation := state.GcpNfsVolume.Status.Location
+	nfsInstanceName := fmt.Sprintf("cm-%.60s", state.GcpNfsVolume.Status.Id)
+	op, err := state.fileRestoreClient.FindRestoreOperation(ctx, project, dstLocation, nfsInstanceName)
+	if err != nil {
+		if meta.IsNotFound(err) {
+			return nil, nil
+		}
+		restore.Status.State = v1beta1.JobStateError
+		return composed.PatchStatus(restore).
+			SetExclusiveConditions(metav1.Condition{
+				Type:    v1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  v1beta1.ConditionReasonNfsRestoreFailed,
+				Message: err.Error(),
+			}).
+			SuccessError(composed.StopWithRequeueDelay(util.Timing.T100ms())).
+			SuccessLogMsg("Error listing operations from GCP.").
+			Run(ctx, state)
+	}
+
+	if op != nil {
+		restore.Status.OpIdentifier = op.Name
+		return composed.PatchStatus(restore).
+			SuccessError(composed.StopWithRequeue).
+			SuccessLogMsg(fmt.Sprintf("Updated the opIdentifier with %s", op.Name)).
+			Run(ctx, state)
+	}
+	return nil, nil
+}

--- a/pkg/skr/gcpnfsvolumerestore/findRestoreOperation_test.go
+++ b/pkg/skr/gcpnfsvolumerestore/findRestoreOperation_test.go
@@ -1,0 +1,178 @@
+package gcpnfsvolumerestore
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/file/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+type findRestoreOperationSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *findRestoreOperationSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *findRestoreOperationSuite) TestFindRestoreOperationRunningOp() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		op := file.Operation{
+			Name: "op-123",
+			Done: false,
+		}
+		opResp := file.ListOperationsResponse{
+			Operations: []*file.Operation{&op},
+		}
+
+		b, err := json.Marshal(opResp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal response: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+	}))
+	defer fakeHttpServer.Close()
+	obj := gcpNfsVolumeRestore.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	assert.Nil(suite.T(), err)
+	state.GcpNfsVolume = gcpNfsVolume.DeepCopy()
+	state.Scope = scope.DeepCopy()
+	err, ctx = findRestoreOperation(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeue, err)
+	fromK8s := &v1beta1.GcpNfsVolumeRestore{}
+	err = factory.skrCluster.K8sClient().Get(ctx, types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, fromK8s)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), "op-123", fromK8s.Status.OpIdentifier)
+}
+
+func (suite *findRestoreOperationSuite) TestFindRestoreOperationNoRunningOp() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		op := file.Operation{
+			Name: "op-123",
+			Done: true,
+		}
+		opResp := file.ListOperationsResponse{
+			Operations: []*file.Operation{&op},
+		}
+
+		b, err := json.Marshal(opResp)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to marshal response: "+err.Error())
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			assert.Fail(suite.T(), "unable to write to provided ResponseWriter: "+err.Error())
+		}
+	}))
+	defer fakeHttpServer.Close()
+	obj := gcpNfsVolumeRestore.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	assert.Nil(suite.T(), err)
+	state.GcpNfsVolume = gcpNfsVolume.DeepCopy()
+	state.Scope = scope.DeepCopy()
+
+	err, ctx = findRestoreOperation(ctx, state)
+	assert.Nil(suite.T(), err)
+	assert.Nil(suite.T(), ctx)
+	fromK8s := &v1beta1.GcpNfsVolumeRestore{}
+	err = factory.skrCluster.K8sClient().Get(ctx, types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, fromK8s)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), "", fromK8s.Status.OpIdentifier)
+}
+
+func (suite *findRestoreOperationSuite) TestFindRestoreOperationErrorNotFound() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Not Found", http.StatusNotFound)
+	}))
+	defer fakeHttpServer.Close()
+	obj := gcpNfsVolumeRestore.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	assert.Nil(suite.T(), err)
+	state.GcpNfsVolume = gcpNfsVolume.DeepCopy()
+	state.Scope = &scope
+	err, ctx = findRestoreOperation(ctx, state)
+	assert.Nil(suite.T(), err)
+	fromK8s := &v1beta1.GcpNfsVolumeRestore{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: obj.Name,
+			Namespace: obj.Namespace},
+		fromK8s)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), "", fromK8s.Status.OpIdentifier)
+	assert.Equal(suite.T(), "", fromK8s.Status.State)
+}
+
+func (suite *findRestoreOperationSuite) TestFindRestoreOperationOtherError() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer fakeHttpServer.Close()
+
+	//Get state object with GcpNfsVolume
+	obj := gcpNfsVolumeRestore.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	state, err := factory.newStateWith(obj)
+	assert.Nil(suite.T(), err)
+	state.GcpNfsVolume = gcpNfsVolume.DeepCopy()
+	state.Scope = &scope
+	err, ctx = findRestoreOperation(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(util.Timing.T100ms()), err)
+	fromK8s := &v1beta1.GcpNfsVolumeRestore{}
+	err = factory.skrCluster.K8sClient().Get(ctx,
+		types.NamespacedName{Name: obj.Name,
+			Namespace: obj.Namespace},
+		fromK8s)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), "", fromK8s.Status.OpIdentifier)
+	assert.Equal(suite.T(), v1beta1.JobStateError, fromK8s.Status.State)
+	assert.Equal(suite.T(), metav1.ConditionTrue, fromK8s.Status.Conditions[0].Status)
+	assert.Equal(suite.T(), cloudcontrolv1beta1.ConditionTypeError, fromK8s.Status.Conditions[0].Type)
+}
+
+func TestFindRestoreOperation(t *testing.T) {
+	suite.Run(t, new(findRestoreOperationSuite))
+}

--- a/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolumeBackup.go
+++ b/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolumeBackup.go
@@ -25,7 +25,7 @@ func loadGcpNfsVolumeBackup(ctx context.Context, st composed.State) (error, cont
 	logger := composed.LoggerFromCtx(ctx)
 
 	restore := state.ObjAsGcpNfsVolumeRestore()
-	logger.WithValues("Nfs Restore source:", restore.Spec.Source.Backup.ToNamespacedName(state.Obj().GetNamespace()),
+	logger.WithValues("nfsRestoreSource:", restore.Spec.Source.Backup.ToNamespacedName(state.Obj().GetNamespace()),
 		"destination:", restore.Spec.Destination.Volume.ToNamespacedName(state.Obj().GetNamespace())).Info("Loading GCPNfsVolumeBackup")
 
 	//Load the nfsVolumeBackup object

--- a/pkg/skr/gcpnfsvolumerestore/reconciler.go
+++ b/pkg/skr/gcpnfsvolumerestore/reconciler.go
@@ -51,8 +51,11 @@ func (r *Reconciler) newAction() composed.Action {
 		loadGcpNfsVolume,
 		loadGcpNfsVolumeBackup,
 		loadScope,
+		acquireLease,
+		findRestoreOperation,
 		runNfsRestore,
 		checkRestoreOperation,
+		releaseLease,
 		removeFinalizer,
 		composed.StopAndForgetAction,
 	)

--- a/pkg/skr/gcpnfsvolumerestore/releaseLease.go
+++ b/pkg/skr/gcpnfsvolumerestore/releaseLease.go
@@ -1,0 +1,24 @@
+package gcpnfsvolumerestore
+
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/skr/common/leases"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func releaseLease(ctx context.Context, st composed.State) (error, context.Context) {
+	//If it reaches here, the operation is in final status
+	state := st.(*State)
+	restore := state.ObjAsGcpNfsVolumeRestore()
+	err := leases.Release(ctx, state.SkrCluster,
+		types.NamespacedName{Name: state.GcpNfsVolume.Name, Namespace: state.GcpNfsVolume.Namespace},
+		types.NamespacedName{Name: restore.Name, Namespace: restore.Namespace},
+		"restore")
+	if err != nil && !apierrors.IsNotFound(err) {
+		return composed.LogErrorAndReturn(err, "Error releasing lease", composed.StopWithRequeueDelay(util.Timing.T100ms()), ctx)
+	}
+	return nil, nil
+}

--- a/pkg/skr/gcpnfsvolumerestore/releaseLease_test.go
+++ b/pkg/skr/gcpnfsvolumerestore/releaseLease_test.go
@@ -1,0 +1,113 @@
+package gcpnfsvolumerestore
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+	"time"
+)
+
+type releaseLeaseSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *releaseLeaseSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *releaseLeaseSuite) TestReleaseLease_OtherLeased() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	// Being in deletion shouldn't have any impact on the logic
+	obj := deletingGcpNfsVolumeRestore.DeepCopy()
+	obj.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	assert.Nil(suite.T(), err)
+	state.GcpNfsVolume = gcpNfsVolume.DeepCopy()
+	leaseDuration := new(int32)
+	*leaseDuration = 600
+	otherOwner := "otherns/other"
+	err = factory.skrCluster.K8sClient().Create(ctx, &v1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("restore-%s", state.GcpNfsVolume.Name),
+			Namespace: state.GcpNfsVolume.Namespace,
+		},
+		Spec: v1.LeaseSpec{
+			HolderIdentity:       &otherOwner,
+			LeaseDurationSeconds: leaseDuration,
+			AcquireTime:          &metav1.MicroTime{Time: time.Now()},
+			RenewTime:            &metav1.MicroTime{Time: time.Now()},
+		},
+	})
+	assert.Nil(suite.T(), err)
+	err, _ = releaseLease(ctx, state)
+	assert.Nil(suite.T(), err)
+	lease := &v1.Lease{}
+	err = factory.skrCluster.K8sClient().Get(ctx, types.NamespacedName{Name: fmt.Sprintf("restore-%s", state.GcpNfsVolume.Name), Namespace: state.GcpNfsVolume.Namespace}, lease)
+	assert.Nil(suite.T(), err)
+	suite.Equal(*lease.Spec.HolderIdentity, otherOwner)
+}
+
+func (suite *releaseLeaseSuite) TestReleaseLease_SelfLeased() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	// Being in deletion shouldn't have any impact on the logic
+	obj := deletingGcpNfsVolumeRestore.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	assert.Nil(suite.T(), err)
+	state.GcpNfsVolume = gcpNfsVolume.DeepCopy()
+	leaseDuration := new(int32)
+	*leaseDuration = 600
+	owner := fmt.Sprintf("%s/%s", obj.Namespace, obj.Name)
+	err = factory.skrCluster.K8sClient().Create(ctx, &v1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("restore-%s", state.GcpNfsVolume.Name),
+			Namespace: state.GcpNfsVolume.Namespace,
+		},
+		Spec: v1.LeaseSpec{
+			HolderIdentity:       &owner,
+			LeaseDurationSeconds: leaseDuration,
+			AcquireTime:          &metav1.MicroTime{Time: time.Now()},
+			RenewTime:            &metav1.MicroTime{Time: time.Now()},
+		},
+	})
+	assert.Nil(suite.T(), err)
+	err, _ = releaseLease(ctx, state)
+	assert.Nil(suite.T(), err)
+	lease := &v1.Lease{}
+	err = factory.skrCluster.K8sClient().Get(ctx, types.NamespacedName{Name: fmt.Sprintf("restore-%s", state.GcpNfsVolume.Name), Namespace: state.GcpNfsVolume.Namespace}, lease)
+	suite.True(apierrors.IsNotFound(err))
+}
+
+func TestReleaseLease(t *testing.T) {
+	suite.Run(t, new(releaseLeaseSuite))
+}

--- a/pkg/skr/gcpnfsvolumerestore/removeFinalizer.go
+++ b/pkg/skr/gcpnfsvolumerestore/removeFinalizer.go
@@ -6,7 +6,6 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func removeFinalizer(ctx context.Context, st composed.State) (error, context.Context) {
@@ -30,11 +29,12 @@ func removeFinalizer(ctx context.Context, st composed.State) (error, context.Con
 			Run(ctx, state)
 	}
 
-	controllerutil.RemoveFinalizer(state.Obj(), cloudresourcesv1beta1.Finalizer)
-	err := state.UpdateObj(ctx)
+	modified, err := st.PatchObjRemoveFinalizer(ctx, cloudresourcesv1beta1.Finalizer)
 	if err != nil {
 		return composed.LogErrorAndReturn(err, "Error saving SKR GcpNfsVolumeRestore after finalizer remove", composed.StopWithRequeue, ctx)
 	}
-
+	if modified {
+		composed.LoggerFromCtx(ctx).Info("Finalizer removed")
+	}
 	return composed.StopAndForget, nil
 }

--- a/pkg/skr/gcpnfsvolumerestore/removeFinalizer_test.go
+++ b/pkg/skr/gcpnfsvolumerestore/removeFinalizer_test.go
@@ -26,7 +26,7 @@ func (suite *removeFinalizerSuite) TestRemoveFinalizer() {
 		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
 	}))
 	defer fakeHttpServer.Close()
-	deletingObj := deletingGpNfsVolumeRestore.DeepCopy()
+	deletingObj := deletingGcpNfsVolumeRestore.DeepCopy()
 	factory, err := newTestStateFactoryWithObj(fakeHttpServer, deletingObj)
 	assert.Nil(suite.T(), err)
 

--- a/pkg/skr/gcpnfsvolumerestore/runNfsRestore_test.go
+++ b/pkg/skr/gcpnfsvolumerestore/runNfsRestore_test.go
@@ -81,7 +81,7 @@ func (suite *runNfsRestoreSuite) TestRunNfsRestoreDeletionTimestamp() {
 		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
 	}))
 	defer fakeHttpServer.Close()
-	deletingObj := deletingGpNfsVolumeRestore.DeepCopy()
+	deletingObj := deletingGcpNfsVolumeRestore.DeepCopy()
 	factory, err := newTestStateFactoryWithObj(fakeHttpServer, deletingObj)
 	assert.Nil(suite.T(), err)
 

--- a/pkg/skr/gcpnfsvolumerestore/setProcessing_test.go
+++ b/pkg/skr/gcpnfsvolumerestore/setProcessing_test.go
@@ -30,7 +30,7 @@ func (suite *setProcessingSuite) TestSetProcessingWhenDeleting() {
 		http.Error(w, "Not Found", http.StatusNotFound)
 	}))
 	defer fakeHttpServer.Close()
-	obj := deletingGpNfsVolumeRestore.DeepCopy()
+	obj := deletingGcpNfsVolumeRestore.DeepCopy()
 	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
 	suite.Nil(err)
 

--- a/pkg/skr/gcpnfsvolumerestore/state_test.go
+++ b/pkg/skr/gcpnfsvolumerestore/state_test.go
@@ -120,7 +120,7 @@ var gcpNfsVolumeRestore = cloudresourcesv1beta1.GcpNfsVolumeRestore{
 	},
 }
 
-var deletingGpNfsVolumeRestore = cloudresourcesv1beta1.GcpNfsVolumeRestore{
+var deletingGcpNfsVolumeRestore = cloudresourcesv1beta1.GcpNfsVolumeRestore{
 	ObjectMeta: v1.ObjectMeta{
 		Name:              "test-gcp-nfs-volume-restore",
 		Namespace:         "test",

--- a/pkg/skr/runtime/config/config_test.go
+++ b/pkg/skr/runtime/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestConfigFromEnv(t *testing.T) {
@@ -28,6 +29,7 @@ func TestConfigFromFile(t *testing.T) {
 	}()
 	err = os.WriteFile(filepath.Join(dir, "skrRuntime.yaml"), []byte(`
 providersDir: /some/path/from/file
+lockingLeaseDuration: 10s
 `), 0644)
 	assert.NoError(t, err, "error creating key file")
 
@@ -40,4 +42,5 @@ providersDir: /some/path/from/file
 	cfg.Read()
 
 	assert.Equal(t, "/some/path/from/file", SkrRuntimeConfig.ProvidersDir)
+	assert.Equal(t, 10*time.Second, SkrRuntimeConfig.SkrLockingLeaseDuration)
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Introducing leasing mechanism to prevent conflicting actions
- Adding api to restore client to find an existing running restore to prevent duplicate execution of restore 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #584 