### PR TITLE
feat(AzureVpcPeering): wait KcpVpcPeering deleted before deleting Network

### DIFF
--- a/pkg/skr/azurevpcpeering/reconciler.go
+++ b/pkg/skr/azurevpcpeering/reconciler.go
@@ -49,6 +49,7 @@ func (r *reconciler) newAction() composed.Action {
 		loadKcpAzureVpcPeering,
 		createKcpVpcPeering,
 		deleteKcpVpcPeering,
+		waitKcpVpcPeeringDeleted,
 		deleteRemoteNetwork,
 		removeFinalizer,
 		updateStatus,

--- a/pkg/skr/azurevpcpeering/waitKcpVpcPeeringDeleted.go
+++ b/pkg/skr/azurevpcpeering/waitKcpVpcPeeringDeleted.go
@@ -1,0 +1,27 @@
+package azurevpcpeering
+
+import (
+	"context"
+
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+)
+
+func waitKcpVpcPeeringDeleted(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	if !composed.MarkedForDeletionPredicate(ctx, state) {
+		return nil, nil
+	}
+
+	if state.KcpVpcPeering == nil {
+		logger.Info("VpcPeering is deleted")
+		return nil, nil
+	}
+
+	logger.Info("Waiting for VpcPeering to be deleted")
+
+	// wait until VpcPeering does not exist / gets deleted
+	return composed.StopWithRequeueDelay(util.Timing.T1000ms()), nil
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- wait VpcPeering to be deleted before deleting Network
