### PR TITLE
docs(AzureVpcPeering): adds missing IP_ADDRESS export

### DIFF
--- a/docs/user/tutorials/01-30-azure-vpc-peering.md
+++ b/docs/user/tutorials/01-30-azure-vpc-peering.md
@@ -60,7 +60,9 @@ the steps that create those resources.
    --vnet-name $VNET_NAME \
    --subnet "MySubnet" \
    --public-ip-address "" \
-   --nsg "" 
+   --nsg ""
+   
+   export IP_ADDRESS=$(az vm show --show-details --resource-group $RESOURCE_GROUP_NAME --name $VM_NAME --query privateIps --output tsv)
    ```
    
 7. Tag the VPC network with the Kyma shoot name


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Adds missing command that exports IP_ADDRESS of created Azure VM