### PR TITLE
fix: prevent reinstallation of CRDs when module disabled

### DIFF
--- a/pkg/skr/runtime/looper/checker.go
+++ b/pkg/skr/runtime/looper/checker.go
@@ -19,7 +19,7 @@ type checker struct {
 }
 
 func (c *checker) IsReady(ctx context.Context, skrCluster cluster.Cluster) bool {
-	timeout := time.Now().Add(time.Second * 3)
+	timeout := time.Now().Add(time.Millisecond * 3500)
 	interval := time.Second
 	for {
 		select {
@@ -40,11 +40,41 @@ func (c *checker) IsReady(ctx context.Context, skrCluster cluster.Cluster) bool 
 	}
 }
 
+// singleCheck returns true if it is ok to proceed with SKR connection that implies installation of CRDs and
+// running controllers. It is important to consider both provisioning and deprovisioning phase:
+// * Provisioning
+//   - CloudResources CRD is not yet installed by KLM
+//   - CloudResources default instance is not yet created by KLM
+// * Deprovisioning
+//   - There are no CloudResources instances since they all have been deleted - KLM marked for deletion,
+//     CloudManager connected to SKR and uninstalled CRDs and removed finalized, K8S deleted CloudResources.
+//     If CloudManager connects again before the KCP Scope is reconciled and this SKR removed from active
+//     we must ensure connection does not proceed and installs CRDs again.
+//   - There is CloudResources instance, but it's marked for deletion and has no finalizer since CloudManager
+//     already have connected, deleted CRDs and removed finalizer, and now K8S API should delete this resource.
+//     Not sure if practically possible, but implementing it just in case.
 func (c *checker) singleCheck(ctx context.Context, skrCluster cluster.Cluster) bool {
 	list := &cloudresourcesv1beta1.CloudResourcesList{}
 	err := skrCluster.GetAPIReader().List(ctx, list)
 	if err != nil {
-		c.logger.Error(err, "SKR readiness failed")
+		c.logger.Error(err, "SKR readiness failed - CloudResources CRD not installed")
+		return false
+	}
+	if len(list.Items) == 0 {
+		c.logger.Error(err, "SKR readiness failed - no CloudResources created")
+		return false
+	}
+	allDeletedAndNoFinalizer := true
+	for _, item := range list.Items {
+		// has deletion timestamp and has no finalizers
+		if !item.DeletionTimestamp.IsZero() && len(item.Finalizers) == 0 {
+			continue
+		}
+		allDeletedAndNoFinalizer = false
+		break
+	}
+	if allDeletedAndNoFinalizer {
+		c.logger.Error(err, "SKR readiness failed - all CloudResources instances are being deleted and have no finalizer")
 		return false
 	}
 	return true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

It occurred that module was disabled, the first connection made and CRDs uninstalled and finalizer removed, second connection occurred before KCP Scope loop disabled that SKR and proceeded and installed CRDs, and then eventually KCP Scope deactivated SKR, leaving SKR with module disabled and w/out CloudResources but with installed other cloud-resources CRDs. This change is supposed to prevent that from happening again.

Changes proposed in this pull request:

- added additional checks in skrRuntime.checker that should stop the connection if module already uninstalled and CRDs deleted

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
