### PR TITLE
fix: KCP Managed Network for Azure vnet name

### DIFF
--- a/pkg/common/network.go
+++ b/pkg/common/network.go
@@ -1,6 +1,8 @@
 package common
 
-import "fmt"
+import (
+	"fmt"
+)
 
 func KcpNetworkKymaCommonName(kymaName string) string {
 	return fmt.Sprintf("%s--kyma", kymaName)
@@ -8,4 +10,12 @@ func KcpNetworkKymaCommonName(kymaName string) string {
 
 func KcpNetworkCMCommonName(kymaName string) string {
 	return fmt.Sprintf("%s--cm", kymaName)
+}
+
+func IsKcpNetworkKyma(kcpNetworkObjName, kymaOrScopeName string) bool {
+	return kcpNetworkObjName == KcpNetworkKymaCommonName(kymaOrScopeName)
+}
+
+func IsKcpNetworkCM(kcpNetworkObjName, kymaOrScopeName string) bool {
+	return kcpNetworkObjName == KcpNetworkCMCommonName(kymaOrScopeName)
 }

--- a/pkg/kcp/iprange/kcpNetworkInit.go
+++ b/pkg/kcp/iprange/kcpNetworkInit.go
@@ -21,8 +21,8 @@ func kcpNetworkInit(ctx context.Context, st composed.State) (error, context.Cont
 		state.networkKey.Name = state.ObjAsIpRange().Spec.Network.Name
 	}
 
-	state.isCloudManagerNetwork = common.KcpNetworkCMCommonName(state.Scope().Name) == state.networkKey.Name
-	state.isKymaNetwork = common.KcpNetworkKymaCommonName(state.Scope().Name) == state.networkKey.Name
+	state.isCloudManagerNetwork = common.IsKcpNetworkCM(state.networkKey.Name, state.Scope().Name)
+	state.isKymaNetwork = common.IsKcpNetworkKyma(state.networkKey.Name, state.Scope().Name)
 
 	logger := composed.LoggerFromCtx(ctx).
 		WithValues(

--- a/pkg/kcp/network/preventCreationOfNonCmManagedNetwork.go
+++ b/pkg/kcp/network/preventCreationOfNonCmManagedNetwork.go
@@ -1,0 +1,60 @@
+package network
+
+import (
+	"context"
+	"errors"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/common"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// preventCreationOfNonCmManagedNetwork passes if obj is managed CM KCP Network, otherwise
+// it will set error status and forget the KCP Network object. Currently, CM supports only
+// creation of the cm managed networks
+func preventCreationOfNonCmManagedNetwork(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*state)
+	logger := composed.LoggerFromCtx(ctx)
+
+	if common.IsKcpNetworkCM(state.ObjAsNetwork().Name, state.Scope().Name) {
+		return nil, ctx
+	}
+
+	logger.Error(errors.New("not supported"), "Non-cm managed network can not be created")
+
+	changed := false
+
+	if state.ObjAsNetwork().Status.State != string(cloudcontrolv1beta1.ErrorState) {
+		state.ObjAsNetwork().Status.State = string(cloudcontrolv1beta1.ErrorState)
+		changed = true
+	}
+
+	if len(state.ObjAsNetwork().Status.Conditions) != 1 {
+		changed = true
+	}
+
+	message := "Not supported"
+
+	cond := meta.FindStatusCondition(state.ObjAsNetwork().Status.Conditions, cloudcontrolv1beta1.ConditionTypeError)
+	if cond == nil {
+		changed = true
+	} else if cond.Status != metav1.ConditionTrue || cond.Reason != cloudcontrolv1beta1.ConditionTypeError || cond.Message != message {
+		changed = true
+	}
+
+	if !changed {
+		return composed.StopAndForget, ctx
+	}
+
+	return composed.PatchStatus(state.ObjAsNetwork()).
+		SetExclusiveConditions(metav1.Condition{
+			Type:    cloudcontrolv1beta1.ConditionTypeError,
+			Status:  metav1.ConditionTrue,
+			Reason:  cloudcontrolv1beta1.ConditionTypeError,
+			Message: message,
+		}).
+		ErrorLogMessage("Error patching KCP Network status with error on unsupported non-cm managed network creation").
+		SuccessError(composed.StopAndForget).
+		Run(ctx, state)
+}

--- a/pkg/kcp/network/reconciler.go
+++ b/pkg/kcp/network/reconciler.go
@@ -69,6 +69,11 @@ func (r *networkReconciler) newAction() composed.Action {
 				handleNetworkReference,
 				// ensure no network reference pass further, allow only managed networks
 				logLogicalErrorOnManagedNetworkMissing,
+
+				// currently we support only creation of the cm managed networks,
+				// if that's not the case this action will set error status and forget the KCP Network object
+				preventCreationOfNonCmManagedNetwork,
+
 				// and now branch to provider specific flow
 				composed.BuildSwitchAction(
 					"providerSwitch",

--- a/pkg/kcp/provider/azure/network/initState.go
+++ b/pkg/kcp/provider/azure/network/initState.go
@@ -23,6 +23,12 @@ func initState(ctx context.Context, st composed.State) (error, context.Context) 
 	// Tags, nil until we determine the use case justifying their presence and unify on tag names across providers
 	state.tags = nil
 
+	// VNet name
+	state.vnetName = state.ObjAsNetwork().Name
+	if common.IsKcpNetworkCM(state.ObjAsNetwork().Name, state.Scope().Name) {
+		state.vnetName = state.resourceGroupName
+	}
+
 	// Cidr
 	state.cidr = state.ObjAsNetwork().Spec.Network.Managed.Cidr
 	if len(state.cidr) == 0 {

--- a/pkg/kcp/provider/azure/network/state.go
+++ b/pkg/kcp/provider/azure/network/state.go
@@ -18,6 +18,7 @@ type State struct {
 	location          string
 	tags              map[string]string
 	resourceGroupName string
+	vnetName          string
 	cidr              string
 
 	resourceGroup *armresources.ResourceGroup

--- a/pkg/kcp/provider/azure/network/statusReady.go
+++ b/pkg/kcp/provider/azure/network/statusReady.go
@@ -59,8 +59,8 @@ func statusReady(ctx context.Context, st composed.State) (error, context.Context
 		state.ObjAsNetwork().Status.Network.Azure.ResourceGroup = state.resourceGroupName
 		changed = true
 	}
-	if state.ObjAsNetwork().Status.Network.Azure.NetworkName != state.ObjAsNetwork().Name {
-		state.ObjAsNetwork().Status.Network.Azure.NetworkName = state.ObjAsNetwork().Name
+	if state.ObjAsNetwork().Status.Network.Azure.NetworkName != state.vnetName {
+		state.ObjAsNetwork().Status.Network.Azure.NetworkName = state.vnetName
 		changed = true
 	}
 

--- a/pkg/kcp/provider/azure/network/vnetCreate.go
+++ b/pkg/kcp/provider/azure/network/vnetCreate.go
@@ -21,7 +21,7 @@ func vnetCreate(ctx context.Context, st composed.State) (error, context.Context)
 	err := state.azureClient.CreateNetwork(
 		ctx,
 		state.resourceGroupName,
-		state.ObjAsNetwork().Name,
+		state.vnetName,
 		state.location,
 		state.cidr,
 		state.tags,

--- a/pkg/kcp/provider/azure/network/vnetDelete.go
+++ b/pkg/kcp/provider/azure/network/vnetDelete.go
@@ -16,7 +16,7 @@ func vnetDelete(ctx context.Context, st composed.State) (error, context.Context)
 
 	logger.Info("Deleting Azure VNet for KCP Network")
 
-	err := state.azureClient.DeleteNetwork(ctx, state.resourceGroupName, state.ObjAsNetwork().Name)
+	err := state.azureClient.DeleteNetwork(ctx, state.resourceGroupName, state.vnetName)
 	if err != nil {
 		return composed.LogErrorAndReturn(err, "Error deleting Azure VNet for KCP Network", composed.StopWithRequeueDelay(util.Timing.T10000ms()), ctx)
 	}

--- a/pkg/kcp/provider/azure/network/vnetLoad.go
+++ b/pkg/kcp/provider/azure/network/vnetLoad.go
@@ -11,7 +11,7 @@ func vnetLoad(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
 	logger := composed.LoggerFromCtx(ctx)
 
-	net, err := state.azureClient.GetNetwork(ctx, state.resourceGroupName, state.ObjAsNetwork().Name)
+	net, err := state.azureClient.GetNetwork(ctx, state.resourceGroupName, state.vnetName)
 	if azureMeta.IgnoreNotFoundError(err) != nil {
 		return composed.LogErrorAndReturn(err, "Error loading Azure vnet for KCP Network", composed.StopWithRequeueDelay(util.Timing.T10000ms()), ctx)
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- changed KCP Network Azure in case of CM network to create vnet with `{shoot-vnet-name}--cm` as specified [here](https://github.com/kyma-project/cloud-manager/blob/main/tools/dev/reconcilers/azure-peering-kyma-cm.png)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
