### PR TITLE
feat(AzureVpcPeering): remove PollUntilDone

### DIFF
--- a/api/cloud-control/v1beta1/vpcpeering_types.go
+++ b/api/cloud-control/v1beta1/vpcpeering_types.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -135,6 +136,20 @@ func (in *VpcPeering) State() string {
 
 func (in *VpcPeering) SetState(v string) {
 	in.Status.State = v
+}
+
+func (in *VpcPeering) CloneForPatchStatus() client.Object {
+	return &VpcPeering{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "VpcPeering",
+			APIVersion: GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: in.Namespace,
+			Name:      in.Name,
+		},
+		Status: in.Status,
+	}
 }
 
 //+kubebuilder:object:root=true

--- a/api/cloud-resources/v1beta1/awsredisinstance_types.go
+++ b/api/cloud-resources/v1beta1/awsredisinstance_types.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	featuretypes "github.com/kyma-project/cloud-manager/pkg/feature/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // AwsRedisInstanceSpec defines the desired state of AwsRedisInstance
@@ -118,6 +119,20 @@ func (in *AwsRedisInstance) State() string {
 
 func (in *AwsRedisInstance) SetState(v string) {
 	in.Status.State = v
+}
+
+func (in *AwsRedisInstance) CloneForPatchStatus() client.Object {
+	return &AwsRedisInstance{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AwsRedisInstance",
+			APIVersion: GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: in.Namespace,
+			Name:      in.Name,
+		},
+		Status: in.Status,
+	}
 }
 
 //+kubebuilder:object:root=true

--- a/pkg/kcp/provider/azure/mock/networkStore.go
+++ b/pkg/kcp/provider/azure/mock/networkStore.go
@@ -132,9 +132,9 @@ func (s *networkStore) getNetworkEntryNoLock(resourceGroupName, virtualNetworkNa
 
 // VpcPeeringClient ==============================================
 
-func (s *networkStore) CreatePeering(ctx context.Context, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, remoteVnetId string, allowVnetAccess bool) (*armnetwork.VirtualNetworkPeering, error) {
+func (s *networkStore) CreatePeering(ctx context.Context, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, remoteVnetId string, allowVnetAccess bool) error {
 	if isContextCanceled(ctx) {
-		return nil, context.Canceled
+		return context.Canceled
 	}
 	s.m.Lock()
 	defer s.m.Unlock()
@@ -144,16 +144,16 @@ func (s *networkStore) CreatePeering(ctx context.Context, resourceGroupName, vir
 	_, err := s.getPeeringNoLock(resourceGroupName, virtualNetworkName, virtualNetworkPeeringName)
 	if azuremeta.IgnoreNotFoundError(err) != nil {
 		// errors like network not found
-		return nil, err
+		return err
 	}
 	if err == nil {
 		// peering already exists
-		return nil, fmt.Errorf("vpc peering %s already exists", id)
+		return fmt.Errorf("vpc peering %s already exists", id)
 	}
 
 	entry, err := s.getNetworkEntryNoLock(resourceGroupName, virtualNetworkName)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if entry.network.Properties == nil {
@@ -177,7 +177,7 @@ func (s *networkStore) CreatePeering(ctx context.Context, resourceGroupName, vir
 
 	entry.network.Properties.VirtualNetworkPeerings = append(entry.network.Properties.VirtualNetworkPeerings, peering)
 
-	return util.JsonClone(peering)
+	return nil
 }
 
 func (s *networkStore) ListPeerings(ctx context.Context, resourceGroup string, virtualNetworkName string) ([]*armnetwork.VirtualNetworkPeering, error) {

--- a/pkg/kcp/provider/azure/vpcpeering/client/client.go
+++ b/pkg/kcp/provider/azure/vpcpeering/client/client.go
@@ -14,7 +14,7 @@ type Client interface {
 		virtualNetworkName,
 		virtualNetworkPeeringName,
 		remoteVnetId string,
-		allowVnetAccess bool) (*armnetwork.VirtualNetworkPeering, error)
+		allowVnetAccess bool) error
 
 	ListPeerings(ctx context.Context, resourceGroupName string, virtualNetworkName string) ([]*armnetwork.VirtualNetworkPeering, error)
 	GetPeering(ctx context.Context, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName string) (*armnetwork.VirtualNetworkPeering, error)
@@ -60,8 +60,8 @@ func (c *client) CreatePeering(
 	virtualNetworkName,
 	virtualNetworkPeeringName,
 	remoteVnetId string,
-	allowVnetAccess bool) (*armnetwork.VirtualNetworkPeering, error) {
-	poller, err := c.peering.BeginCreateOrUpdate(
+	allowVnetAccess bool) error {
+	_, err := c.peering.BeginCreateOrUpdate(
 		ctx,
 		resourceGroupName,
 		virtualNetworkName,
@@ -80,17 +80,7 @@ func (c *client) CreatePeering(
 		nil,
 	)
 
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := poller.PollUntilDone(ctx, nil)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &res.VirtualNetworkPeering, nil
+	return err
 }
 
 func (c *client) ListPeerings(ctx context.Context, resourceGroupName string, virtualNetworkName string) ([]*armnetwork.VirtualNetworkPeering, error) {
@@ -136,17 +126,6 @@ func (c *client) GetNetwork(ctx context.Context, resourceGroupName, virtualNetwo
 }
 
 func (c *client) DeletePeering(ctx context.Context, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName string) error {
-	pooler, err := c.peering.BeginDelete(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, nil)
-
-	if err != nil {
-		return err
-	}
-
-	_, err = pooler.PollUntilDone(ctx, nil)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err := c.peering.BeginDelete(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, nil)
+	return err
 }

--- a/pkg/kcp/provider/azure/vpcpeering/createRemoteVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/createRemoteVpcPeering.go
@@ -6,10 +6,8 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	azureconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/config"
 	azuremeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/meta"
-	"github.com/kyma-project/cloud-manager/pkg/util"
-	"k8s.io/utils/ptr"
-
 	azureutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/util"
+	"github.com/kyma-project/cloud-manager/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -52,7 +50,7 @@ func createRemoteVpcPeering(ctx context.Context, st composed.State) (error, cont
 		state.Scope().Spec.Scope.Azure.VpcNetwork, // ResourceGroup name is the same as VPC network name.
 		state.Scope().Spec.Scope.Azure.VpcNetwork)
 
-	peering, err := c.CreatePeering(ctx,
+	err = c.CreatePeering(ctx,
 		resourceGroupName,
 		virtualNetworkName,
 		virtualNetworkPeeringName,
@@ -78,25 +76,7 @@ func createRemoteVpcPeering(ctx context.Context, st composed.State) (error, cont
 			Run(ctx, state)
 	}
 
-	peering = nil
-
-	if peering == nil {
-		return composed.StopWithRequeue, nil
-	}
-
-	state.remotePeering = peering
-
-	logger = logger.WithValues("remotePeeringId", ptr.Deref(peering.ID, ""))
-
-	ctx = composed.LoggerIntoCtx(ctx, logger)
-
 	logger.Info("Azure remote VPC Peering created")
 
-	obj.Status.RemoteId = ptr.Deref(peering.ID, "")
-
-	return composed.UpdateStatus(obj).
-		ErrorLogMessage("Error updating VpcPeering status with remote connection id").
-		FailedError(composed.StopWithRequeue).
-		SuccessErrorNil().
-		Run(ctx, state)
+	return composed.StopWithRequeue, nil
 }

--- a/pkg/kcp/provider/azure/vpcpeering/createRemoteVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/createRemoteVpcPeering.go
@@ -78,6 +78,12 @@ func createRemoteVpcPeering(ctx context.Context, st composed.State) (error, cont
 			Run(ctx, state)
 	}
 
+	peering = nil
+
+	if peering == nil {
+		return composed.StopWithRequeue, nil
+	}
+
 	state.remotePeering = peering
 
 	logger = logger.WithValues("remotePeeringId", ptr.Deref(peering.ID, ""))

--- a/pkg/kcp/provider/azure/vpcpeering/createVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/createVpcPeering.go
@@ -7,7 +7,6 @@ import (
 	azuremeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/meta"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 func createVpcPeering(ctx context.Context, st composed.State) (error, context.Context) {
@@ -22,7 +21,7 @@ func createVpcPeering(ctx context.Context, st composed.State) (error, context.Co
 	resourceGroupName := state.Scope().Spec.Scope.Azure.VpcNetwork // TBD resourceGroup name have the same name as VPC
 	virtualNetworkPeeringName := obj.Name
 
-	peering, err := state.client.CreatePeering(ctx,
+	err := state.client.CreatePeering(ctx,
 		resourceGroupName,
 		state.Scope().Spec.Scope.Azure.VpcNetwork,
 		virtualNetworkPeeringName,
@@ -48,28 +47,7 @@ func createVpcPeering(ctx context.Context, st composed.State) (error, context.Co
 			Run(ctx, state)
 	}
 
-	peering = nil
-
-	if peering == nil {
-		return composed.StopWithRequeue, nil
-	}
-
-	state.peering = peering
-
-	logger = logger.WithValues("id", ptr.Deref(peering.ID, ""))
-
-	ctx = composed.LoggerIntoCtx(ctx, logger)
-
 	logger.Info("Azure VPC Peering created")
 
-	obj.Status.Id = ptr.Deref(peering.ID, "")
-	obj.Status.State = cloudcontrolv1beta1.VirtualNetworkPeeringStateInitiated
-
-	err = state.UpdateObjStatus(ctx)
-
-	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error updating VPC Peering status with connection id", composed.StopWithRequeue, ctx)
-	}
-
-	return nil, ctx
+	return composed.StopWithRequeue, ctx
 }

--- a/pkg/kcp/provider/azure/vpcpeering/createVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/createVpcPeering.go
@@ -48,6 +48,12 @@ func createVpcPeering(ctx context.Context, st composed.State) (error, context.Co
 			Run(ctx, state)
 	}
 
+	peering = nil
+
+	if peering == nil {
+		return composed.StopWithRequeue, nil
+	}
+
 	state.peering = peering
 
 	logger = logger.WithValues("id", ptr.Deref(peering.ID, ""))

--- a/pkg/kcp/provider/azure/vpcpeering/createVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/createVpcPeering.go
@@ -49,5 +49,5 @@ func createVpcPeering(ctx context.Context, st composed.State) (error, context.Co
 
 	logger.Info("Azure VPC Peering created")
 
-	return composed.StopWithRequeue, ctx
+	return nil, nil
 }

--- a/pkg/kcp/provider/azure/vpcpeering/loadRemoteVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/loadRemoteVpcPeering.go
@@ -19,20 +19,20 @@ func loadRemoteVpcPeering(ctx context.Context, st composed.State) (error, contex
 	clientSecret := azureconfig.AzureConfig.PeeringCreds.ClientSecret
 	tenantId := state.tenantId
 
-	remote, err := azureutil.ParseResourceID(obj.Spec.VpcPeering.Azure.RemoteVnet)
+	resource, err := azureutil.ParseResourceID(obj.Spec.VpcPeering.Azure.RemoteVnet)
 
 	if err != nil {
 		return composed.LogErrorAndReturn(err, "Error parsing remote virtual network peering ID", composed.StopAndForget, ctx)
 	}
 
-	subscriptionId := remote.Subscription
+	subscriptionId := resource.Subscription
 
 	c, err := state.provider(ctx, clientId, clientSecret, subscriptionId, tenantId)
 	if err != nil {
 		return composed.LogErrorAndReturn(err, "Failed to create azure loadRemoteVpcPeering client", composed.StopWithRequeueDelay(util.Timing.T300000ms()), ctx)
 	}
 
-	virtualNetworkName := remote.ResourceName
+	virtualNetworkName := resource.ResourceName
 	resourceGroupName := obj.Spec.VpcPeering.Azure.RemoteResourceGroup
 	virtualNetworkPeeringName := obj.Spec.VpcPeering.Azure.RemotePeeringName
 

--- a/pkg/kcp/provider/azure/vpcpeering/loadRemoteVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/loadRemoteVpcPeering.go
@@ -54,11 +54,13 @@ func loadRemoteVpcPeering(ctx context.Context, st composed.State) (error, contex
 
 	logger.Info("Azure remote VPC peering loaded")
 
-	if len(obj.Status.RemoteId) > 0 {
+	remoteId := ptr.Deref(peering.ID, "")
+
+	if obj.Status.RemoteId == remoteId {
 		return nil, ctx
 	}
 
-	obj.Status.RemoteId = ptr.Deref(peering.ID, "")
+	obj.Status.RemoteId = remoteId
 
 	return composed.PatchStatus(obj).
 		ErrorLogMessage("Error updating VpcPeering status after loading vpc peering connection").

--- a/pkg/kcp/provider/azure/vpcpeering/loadVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/loadVpcPeering.go
@@ -34,15 +34,20 @@ func loadVpcPeering(ctx context.Context, st composed.State) (error, context.Cont
 
 	logger.Info("Azure VPC Peering loaded")
 
-	if len(obj.Status.Id) > 0 {
+	id := ptr.Deref(peering.ID, "")
+
+	var peeringState string
+
+	if peering.Properties.PeeringState != nil {
+		peeringState = string(*peering.Properties.PeeringState)
+	}
+
+	if obj.Status.Id == id && obj.Status.State == peeringState {
 		return nil, ctx
 	}
 
-	obj.Status.Id = ptr.Deref(peering.ID, "")
-
-	if peering.Properties.PeeringState != nil {
-		obj.Status.State = string(*peering.Properties.PeeringState)
-	}
+	obj.Status.Id = id
+	obj.Status.State = peeringState
 
 	return composed.PatchStatus(obj).
 		ErrorLogMessage("Error updating VpcPeering status after loading vpc peering connection").

--- a/pkg/kcp/provider/azure/vpcpeering/loadVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/loadVpcPeering.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	azuremeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/meta"
-	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/util"
 	"k8s.io/utils/ptr"
 )
 
@@ -13,17 +12,15 @@ func loadVpcPeering(ctx context.Context, st composed.State) (error, context.Cont
 	logger := composed.LoggerFromCtx(ctx)
 	obj := state.ObjAsVpcPeering()
 
-	if len(obj.Status.Id) == 0 {
+	virtualNetworkName := state.Scope().Spec.Scope.Azure.VpcNetwork
+	resourceGroupName := virtualNetworkName // resourceGroup name have the same name as VPC
+	virtualNetworkPeeringName := obj.Name
+
+	peering, err := state.client.GetPeering(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName)
+
+	if azuremeta.IsNotFound(err) {
 		return nil, nil
 	}
-
-	resource, err := util.ParseResourceID(obj.Status.Id)
-
-	if err != nil {
-		return azuremeta.LogErrorAndReturn(err, "Error parsing virtual network peering ID", ctx)
-	}
-
-	peering, err := state.client.GetPeering(ctx, resource.ResourceGroup, resource.ResourceName, resource.SubResourceName)
 
 	if err != nil {
 		return azuremeta.LogErrorAndReturn(err, "Error loading VPC Peering", ctx)
@@ -37,5 +34,18 @@ func loadVpcPeering(ctx context.Context, st composed.State) (error, context.Cont
 
 	logger.Info("Azure VPC Peering loaded")
 
-	return nil, ctx
+	if len(obj.Status.Id) > 0 {
+		return nil, ctx
+	}
+
+	obj.Status.Id = ptr.Deref(peering.ID, "")
+
+	if peering.Properties.PeeringState != nil {
+		obj.Status.State = string(*peering.Properties.PeeringState)
+	}
+
+	return composed.PatchStatus(obj).
+		ErrorLogMessage("Error updating VpcPeering status after loading vpc peering connection").
+		SuccessErrorNil().
+		Run(ctx, state)
 }

--- a/pkg/kcp/provider/azure/vpcpeering/waitVpcPeeringReady.go
+++ b/pkg/kcp/provider/azure/vpcpeering/waitVpcPeeringReady.go
@@ -12,6 +12,10 @@ func waitVpcPeeringReady(ctx context.Context, st composed.State) (error, context
 	state := st.(*State)
 	logger := composed.LoggerFromCtx(ctx)
 
+	if state.peering == nil {
+		return composed.StopWithRequeue, nil
+	}
+
 	if ptr.Deref(state.peering.Properties.PeeringState, "") != armnetwork.VirtualNetworkPeeringStateConnected {
 		logger.Info("Waiting for peering Connected state",
 			"Id", ptr.Deref(state.peering.ID, ""),

--- a/pkg/skr/azurevpcpeering/updateStatus.go
+++ b/pkg/skr/azurevpcpeering/updateStatus.go
@@ -2,16 +2,11 @@ package azurevpcpeering
 
 import (
 	"context"
-	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
-	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func updateStatus(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
-	logger := composed.LoggerFromCtx(ctx)
 	obj := state.ObjAsAzureVpcPeering()
 
 	if state.KcpVpcPeering == nil {
@@ -19,42 +14,13 @@ func updateStatus(ctx context.Context, st composed.State) (error, context.Contex
 		return nil, nil
 	}
 
-	kcpCondErr := meta.FindStatusCondition(state.KcpVpcPeering.Status.Conditions, cloudcontrolv1beta1.ConditionTypeError)
-	kcpCondReady := meta.FindStatusCondition(state.KcpVpcPeering.Status.Conditions, cloudcontrolv1beta1.ConditionTypeReady)
-
-	skrCondErr := meta.FindStatusCondition(state.ObjAsAzureVpcPeering().Status.Conditions, cloudresourcesv1beta1.ConditionTypeError)
-	skrCondReady := meta.FindStatusCondition(state.ObjAsAzureVpcPeering().Status.Conditions, cloudresourcesv1beta1.ConditionTypeReady)
-
-	if kcpCondErr != nil && (skrCondErr == nil || skrCondErr.Message != kcpCondErr.Message) {
+	if composed.AnyConditionChanged(obj, *state.KcpVpcPeering.Conditions()...) || obj.Status.State != state.KcpVpcPeering.Status.State {
 		obj.Status.State = state.KcpVpcPeering.Status.State
-		return composed.UpdateStatus(obj).
-			SetCondition(metav1.Condition{
-				Type:    cloudresourcesv1beta1.ConditionTypeError,
-				Status:  metav1.ConditionTrue,
-				Reason:  cloudresourcesv1beta1.ConditionReasonError,
-				Message: kcpCondErr.Message,
-			}).
-			RemoveConditions(cloudresourcesv1beta1.ConditionTypeReady).
-			ErrorLogMessage("Error updating SKR AzureVpcPeering status with not ready condition due to KCP error").
+		composed.UpdateStatus(obj).
+			SetExclusiveConditions(*state.KcpVpcPeering.Conditions()...).
+			ErrorLogMessage("Error updating SKR AzureVpcPeering status").
 			SuccessLogMsg("Updated and forgot SKR AzureVpcPeering status with Error condition").
 			SuccessError(composed.StopAndForget).
-			Run(ctx, state)
-	}
-
-	if kcpCondReady != nil && skrCondReady == nil {
-		logger.Info("Updating SKR AzureVpcPeering status with Ready condition")
-
-		obj.Status.State = state.KcpVpcPeering.Status.State
-		return composed.UpdateStatus(obj).
-			SetCondition(metav1.Condition{
-				Type:    cloudresourcesv1beta1.ConditionTypeReady,
-				Status:  metav1.ConditionTrue,
-				Reason:  cloudresourcesv1beta1.ConditionTypeReady,
-				Message: kcpCondReady.Message,
-			}).
-			RemoveConditions(cloudresourcesv1beta1.ConditionTypeError).
-			ErrorLogMessage("Error updating SKR AzureVpcPeering status with ready condition").
-			SuccessError(composed.StopWithRequeue).
 			Run(ctx, state)
 	}
 

--- a/pkg/skr/azurevpcpeering/updateStatus.go
+++ b/pkg/skr/azurevpcpeering/updateStatus.go
@@ -19,7 +19,7 @@ func updateStatus(ctx context.Context, st composed.State) (error, context.Contex
 		composed.UpdateStatus(obj).
 			SetExclusiveConditions(*state.KcpVpcPeering.Conditions()...).
 			ErrorLogMessage("Error updating SKR AzureVpcPeering status").
-			SuccessLogMsg("Updated and forgot SKR AzureVpcPeering status with Error condition").
+			SuccessLogMsg("Updated and forgot SKR AzureVpcPeering status").
 			SuccessError(composed.StopAndForget).
 			Run(ctx, state)
 	}

--- a/pkg/skr/azurevpcpeering/updateStatus.go
+++ b/pkg/skr/azurevpcpeering/updateStatus.go
@@ -16,7 +16,7 @@ func updateStatus(ctx context.Context, st composed.State) (error, context.Contex
 
 	if composed.AnyConditionChanged(obj, *state.KcpVpcPeering.Conditions()...) || obj.Status.State != state.KcpVpcPeering.Status.State {
 		obj.Status.State = state.KcpVpcPeering.Status.State
-		composed.UpdateStatus(obj).
+		return composed.UpdateStatus(obj).
 			SetExclusiveConditions(*state.KcpVpcPeering.Conditions()...).
 			ErrorLogMessage("Error updating SKR AzureVpcPeering status").
 			SuccessLogMsg("Updated and forgot SKR AzureVpcPeering status").


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Azure client modified not to use PullUntilDone as it may wait indefinitely.
- KCP Azure reconciler logic is changed according to the change that client.CreatePeering no longer returns created armnetwork.VirtualNetworkPeering object
- SKR updateStatus update logic is simplified