### PR TITLE
fix(GcpNfsBackupSchedule): optional sourceRef namespace name

### DIFF
--- a/api/cloud-resources/v1beta1/gcpnfsbackupschedule_types.go
+++ b/api/cloud-resources/v1beta1/gcpnfsbackupschedule_types.go
@@ -79,7 +79,7 @@ type GcpNfsBackupScheduleSpec struct {
 
 // GcpNfsBackupScheduleStatus defines the observed state of GcpNfsBackupSchedule
 type GcpNfsBackupScheduleStatus struct {
-	// +kubebuilder:validation:Enum=Processing;Pending;Suspended;Active;Done;Error
+	// +kubebuilder:validation:Enum=Processing;Pending;Suspended;Active;Done;Error;Deleting
 	State string `json:"state,omitempty"`
 
 	// List of status conditions

--- a/config/crd/bases/cloud-resources.kyma-project.io_gcpnfsbackupschedules.yaml
+++ b/config/crd/bases/cloud-resources.kyma-project.io_gcpnfsbackupschedules.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-    cloud-resources.kyma-project.io/version: v0.0.2
+    cloud-resources.kyma-project.io/version: v0.0.3
   name: gcpnfsbackupschedules.cloud-resources.kyma-project.io
 spec:
   group: cloud-resources.kyma-project.io
@@ -355,6 +355,7 @@ spec:
                     - Active
                     - Done
                     - Error
+                    - Deleting
                   type: string
               type: object
           type: object

--- a/config/dist/skr/crd/bases/providers/gcp/cloud-resources.kyma-project.io_gcpnfsbackupschedules.yaml
+++ b/config/dist/skr/crd/bases/providers/gcp/cloud-resources.kyma-project.io_gcpnfsbackupschedules.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-    cloud-resources.kyma-project.io/version: v0.0.2
+    cloud-resources.kyma-project.io/version: v0.0.3
   name: gcpnfsbackupschedules.cloud-resources.kyma-project.io
 spec:
   group: cloud-resources.kyma-project.io
@@ -355,6 +355,7 @@ spec:
                     - Active
                     - Done
                     - Error
+                    - Deleting
                   type: string
               type: object
           type: object

--- a/config/patchAfterMakeManifests.sh
+++ b/config/patchAfterMakeManifests.sh
@@ -15,4 +15,4 @@ yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.1
 yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.1"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_azureredisinstances.yaml
 yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.3"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_gcpnfsvolumebackups.yaml
 yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.2"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_gcpnfsvolumerestores.yaml
-yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.2"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_gcpnfsbackupschedules.yaml
+yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.3"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_gcpnfsbackupschedules.yaml

--- a/pkg/skr/backupschedule/backupImplGcpNfs.go
+++ b/pkg/skr/backupschedule/backupImplGcpNfs.go
@@ -21,7 +21,7 @@ func (impl *backupImplGcpNfs) emptyBackupList() client.ObjectList {
 func (impl *backupImplGcpNfs) toObjectSlice(list client.ObjectList) []client.Object {
 	var objects []client.Object
 
-	if x, ok := list.(*cloudresourcesv1beta1.GcpNfsVolumeList); ok {
+	if x, ok := list.(*cloudresourcesv1beta1.GcpNfsVolumeBackupList); ok {
 		for _, item := range x.Items {
 			objects = append(objects, &item)
 		}

--- a/pkg/skr/backupschedule/deleteCascade.go
+++ b/pkg/skr/backupschedule/deleteCascade.go
@@ -31,6 +31,10 @@ func deleteCascade(ctx context.Context, st composed.State) (error, context.Conte
 	logger.WithValues("GcpNfsBackupSchedule", schedule.GetName()).Info("Cascade delete of created backups.")
 
 	for _, backup := range state.Backups {
+		if composed.IsMarkedForDeletion(backup) {
+			logger.WithValues("Backup", backup.GetName()).Info("Backup is already being deleted.")
+			continue
+		}
 		logger.WithValues("Backup", backup.GetName()).Info("Deleting backup object")
 		err := state.Cluster().K8sClient().Delete(ctx, backup)
 		if err != nil {

--- a/pkg/skr/backupschedule/loadSource.go
+++ b/pkg/skr/backupschedule/loadSource.go
@@ -2,7 +2,6 @@ package backupschedule
 
 import (
 	"context"
-
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/kyma-project/cloud-manager/pkg/util"
@@ -66,9 +65,14 @@ func loadSource(ctx context.Context, st composed.State) (error, context.Context)
 
 func getSourceRef(ctx context.Context, state *State) (composed.ObjWithConditions, error) {
 	schedule := state.ObjAsBackupSchedule()
+	namespace := schedule.GetSourceRef().Namespace
+	if len(namespace) <= 0 {
+		namespace = schedule.GetNamespace()
+	}
+
 	key := types.NamespacedName{
 		Name:      schedule.GetSourceRef().Name,
-		Namespace: schedule.GetSourceRef().Namespace,
+		Namespace: namespace,
 	}
 
 	source := state.backupImpl.emptySourceObject()


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- optional namespace in GcpNfsBackupSchedule `sourceRef`
- `DeleteCascade` option is not deleting the backup resources.

**Related issue(s)**
part of #585
fixes #623