### PR TITLE
fix(scope): hardening gcp enableApis and check operation status

### DIFF
--- a/pkg/kcp/scope/checkGcpOperations.go
+++ b/pkg/kcp/scope/checkGcpOperations.go
@@ -2,10 +2,12 @@ package scope
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os"
-
 	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"google.golang.org/api/googleapi"
+	"os"
 
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 )
@@ -35,6 +37,25 @@ func checkGcpOperations(ctx context.Context, st composed.State) (error, context.
 	for _, opName := range scope.Status.GcpOperations {
 		logger.WithValues("Scope", scope.Name).Info("Checking Service Enablement GCP Operation Status")
 		op, err := client.GetServiceUsageOperation(ctx, opName)
+		//If the operation is not found, reset the operation to retry
+		var e *googleapi.Error
+		if ok := errors.As(err, &e); ok {
+			if e.Code == 404 {
+				logger.WithValues("operationName", opName).Info("Operation not found in GCP. "+
+					"Removing operation id from status and retry.", "error", err)
+				continue
+				// By not adding it to unfinished, it will be removed and retried
+			}
+			if e.Code == 400 {
+				logger.WithValues("operationName", opName).
+					Info("Operation failed because of invalid request. "+
+						"This can happen because of invalid operation id. "+
+						"Removing operation id from status and retry.", "error", err)
+				// By not adding it to unfinished, it will be removed and retried
+				continue
+
+			}
+		}
 		if err != nil {
 			logger.Error(err, "Error getting Service Usage Operation from GCP. Retry via requeue.")
 			return composed.StopWithRequeueDelay(gcpclient.GcpRetryWaitTime), nil
@@ -52,7 +73,9 @@ func checkGcpOperations(ctx context.Context, st composed.State) (error, context.
 
 		if op != nil && op.Done {
 			if op.Error != nil {
-				logger.WithValues("operationName", opName).Info("Operation failed. Removing from status.")
+				logger.WithValues("operationName", opName).
+					Info("Operation failed. Removing from status to retry.", "error message",
+						op.Error.Message, "error code", op.Error.Code)
 			}
 		}
 
@@ -69,6 +92,6 @@ func checkGcpOperations(ctx context.Context, st composed.State) (error, context.
 	// We should requeue and verify that all APIs are really enabled.
 	return composed.PatchStatus(scope).
 		ErrorLogMessage("Error patching KCP Scope status with GCP operations").
-		SuccessError(composed.StopWithRequeue).
+		SuccessError(composed.StopWithRequeueDelay(util.Timing.T100ms())).
 		Run(ctx, state)
 }

--- a/pkg/kcp/scope/enableApisGcp.go
+++ b/pkg/kcp/scope/enableApisGcp.go
@@ -76,13 +76,34 @@ func verifyAndAddOperationToStatus(ctx context.Context, scope *v1beta1.Scope, cl
 	operation, err := verifyAndEnable(ctx, scope, client, service)
 	if err != nil {
 		return composed.LogErrorAndReturn(
-			fmt.Errorf("error enabling service %s: %w", gcpclient.ComputeService, err),
+			fmt.Errorf("error enabling service %s: %w", service, err),
 			"Error enabling GCP APIs",
 			composed.StopAndForget,
 			ctx)
 	}
-	scope.Status.GcpOperations = make([]string, 0)
 	if operation != nil {
+		if operation.Done {
+			if operation.Error != nil {
+				return composed.LogErrorAndReturn(
+					fmt.Errorf("Enabling service %s operation failed: %s. Retry with delay", service, operation.Error.Message),
+					"Error enabling GCP APIs",
+					composed.StopWithRequeueDelay(gcpclient.GcpRetryWaitTime),
+					ctx)
+			} else {
+				//operation already succeeded.
+				return nil, ctx
+			}
+		}
+		if operation.Name == "operations/noop.DONE_OPERATION" {
+			return composed.LogErrorAndReturn(
+				fmt.Errorf("enabling service %s returned an invalid operation id '%s'. Retry with delay", service, "operations/noop.DONE_OPERATION"),
+				"Error enabling GCP APIs",
+				composed.StopWithRequeueDelay(gcpclient.GcpRetryWaitTime),
+				ctx)
+		}
+		if scope.Status.GcpOperations == nil {
+			scope.Status.GcpOperations = make([]string, 0)
+		}
 		scope.Status.GcpOperations = append(scope.Status.GcpOperations, operation.Name)
 	}
 	return nil, ctx


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Handing the situation where enabling api for gcp is done right away
- Checking operation id is not "operations/noop.DONE_OPERATION" enabling apis for gcp
- retrying operation again if it is not found of invalid (404 or 400)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #678 