### PR TITLE
fix(gcpNfsVolumeRestore): completed restore should skip most of the r…

### DIFF
--- a/pkg/skr/gcpnfsvolumerestore/acquireLease.go
+++ b/pkg/skr/gcpnfsvolumerestore/acquireLease.go
@@ -17,7 +17,7 @@ func acquireLease(ctx context.Context, st composed.State) (error, context.Contex
 	logger := composed.LoggerFromCtx(ctx)
 	restore := state.ObjAsGcpNfsVolumeRestore()
 	res, err := leases.Acquire(ctx, state.SkrCluster,
-		types.NamespacedName{Name: state.GcpNfsVolume.Name, Namespace: state.GcpNfsVolume.Namespace},
+		restore.Spec.Destination.Volume.ToNamespacedName(restore.Namespace),
 		types.NamespacedName{Name: restore.Name, Namespace: restore.Namespace},
 		"restore")
 	switch res {

--- a/pkg/skr/gcpnfsvolumerestore/checkRestoreOperation.go
+++ b/pkg/skr/gcpnfsvolumerestore/checkRestoreOperation.go
@@ -86,7 +86,7 @@ func checkRestoreOperation(ctx context.Context, st composed.State) (error, conte
 			}).
 			OnUpdateSuccess(func(ctx context.Context) (error, context.Context) {
 				return nil, nil
-			}). //proceed in case deletion is in progress
+			}). //proceed to release the lease
 			SuccessLogMsg(fmt.Sprintf("Filestore Operation error : %s", op.Error.Message)).
 			Run(ctx, state)
 	}
@@ -102,7 +102,7 @@ func checkRestoreOperation(ctx context.Context, st composed.State) (error, conte
 		}).
 		OnUpdateSuccess(func(ctx context.Context) (error, context.Context) {
 			return nil, nil
-		}). //proceed in case deletion is in progress
+		}). //proceed to release the lease
 		SuccessLogMsg("GcpNfsVolumeRestore status got updated with Ready condition and Done state.").
 		Run(ctx, state)
 }

--- a/pkg/skr/gcpnfsvolumerestore/findRestoreOperation.go
+++ b/pkg/skr/gcpnfsvolumerestore/findRestoreOperation.go
@@ -26,7 +26,7 @@ func findRestoreOperation(ctx context.Context, st composed.State) (error, contex
 	logger.WithValues("nfsRestoreSource", restore.Spec.Source.Backup.ToNamespacedName(state.Obj().GetNamespace()),
 		"destination", restore.Spec.Destination.Volume.ToNamespacedName(state.Obj().GetNamespace())).Info("Finding GCP Restore Operations")
 
-	//If no OpIdentifier, then continue to next action.
+	//If OpIdentifier exists, then continue to next action.
 	if opName != "" {
 		return nil, nil
 	}

--- a/pkg/skr/gcpnfsvolumerestore/findRestoreOperation_test.go
+++ b/pkg/skr/gcpnfsvolumerestore/findRestoreOperation_test.go
@@ -3,7 +3,6 @@ package gcpnfsvolumerestore
 import (
 	"context"
 	"github.com/go-logr/logr"
-	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/kyma-project/cloud-manager/pkg/util"
@@ -170,7 +169,7 @@ func (suite *findRestoreOperationSuite) TestFindRestoreOperationOtherError() {
 	assert.Equal(suite.T(), "", fromK8s.Status.OpIdentifier)
 	assert.Equal(suite.T(), v1beta1.JobStateError, fromK8s.Status.State)
 	assert.Equal(suite.T(), metav1.ConditionTrue, fromK8s.Status.Conditions[0].Status)
-	assert.Equal(suite.T(), cloudcontrolv1beta1.ConditionTypeError, fromK8s.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, fromK8s.Status.Conditions[0].Type)
 }
 
 func TestFindRestoreOperation(t *testing.T) {

--- a/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolume.go
+++ b/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolume.go
@@ -4,13 +4,11 @@ import (
 	"context"
 
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
-	"github.com/kyma-project/cloud-manager/pkg/composed"
-	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 )
 
 func loadGcpNfsVolume(ctx context.Context, st composed.State) (error, context.Context) {
@@ -55,7 +53,7 @@ func loadGcpNfsVolume(ctx context.Context, st composed.State) (error, context.Co
 				SetExclusiveConditions(metav1.Condition{
 					Type:    cloudresourcesv1beta1.ConditionTypeError,
 					Status:  metav1.ConditionTrue,
-					Reason:  cloudcontrolv1beta1.ReasonGcpError,
+					Reason:  cloudresourcesv1beta1.ConditionReasonNfsVolumeNotReady,
 					Message: "Error loading GcpNfsVolume",
 				}).
 				SuccessError(composed.StopWithRequeueDelay(gcpclient.GcpConfig.GcpRetryWaitTime)).

--- a/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolumeBackup_test.go
+++ b/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolumeBackup_test.go
@@ -2,7 +2,6 @@ package gcpnfsvolumerestore
 
 import (
 	"context"
-	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
@@ -78,7 +77,7 @@ func (suite *loadGcpNfsVolumeBackupSuite) TestVolumeBackupNotReady() {
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), v1beta1.JobStateError, fromK8s.Status.State)
 	assert.Equal(suite.T(), metav1.ConditionTrue, fromK8s.Status.Conditions[0].Status)
-	assert.Equal(suite.T(), cloudcontrolv1beta1.ConditionTypeError, fromK8s.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, fromK8s.Status.Conditions[0].Type)
 }
 
 func (suite *loadGcpNfsVolumeBackupSuite) TestVolumeBackupReady() {

--- a/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolume_test.go
+++ b/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolume_test.go
@@ -2,7 +2,6 @@ package gcpnfsvolumerestore
 
 import (
 	"context"
-	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
@@ -79,7 +78,7 @@ func (suite *loadGcpNfsVolumeSuite) TestVolumeNotReady() {
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), v1beta1.JobStateError, fromK8s.Status.State)
 	assert.Equal(suite.T(), metav1.ConditionTrue, fromK8s.Status.Conditions[0].Status)
-	assert.Equal(suite.T(), cloudcontrolv1beta1.ConditionTypeError, fromK8s.Status.Conditions[0].Type)
+	assert.Equal(suite.T(), v1beta1.ConditionTypeError, fromK8s.Status.Conditions[0].Type)
 }
 
 func (suite *loadGcpNfsVolumeSuite) TestVolumeReady() {

--- a/pkg/skr/gcpnfsvolumerestore/reconciler.go
+++ b/pkg/skr/gcpnfsvolumerestore/reconciler.go
@@ -46,15 +46,20 @@ func (r *Reconciler) newAction() composed.Action {
 		"crGcpNfsVolumeRestoreMain",
 		feature.LoadFeatureContextFromObj(&cloudresourcesv1beta1.GcpNfsVolumeRestore{}),
 		composed.LoadObj,
-		setProcessing,
-		addFinalizer,
-		loadGcpNfsVolume,
-		loadGcpNfsVolumeBackup,
-		loadScope,
-		acquireLease,
-		findRestoreOperation,
-		runNfsRestore,
-		checkRestoreOperation,
+		composed.IfElse(
+			composed.Not(CompletedRestorePredicate),
+			composed.ComposeActions("crGcpNfsVolumeNotCompleted",
+				setProcessing,
+				addFinalizer,
+				loadGcpNfsVolume,
+				loadGcpNfsVolumeBackup,
+				loadScope,
+				acquireLease,
+				findRestoreOperation,
+				runNfsRestore,
+				checkRestoreOperation,
+			),
+			nil),
 		releaseLease,
 		removeFinalizer,
 		composed.StopAndForgetAction,
@@ -71,4 +76,9 @@ func NewReconciler(kymaRef klog.ObjectRef, kcpCluster cluster.Cluster, skrCluste
 		composedStateFactory: composedStateFactory,
 		stateFactory:         stateFactory,
 	}
+}
+
+func CompletedRestorePredicate(_ context.Context, state composed.State) bool {
+	currentState := state.Obj().(*cloudresourcesv1beta1.GcpNfsVolumeRestore).Status.State
+	return currentState == cloudresourcesv1beta1.JobStateDone || currentState == cloudresourcesv1beta1.JobStateFailed
 }

--- a/pkg/skr/gcpnfsvolumerestore/releaseLease.go
+++ b/pkg/skr/gcpnfsvolumerestore/releaseLease.go
@@ -14,7 +14,7 @@ func releaseLease(ctx context.Context, st composed.State) (error, context.Contex
 	state := st.(*State)
 	restore := state.ObjAsGcpNfsVolumeRestore()
 	err := leases.Release(ctx, state.SkrCluster,
-		types.NamespacedName{Name: state.GcpNfsVolume.Name, Namespace: state.GcpNfsVolume.Namespace},
+		restore.Spec.Destination.Volume.ToNamespacedName(restore.Namespace),
 		types.NamespacedName{Name: restore.Name, Namespace: restore.Namespace},
 		"restore")
 	if err != nil && !apierrors.IsNotFound(err) {

--- a/pkg/skr/gcpnfsvolumerestore/setProcessing_test.go
+++ b/pkg/skr/gcpnfsvolumerestore/setProcessing_test.go
@@ -3,7 +3,6 @@ package gcpnfsvolumerestore
 import (
 	"context"
 	"github.com/go-logr/logr"
-	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/stretchr/testify/suite"
@@ -61,7 +60,7 @@ func (suite *setProcessingSuite) TestSetProcessingWhenStateDone() {
 	//Get state object with GcpNfsVolume
 	obj.Status.State = v1beta1.JobStateDone
 	meta.SetStatusCondition(&obj.Status.Conditions, metav1.Condition{
-		Type:    cloudcontrolv1beta1.ConditionTypeReady,
+		Type:    v1beta1.ConditionTypeReady,
 		Status:  metav1.ConditionTrue,
 		Reason:  "test",
 		Message: "test",
@@ -89,7 +88,7 @@ func (suite *setProcessingSuite) TestSetProcessingWhenStateFailed() {
 	//Get state object with GcpNfsVolume
 	obj.Status.State = v1beta1.JobStateFailed
 	meta.SetStatusCondition(&obj.Status.Conditions, metav1.Condition{
-		Type:    cloudcontrolv1beta1.ConditionTypeError,
+		Type:    v1beta1.ConditionTypeError,
 		Status:  metav1.ConditionTrue,
 		Reason:  "test",
 		Message: "test",
@@ -139,7 +138,7 @@ func (suite *setProcessingSuite) TestSetProcessingWhenStateError() {
 	//Get state object with GcpNfsVolume
 	obj.Status.State = v1beta1.JobStateError
 	meta.SetStatusCondition(&obj.Status.Conditions, metav1.Condition{
-		Type:    cloudcontrolv1beta1.ConditionTypeError,
+		Type:    v1beta1.ConditionTypeError,
 		Status:  metav1.ConditionTrue,
 		Reason:  "test",
 		Message: "test",


### PR DESCRIPTION
…econciler

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- restore reconciler to skip most of the steps if restore already completed.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #639 