### PR TITLE
feat(AwsVpcPeering): wait KcpVpcPeering deleted before deleting Network

### DIFF
--- a/pkg/kcp/provider/aws/vpcpeering/checkNetworkTag.go
+++ b/pkg/kcp/provider/aws/vpcpeering/checkNetworkTag.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
+	"github.com/kyma-project/cloud-manager/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 func checkNetworkTag(ctx context.Context, st composed.State) (error, context.Context) {
@@ -26,7 +26,7 @@ func checkNetworkTag(ctx context.Context, st composed.State) (error, context.Con
 
 	// If VpcNetwork is found but tags don't match user can recover by adding tag to remote VPC network so, we are
 	// adding stop with requeue delay of one minute.
-	hasShootTag := util.HasEc2Tag(state.remoteVpc.Tags, state.Scope().Spec.ShootName)
+	hasShootTag := awsutil.HasEc2Tag(state.remoteVpc.Tags, state.Scope().Spec.ShootName)
 
 	if !hasShootTag {
 
@@ -41,7 +41,7 @@ func checkNetworkTag(ctx context.Context, st composed.State) (error, context.Con
 			}).
 			ErrorLogMessage("Error updating VpcPeering status due to remote vpc network tag mismatch").
 			FailedError(composed.StopWithRequeue).
-			SuccessError(composed.StopWithRequeueDelay(time.Minute)).
+			SuccessError(composed.StopWithRequeueDelay(util.Timing.T60000ms())).
 			Run(ctx, state)
 	}
 

--- a/pkg/kcp/provider/aws/vpcpeering/createRemoteClient.go
+++ b/pkg/kcp/provider/aws/vpcpeering/createRemoteClient.go
@@ -3,8 +3,11 @@ package vpcpeering
 import (
 	"context"
 	"fmt"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func createRemoteClient(ctx context.Context, st composed.State) (error, context.Context) {
@@ -32,7 +35,31 @@ func createRemoteClient(ctx context.Context, st composed.State) (error, context.
 	)
 
 	if err != nil {
-		return awsmeta.LogErrorAndReturn(err, "Error initializing remote AWS client", ctx)
+		logger.Error(err, "Error initializing remote AWS client")
+
+		changed := false
+		if meta.SetStatusCondition(state.ObjAsVpcPeering().Conditions(), metav1.Condition{
+			Type:    cloudcontrolv1beta1.ConditionTypeError,
+			Status:  metav1.ConditionTrue,
+			Reason:  cloudcontrolv1beta1.ConditionTypeError,
+			Message: fmt.Sprintf("Failed creating AWS client for account %s", remoteAccountId),
+		}) {
+			changed = true
+		}
+
+		if state.ObjAsVpcPeering().Status.State != string(cloudcontrolv1beta1.ErrorState) {
+			state.ObjAsVpcPeering().Status.State = string(cloudcontrolv1beta1.ErrorState)
+			changed = true
+		}
+
+		if !changed {
+			return composed.StopWithRequeueDelay(util.Timing.T300000ms()), nil
+		}
+
+		return composed.PatchStatus(state.ObjAsVpcPeering()).
+			ErrorLogMessage("Error patching KCP VpcPeering with error state after remote client creation failed").
+			SuccessError(composed.StopWithRequeueDelay(util.Timing.T300000ms())). // try again in 5mins
+			Run(ctx, state)
 	}
 
 	state.remoteClient = client

--- a/pkg/kcp/provider/aws/vpcpeering/createRoutes.go
+++ b/pkg/kcp/provider/aws/vpcpeering/createRoutes.go
@@ -51,15 +51,17 @@ func createRoutes(ctx context.Context, st composed.State) (error, context.Contex
 					changed = true
 				}
 
-				condition := metav1.Condition{
+				if meta.SetStatusCondition(obj.Conditions(), metav1.Condition{
 					Type:    cloudcontrolv1beta1.ConditionTypeError,
 					Status:  metav1.ConditionTrue,
 					Reason:  cloudcontrolv1beta1.ReasonFailedCreatingRoutes,
 					Message: fmt.Sprintf("AWS Failed to create route for route table %s", routeTableName),
+				}) {
+					changed = true
 				}
 
-				if meta.SetStatusCondition(obj.Conditions(), condition) {
-					changed = true
+				if obj.Status.State != string(cloudcontrolv1beta1.ErrorState) {
+					obj.Status.State = string(cloudcontrolv1beta1.ErrorState)
 				}
 
 				if changed {

--- a/pkg/kcp/provider/aws/vpcpeering/createRoutes.go
+++ b/pkg/kcp/provider/aws/vpcpeering/createRoutes.go
@@ -7,9 +7,13 @@ import (
 	"github.com/elliotchance/pie/v2"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
+	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
+	"github.com/kyma-project/cloud-manager/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	"k8s.io/apimachinery/pkg/api/meta"
 )
 
 func createRoutes(ctx context.Context, st composed.State) (error, context.Context) {
@@ -27,8 +31,8 @@ func createRoutes(ctx context.Context, st composed.State) (error, context.Contex
 			err := state.client.CreateRoute(ctx, t.RouteTableId, state.remoteVpc.CidrBlock, state.remoteVpcPeering.VpcPeeringConnectionId)
 
 			if err != nil {
-				routeTableName := util.GetEc2TagValue(t.Tags, "Name")
-				vpcName := util.GetEc2TagValue(state.vpc.Tags, "Name")
+				routeTableName := awsutil.GetEc2TagValue(t.Tags, "Name")
+				vpcName := awsutil.GetEc2TagValue(state.vpc.Tags, "Name")
 
 				logger.
 					WithValues(
@@ -38,16 +42,33 @@ func createRoutes(ctx context.Context, st composed.State) (error, context.Contex
 					).
 					Error(err, "Failed to create route")
 
-				return composed.UpdateStatus(obj).
-					SetExclusiveConditions(metav1.Condition{
-						Type:    cloudcontrolv1beta1.ConditionTypeError,
-						Status:  metav1.ConditionTrue,
-						Reason:  cloudcontrolv1beta1.ReasonFailedCreatingRoutes,
-						Message: fmt.Sprintf("AWS Failed to create route for route table %s", routeTableName),
-					}).
-					ErrorLogMessage("Error updating VpcPeering status when creating routes").
-					SuccessError(composed.StopAndForget).
-					Run(ctx, state)
+				if awsmeta.IsErrorRetryable(err) {
+					return composed.StopWithRequeueDelay(util.Timing.T10000ms()), nil
+				}
+
+				changed := false
+				if meta.RemoveStatusCondition(obj.Conditions(), cloudcontrolv1beta1.ConditionTypeReady) {
+					changed = true
+				}
+
+				condition := metav1.Condition{
+					Type:    cloudcontrolv1beta1.ConditionTypeError,
+					Status:  metav1.ConditionTrue,
+					Reason:  cloudcontrolv1beta1.ReasonFailedCreatingRoutes,
+					Message: fmt.Sprintf("AWS Failed to create route for route table %s", routeTableName),
+				}
+
+				if meta.SetStatusCondition(obj.Conditions(), condition) {
+					changed = true
+				}
+
+				if changed {
+					// User can not recover from internal error
+					return composed.PatchStatus(obj).
+						ErrorLogMessage("Error updating VpcPeering status when creating routes").
+						SuccessError(composed.StopAndForget).
+						Run(ctx, state)
+				}
 			}
 		}
 	}

--- a/pkg/kcp/provider/aws/vpcpeering/createVpcPeeringConnection.go
+++ b/pkg/kcp/provider/aws/vpcpeering/createVpcPeeringConnection.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
 	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -16,7 +17,6 @@ import (
 func createVpcPeeringConnection(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
 	logger := composed.LoggerFromCtx(ctx)
-	obj := state.ObjAsVpcPeering()
 
 	if state.vpcPeering != nil {
 		return nil, nil
@@ -33,11 +33,11 @@ func createVpcPeeringConnection(ctx context.Context, st composed.State) (error, 
 		},
 		{
 			Key:   ptr.To(common.TagCloudManagerRemoteName),
-			Value: ptr.To(obj.Spec.RemoteRef.String()),
+			Value: ptr.To(state.ObjAsVpcPeering().Spec.RemoteRef.String()),
 		},
 		{
 			Key:   ptr.To(common.TagScope),
-			Value: ptr.To(obj.Spec.Scope.Name),
+			Value: ptr.To(state.ObjAsVpcPeering().Spec.Scope.Name),
 		},
 		{
 			Key:   ptr.To(common.TagShoot),
@@ -47,7 +47,7 @@ func createVpcPeeringConnection(ctx context.Context, st composed.State) (error, 
 
 	remoteRegion := state.remoteNetwork.Spec.Network.Reference.Aws.Region
 
-	con, err := state.client.CreateVpcPeeringConnection(
+	vpcPeering, err := state.client.CreateVpcPeeringConnection(
 		ctx,
 		state.vpc.VpcId,
 		state.remoteVpc.VpcId,
@@ -62,39 +62,49 @@ func createVpcPeeringConnection(ctx context.Context, st composed.State) (error, 
 			return composed.StopWithRequeueDelay(util.Timing.T10000ms()), nil
 		}
 
-		condition := metav1.Condition{
-			Type:    cloudcontrolv1beta1.ConditionTypeError,
-			Status:  "True",
-			Reason:  cloudcontrolv1beta1.ReasonFailedCreatingVpcPeeringConnection,
-			Message: fmt.Sprintf("Failed creating VpcPeerings. %s", awsmeta.GetErrorMessage(err)),
+		changed := false
+
+		if meta.RemoveStatusCondition(state.ObjAsVpcPeering().Conditions(), cloudcontrolv1beta1.ConditionTypeReady) {
+			changed = true
 		}
 
-		if !composed.AnyConditionChanged(obj, condition) {
+		if meta.SetStatusCondition(state.ObjAsVpcPeering().Conditions(), metav1.Condition{
+			Type:    cloudcontrolv1beta1.ConditionTypeError,
+			Status:  metav1.ConditionTrue,
+			Reason:  cloudcontrolv1beta1.ReasonFailedCreatingVpcPeeringConnection,
+			Message: fmt.Sprintf("Failed creating VpcPeerings. %s", awsmeta.GetErrorMessage(err)),
+		}) {
+			changed = true
+		}
+
+		if state.ObjAsVpcPeering().Status.State != string(cloudcontrolv1beta1.WarningState) {
+			state.ObjAsVpcPeering().Status.State = string(cloudcontrolv1beta1.WarningState)
+		}
+
+		if !changed {
 			return composed.StopWithRequeueDelay(util.Timing.T300000ms()), nil
 		}
 
-		return composed.UpdateStatus(obj).
-			SetExclusiveConditions(condition).
+		return composed.UpdateStatus(state.ObjAsVpcPeering()).
 			ErrorLogMessage("Error updating VpcPeering status due to failed creating vpc peering connection").
 			FailedError(composed.StopWithRequeue).
 			SuccessError(composed.StopWithRequeueDelay(util.Timing.T300000ms())).
 			Run(ctx, state)
 	}
 
-	logger = logger.WithValues("id", ptr.Deref(con.VpcPeeringConnectionId, ""))
+	logger = logger.WithValues("id", ptr.Deref(vpcPeering.VpcPeeringConnectionId, ""))
 
 	ctx = composed.LoggerIntoCtx(ctx, logger)
 
 	logger.Info("AWS VPC Peering Connection created")
 
-	state.vpcPeering = con
+	state.vpcPeering = vpcPeering
 
-	obj.Status.Id = ptr.Deref(con.VpcPeeringConnectionId, "")
+	state.ObjAsVpcPeering().Status.Id = ptr.Deref(vpcPeering.VpcPeeringConnectionId, "")
 
-	err = state.UpdateObjStatus(ctx)
-
-	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error updating VPC Peering status with connection id", composed.StopWithRequeue, ctx)
-	}
-	return nil, ctx
+	return composed.PatchStatus(state.ObjAsVpcPeering()).
+		ErrorLogMessage("Error updating VPC Peering status with connection id").
+		FailedError(composed.StopWithRequeue).
+		SuccessErrorNil().
+		Run(ctx, state)
 }

--- a/pkg/kcp/vpcpeering/state.go
+++ b/pkg/kcp/vpcpeering/state.go
@@ -6,14 +6,14 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/kcp/vpcpeering/types"
 )
 
-type state struct {
+type State struct {
 	focal.State
 }
 
-func (s *state) ObjAsVpcPeering() *cloudcontrolv1beta1.VpcPeering {
+func (s *State) ObjAsVpcPeering() *cloudcontrolv1beta1.VpcPeering {
 	return s.Obj().(*cloudcontrolv1beta1.VpcPeering)
 }
 
 func newState(focalState focal.State) types.State {
-	return &state{State: focalState}
+	return &State{State: focalState}
 }

--- a/pkg/skr/awsvpcpeering/deleteKcpVpcPeering.go
+++ b/pkg/skr/awsvpcpeering/deleteKcpVpcPeering.go
@@ -28,7 +28,7 @@ func deleteKcpVpcPeering(ctx context.Context, st composed.State) (error, context
 	err := state.KcpCluster.K8sClient().Delete(ctx, state.KcpVpcPeering)
 
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error creating KCP VpcPeering", composed.StopWithRequeue, ctx)
+		return composed.LogErrorAndReturn(err, "Error deleting KCP VpcPeering", composed.StopWithRequeue, ctx)
 	}
 
 	// give some time to cloud-control and cloud providers to delete it, and then run again

--- a/pkg/skr/awsvpcpeering/reconciler.go
+++ b/pkg/skr/awsvpcpeering/reconciler.go
@@ -49,6 +49,7 @@ func (r *reconciler) newAction() composed.Action {
 		loadKcpAwsVpcPeering,
 		createKcpVpcPeering,
 		deleteKcpVpcPeering,
+		waitKcpVpcPeeringDeleted,
 		deleteKcpRemoteNetwork,
 		removeFinalizer,
 		updateStatus,

--- a/pkg/skr/awsvpcpeering/waitKcpVpcPeeringDeleted.go
+++ b/pkg/skr/awsvpcpeering/waitKcpVpcPeeringDeleted.go
@@ -1,0 +1,27 @@
+package awsvpcpeering
+
+import (
+	"context"
+
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+)
+
+func waitKcpVpcPeeringDeleted(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	if !composed.MarkedForDeletionPredicate(ctx, state) {
+		return nil, nil
+	}
+
+	if state.KcpVpcPeering == nil {
+		logger.Info("VpcPeering is deleted")
+		return nil, nil
+	}
+
+	logger.Info("Waiting for VpcPeering to be deleted")
+
+	// wait until VpcPeering does not exist / gets deleted
+	return composed.StopWithRequeueDelay(util.Timing.T1000ms()), nil
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- wait KcpVpcPeering to be deleted before deleting Network
- handle retriable errors