### PR TITLE
feat(AzureVpcPeering): local peering name

### DIFF
--- a/api/cloud-control/v1beta1/vpcpeering_types.go
+++ b/api/cloud-control/v1beta1/vpcpeering_types.go
@@ -176,6 +176,13 @@ func (in *VpcPeering) CloneForPatchStatus() client.Object {
 	}
 }
 
+func (in *VpcPeering) GetLocalPeeringName() string {
+	if len(in.Spec.Details.LocalPeeringName) > 0 {
+		return in.Spec.Details.LocalPeeringName
+	}
+	return in.Name
+}
+
 //+kubebuilder:object:root=true
 
 // VpcPeeringList contains a list of VpcPeering

--- a/pkg/kcp/provider/azure/vpcpeering/peeringLocalCreate.go
+++ b/pkg/kcp/provider/azure/vpcpeering/peeringLocalCreate.go
@@ -22,7 +22,7 @@ func peeringLocalCreate(ctx context.Context, st composed.State) (error, context.
 		ctx,
 		state.localNetworkId.ResourceGroup,
 		state.localNetworkId.NetworkName(),
-		state.ObjAsVpcPeering().Name,
+		state.ObjAsVpcPeering().GetLocalPeeringName(),
 		state.remoteNetworkId.String(),
 		true,
 	)

--- a/pkg/kcp/provider/azure/vpcpeering/peeringLocalLoad.go
+++ b/pkg/kcp/provider/azure/vpcpeering/peeringLocalLoad.go
@@ -16,7 +16,7 @@ func peeringLocalLoad(ctx context.Context, st composed.State) (error, context.Co
 		ctx,
 		state.localNetworkId.ResourceGroup,
 		state.localNetworkId.NetworkName(),
-		state.ObjAsVpcPeering().Name,
+		state.ObjAsVpcPeering().GetLocalPeeringName(),
 	)
 	if azuremeta.IsNotFound(err) {
 		logger.Info("Local Azure Peering not found for KCP VpcPeering")


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Allows KCP Azure VpcPeering to specify local peering name. If local peering name is not specified it will failback to object name