### PR TITLE
chore: KCP Scope refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.29.3
+ENVTEST_K8S_VERSION = 1.29.4
 JV_VERSION = v0.5.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)

--- a/api/cloud-control/v1beta1/scope_types.go
+++ b/api/cloud-control/v1beta1/scope_types.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ScopeSpec defines the desired state of Scope
@@ -179,6 +180,9 @@ type AwsZone struct {
 
 // ScopeStatus defines the observed state of Scope
 type ScopeStatus struct {
+	// +optional
+	State StatusState `json:"state,omitempty"`
+
 	// List of status conditions to indicate the status of a Peering.
 	// +optional
 	// +listType=map
@@ -211,6 +215,20 @@ func (in *Scope) Conditions() *[]metav1.Condition {
 
 func (in *Scope) GetObjectMeta() *metav1.ObjectMeta {
 	return &in.ObjectMeta
+}
+
+func (in *Scope) CloneForPatchStatus() client.Object {
+	return &Scope{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Scope",
+			APIVersion: GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: in.Namespace,
+			Name:      in.Name,
+		},
+		Status: in.Status,
+	}
 }
 
 //+kubebuilder:object:root=true

--- a/api/cloud-control/v1beta1/scope_types.go
+++ b/api/cloud-control/v1beta1/scope_types.go
@@ -187,11 +187,11 @@ type ScopeStatus struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=type
-	Conditions []metav1.Condition `json:"conditions,omitempty"`
+	Conditions []metav1.Condition `json:"conditions"`
 
 	// Operation Identifier to track the ServiceUsage Operation
 	// +optional
-	GcpOperations []string `json:"gcpOperations,omitempty"`
+	GcpOperations []string `json:"gcpOperations"`
 }
 
 //+kubebuilder:object:root=true
@@ -218,7 +218,7 @@ func (in *Scope) GetObjectMeta() *metav1.ObjectMeta {
 }
 
 func (in *Scope) CloneForPatchStatus() client.Object {
-	return &Scope{
+	result := &Scope{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Scope",
 			APIVersion: GroupVersion.String(),
@@ -229,6 +229,13 @@ func (in *Scope) CloneForPatchStatus() client.Object {
 		},
 		Status: in.Status,
 	}
+	if result.Status.GcpOperations == nil {
+		result.Status.GcpOperations = []string{}
+	}
+	if result.Status.Conditions == nil {
+		result.Status.Conditions = []metav1.Condition{}
+	}
+	return result
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/cloud-control.kyma-project.io_scopes.yaml
+++ b/config/crd/bases/cloud-control.kyma-project.io_scopes.yaml
@@ -290,6 +290,8 @@ spec:
                 items:
                   type: string
                 type: array
+              state:
+                type: string
             type: object
         type: object
     served: true

--- a/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_scopes.yaml
+++ b/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_scopes.yaml
@@ -290,6 +290,8 @@ spec:
                 items:
                   type: string
                 type: array
+              state:
+                type: string
             type: object
         type: object
     served: true

--- a/pkg/kcp/scope/addReadyCondition.go
+++ b/pkg/kcp/scope/addReadyCondition.go
@@ -4,22 +4,43 @@ import (
 	"context"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func addReadyCondition(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
-	scope := state.ObjAsScope()
-	return composed.UpdateStatus(scope).
-		SetCondition(metav1.Condition{
+
+	changed := false
+
+	if state.ObjAsScope().Status.State != cloudcontrolv1beta1.ReadyState {
+		state.ObjAsScope().Status.State = cloudcontrolv1beta1.ReadyState
+		changed = true
+	}
+
+	if len(state.ObjAsScope().Status.Conditions) != 1 {
+		changed = true
+	}
+
+	cond := meta.FindStatusCondition(*state.ObjAsScope().Conditions(), cloudcontrolv1beta1.ConditionTypeReady)
+	if cond == nil {
+		changed = true
+	} else if cond.Status != metav1.ConditionTrue || cond.Reason != cloudcontrolv1beta1.ReasonReady || cond.Message != cloudcontrolv1beta1.ReasonReady {
+		changed = true
+	}
+
+	if !changed {
+		return nil, ctx
+	}
+
+	return composed.PatchStatus(state.ObjAsScope()).
+		SetExclusiveConditions(metav1.Condition{
 			Type:    cloudcontrolv1beta1.ConditionTypeReady,
 			Status:  metav1.ConditionTrue,
 			Reason:  cloudcontrolv1beta1.ReasonReady,
-			Message: "Ready",
+			Message: cloudcontrolv1beta1.ReasonReady,
 		}).
-		ErrorLogMessage("Error updating scope status with ready condition").
-		OnUpdateSuccess(func(ctx context.Context) (error, context.Context) {
-			return nil, nil
-		}).
+		ErrorLogMessage("Error patching scope status with ready condition").
+		SuccessErrorNil().
 		Run(ctx, state)
 }

--- a/pkg/kcp/scope/checkGcpOperations.go
+++ b/pkg/kcp/scope/checkGcpOperations.go
@@ -60,13 +60,15 @@ func checkGcpOperations(ctx context.Context, st composed.State) (error, context.
 	scope.Status.GcpOperations = unfinishedOperations
 	if len(unfinishedOperations) > 0 {
 		scope.Status.GcpOperations = unfinishedOperations
-		return composed.UpdateStatus(scope).
+		return composed.PatchStatus(scope).
+			ErrorLogMessage("Error patching KCP Scope status with GCP unfinished operations").
 			SuccessError(composed.StopWithRequeueDelay(gcpclient.GcpOperationWaitTime)).
 			Run(ctx, state)
 	}
 	// Even if all operations are done (which might take us several iterations to figure out), we have issues with failed or not found operations.
 	// We should requeue and verify that all APIs are really enabled.
-	return composed.UpdateStatus(scope).
+	return composed.PatchStatus(scope).
+		ErrorLogMessage("Error patching KCP Scope status with GCP operations").
 		SuccessError(composed.StopWithRequeue).
 		Run(ctx, state)
 }

--- a/pkg/kcp/scope/enableApisGcp.go
+++ b/pkg/kcp/scope/enableApisGcp.go
@@ -66,7 +66,8 @@ func enableApisGcp(ctx context.Context, st composed.State) (error, context.Conte
 		logger.Info("All APIs are enabled. Proceeding to next step.")
 		return nil, nil
 	}
-	return composed.UpdateStatus(scope).
+	return composed.PatchStatus(scope).
+		ErrorLogMessage("Error patching KCP Scope status with updates of pending operations").
 		SuccessError(composed.StopWithRequeueDelay(gcpclient.GcpOperationWaitTime)).
 		Run(ctx, state)
 }

--- a/pkg/kcp/scope/findKymaModuleState.go
+++ b/pkg/kcp/scope/findKymaModuleState.go
@@ -11,6 +11,11 @@ func findKymaModuleState(ctx context.Context, st composed.State) (error, context
 	state := st.(*State)
 	logger := composed.LoggerFromCtx(ctx)
 
+	if state.kyma == nil {
+		state.moduleState = util.KymaModuleStateNotPresent
+		return nil, ctx
+	}
+
 	moduleName := "cloud-manager"
 	moduleState := util.GetKymaModuleStateFromStatus(state.kyma, moduleName)
 	moduleInSpec := util.IsKymaModuleListedInSpec(state.kyma, moduleName)

--- a/pkg/testinfra/run.go
+++ b/pkg/testinfra/run.go
@@ -40,7 +40,7 @@ func Start() (Infra, error) {
 	}
 	envtestK8sVersion := os.Getenv("ENVTEST_K8S_VERSION")
 	if len(envtestK8sVersion) == 0 {
-		envtestK8sVersion = "1.29.3"
+		envtestK8sVersion = "1.29.4"
 	}
 
 	ginkgo.By("Preparing CRDs")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- refactored the KCP Scope reconciler action flow so it's easier to read and understand
- added field `status.state` to KCP Scope
- added `CloneForPatchStatus()` to KCP Scope
- changed KCP Scope reconciler to use patch for adding and removing Kyma finalizer
- changed KCP Scope reconciler to update status with ready condition only if there's a change and to use patch then
- made KCP Scope state.kymaModuleState to default to NotPresent if Kyma does not exist (not important now since it stops before that step if Kyma not found, but will be later when we start orphan clenup)
- changed KCP Scope to be able to work in case when Kyma does not exist but Scope exists (same as above)
- renamed in `kcp/scope` predicates `ObjIsLoadedPredicate` to `predicateScopeExists`, and `UpdateIsNeededPredicate` to `predicateScopeCreateOrUpdateNeeded`
- upgraded envtest k8s version from `1.29.3` to `1.29.4`
- removed KCP Scope status conditions and gcpOperations the omitempty, and if nil set empty array in CloneForPatchStatus so patch status can work when setting it back to none that's used in enableApisGcp
- changed kcp.scope to use composed.PatchStatus instead of composed.UpdateStatus in all places, including gcp enable apis


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
