### PR TITLE
fix: Azure tags removed

### DIFF
--- a/internal/controller/cloud-control/iprange_azure_test.go
+++ b/internal/controller/cloud-control/iprange_azure_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Feature: KCP IpRange for Azure", func() {
 
 		var azureSubnet *armnetwork.Subnet
 
-		By("Then Azure Subnet is created", func() {
+		By("And Then Azure Subnet is created", func() {
 			Eventually(func() error {
 				sn, err := azureMock.GetSubnet(infra.Ctx(), cmCommonName, cmCommonName, cmCommonName)
 				if err != nil {
@@ -228,7 +228,7 @@ var _ = Describe("Feature: KCP IpRange for Azure", func() {
 			Expect(ptr.Deref(azureSubnet.Properties.NetworkSecurityGroup.ID, "")).To(Equal(ptr.Deref(azureSecurityGroup.ID, "")))
 		})
 
-		By("Then KCP IpRange has Ready condition", func() {
+		By("And Then KCP IpRange has Ready condition", func() {
 			Eventually(LoadAndCheck).
 				WithArguments(infra.Ctx(), infra.KCP().Client(), kcpIpRange, NewObjActions(),
 					HavingConditionTrue(cloudcontrolv1beta1.ConditionTypeReady)).

--- a/internal/controller/cloud-control/network_azure_test.go
+++ b/internal/controller/cloud-control/network_azure_test.go
@@ -1,7 +1,6 @@
 package cloudcontrol
 
 import (
-	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
@@ -92,19 +91,6 @@ var _ = Describe("Feature: KCP Azure managed Network", func() {
 
 		By("And Then Azure ResourceGroup location equals to Scope region", func() {
 			Expect(ptr.Deref(azureResourceGroup.Location, "")).To(Equal(scope.Spec.Region))
-		})
-
-		By("And Then Azure ResourceGroup tags are set", func() {
-			Expect(azureResourceGroup.Tags).NotTo(BeNil())
-
-			Expect(azureResourceGroup.Tags).To(HaveKey(common.TagCloudManagerName))
-			Expect(ptr.Deref(azureResourceGroup.Tags[common.TagCloudManagerName], "")).To(Equal(fmt.Sprintf("%s/%s", net.Namespace, net.Name)))
-
-			Expect(azureResourceGroup.Tags).To(HaveKey(common.TagScope))
-			Expect(ptr.Deref(azureResourceGroup.Tags[common.TagScope], "")).To(Equal(fmt.Sprintf("%s/%s", scope.Namespace, scope.Name)))
-
-			Expect(azureResourceGroup.Tags).To(HaveKey(common.TagShoot))
-			Expect(ptr.Deref(azureResourceGroup.Tags[common.TagShoot], "")).To(Equal(scope.Spec.ShootName))
 		})
 
 		var azureVNet *armnetwork.VirtualNetwork

--- a/pkg/kcp/provider/azure/iprange/securityGroupCreate.go
+++ b/pkg/kcp/provider/azure/iprange/securityGroupCreate.go
@@ -2,9 +2,7 @@ package iprange
 
 import (
 	"context"
-	"fmt"
 	cloudcontrol1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
-	"github.com/kyma-project/cloud-manager/pkg/common"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	azuremeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/meta"
 	"github.com/kyma-project/cloud-manager/pkg/util"
@@ -25,12 +23,7 @@ func securityGroupCreate(ctx context.Context, st composed.State) (error, context
 		ctx, state.resourceGroupName, state.securityGroupName,
 		state.Scope().Spec.Region,
 		nil,
-		map[string]string{
-			common.TagScope:                  fmt.Sprintf("%s/%s", state.Scope().Namespace, state.Scope().Name),
-			common.TagShoot:                  state.Scope().Spec.ShootName,
-			common.TagCloudManagerRemoteName: state.ObjAsIpRange().Spec.RemoteRef.String(),
-			common.TagCloudManagerName:       fmt.Sprintf("%s/%s", state.ObjAsIpRange().Namespace, state.ObjAsIpRange().Name),
-		},
+		nil, // The following characters are not supported: <>%&\?/.
 	)
 
 	if azuremeta.IsTooManyRequests(err) {
@@ -38,6 +31,8 @@ func securityGroupCreate(ctx context.Context, st composed.State) (error, context
 	}
 
 	if err != nil {
+		logger.Error(err, "Error creating Azure KCP IpRange security group", ctx)
+
 		state.ObjAsIpRange().Status.State = cloudcontrol1beta1.ErrorState
 
 		return composed.PatchStatus(state.ObjAsIpRange()).

--- a/pkg/kcp/provider/azure/network/initState.go
+++ b/pkg/kcp/provider/azure/network/initState.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"context"
-	"fmt"
 	"github.com/kyma-project/cloud-manager/pkg/common"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	azurecommon "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/common"
@@ -21,12 +20,8 @@ func initState(ctx context.Context, st composed.State) (error, context.Context) 
 		state.location = state.Scope().Spec.Region
 	}
 
-	// Tags
-	state.tags = map[string]string{
-		common.TagCloudManagerName: state.Name().String(),
-		common.TagShoot:            state.Scope().Spec.ShootName,
-		common.TagScope:            fmt.Sprintf("%s/%s", state.Scope().Namespace, state.Scope().Name),
-	}
+	// Tags, nil until we determine the use case justifying their presence and unify on tag names across providers
+	state.tags = nil
 
 	// Cidr
 	state.cidr = state.ObjAsNetwork().Spec.Network.Managed.Cidr


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Azure in tag name does not accept `<>%&\?/.`. Until use case for tags is identified and their names unified across providers removing them from Azure implementation. 

Changes proposed in this pull request:

- remove tags for Azure 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
