### PR TITLE
fix: copy Kyma labels to Scope

### DIFF
--- a/api/cloud-control/v1beta1/scope_types.go
+++ b/api/cloud-control/v1beta1/scope_types.go
@@ -21,6 +21,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	LabelScopeGlobalAccountId = "kyma-project.io/global-account-id"
+	LabelScopeSubaccountId    = "kyma-project.io/subaccount-id"
+	LabelScopeShootName       = "kyma-project.io/shoot-name"
+	LabelScopeRegion          = "kyma-project.io/region"
+	LabelScopeBrokerPlanName  = "kyma-project.io/broker-plan-name"
+)
+
+var ScopeLabels = []string{
+	LabelScopeGlobalAccountId,
+	LabelScopeSubaccountId,
+	LabelScopeShootName,
+	LabelScopeRegion,
+	LabelScopeBrokerPlanName,
+}
+
 // ScopeSpec defines the desired state of Scope
 type ScopeSpec struct {
 	// +kubebuilder:validation:Required

--- a/internal/controller/cloud-control/scope_aws_test.go
+++ b/internal/controller/cloud-control/scope_aws_test.go
@@ -1,6 +1,7 @@
 package cloudcontrol
 
 import (
+	"fmt"
 	gardenerTypes "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
@@ -72,6 +73,12 @@ var _ = Describe("Feature: KCP Scope AWS", func() {
 				WithArguments(infra.Ctx(), infra.KCP().Client(), scope, NewObjActions(), HavingConditionTrue(cloudresourcesv1beta1.ConditionTypeReady)).
 				Should(Succeed(), "expected created Scope to have Ready condition")
 		})
+
+		for _, label := range cloudcontrolv1beta1.ScopeLabels {
+			By(fmt.Sprintf("And Then Scope has label %s", label), func() {
+				Expect(scope.Labels).To(HaveKeyWithValue(label, kymaCR.GetLabels()[label]))
+			})
+		}
 
 		By("And Then Scope provider is aws", func() {
 			Expect(scope.Spec.Provider).To(Equal(cloudcontrolv1beta1.ProviderAws))

--- a/internal/controller/cloud-control/scope_azure_test.go
+++ b/internal/controller/cloud-control/scope_azure_test.go
@@ -1,6 +1,7 @@
 package cloudcontrol
 
 import (
+	"fmt"
 	gardenerTypes "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
@@ -72,6 +73,12 @@ var _ = Describe("Feature: KCP Scope Azure", func() {
 				WithArguments(infra.Ctx(), infra.KCP().Client(), scope, NewObjActions(), HavingConditionTrue(cloudresourcesv1beta1.ConditionTypeReady)).
 				Should(Succeed(), "expected created Scope to have Ready condition")
 		})
+
+		for _, label := range cloudcontrolv1beta1.ScopeLabels {
+			By(fmt.Sprintf("And Then Scope has label %s", label), func() {
+				Expect(scope.Labels).To(HaveKeyWithValue(label, kymaCR.GetLabels()[label]))
+			})
+		}
 
 		By("And Then Scope provider is Azure", func() {
 			Expect(scope.Spec.Provider).To(Equal(cloudcontrolv1beta1.ProviderAzure))

--- a/internal/controller/cloud-control/scope_gcp_test.go
+++ b/internal/controller/cloud-control/scope_gcp_test.go
@@ -1,6 +1,7 @@
 package cloudcontrol
 
 import (
+	"fmt"
 	gardenerTypes "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	. "github.com/kyma-project/cloud-manager/pkg/testinfra/dsl"
@@ -61,6 +62,12 @@ var _ = Describe("Feature: KCP Scope GCP", func() {
 				WithArguments(infra.Ctx(), infra.KCP().Client(), scope, NewObjActions(), HavingConditionTrue(cloudcontrolv1beta1.ConditionTypeReady)).
 				Should(Succeed(), "expected Scope to have Ready condition")
 		})
+
+		for _, label := range cloudcontrolv1beta1.ScopeLabels {
+			By(fmt.Sprintf("And Then Scope has label %s", label), func() {
+				Expect(scope.Labels).To(HaveKeyWithValue(label, kymaCR.GetLabels()[label]))
+			})
+		}
 
 		By("And Then Scope has provider gcp", func() {
 			Expect(scope.Spec.Provider).To(Equal(cloudcontrolv1beta1.ProviderGCP))

--- a/pkg/feature/context.go
+++ b/pkg/feature/context.go
@@ -122,11 +122,11 @@ func (b *contextBuilderImpl) LoadFromKyma(u *unstructured.Unstructured) ContextB
 	if u != nil && u.Object != nil {
 		b.Kyma(u.GetName())
 		if labels := u.GetLabels(); len(labels) > 0 {
-			b.BrokerPlan(labels["kyma-project.io/broker-plan-name"])
-			b.GlobalAccount(labels["kyma-project.io/global-account-id"])
-			b.SubAccount(labels["kyma-project.io/subaccount-id"])
-			b.Region(labels["kyma-project.io/region"])
-			b.Shoot(labels["kyma-project.io/shoot-name"])
+			b.BrokerPlan(labels[cloudcontrolv1beta1.LabelScopeBrokerPlanName])
+			b.GlobalAccount(labels[cloudcontrolv1beta1.LabelScopeGlobalAccountId])
+			b.SubAccount(labels[cloudcontrolv1beta1.LabelScopeSubaccountId])
+			b.Region(labels[cloudcontrolv1beta1.LabelScopeRegion])
+			b.Shoot(labels[cloudcontrolv1beta1.LabelScopeShootName])
 		}
 	}
 	return b

--- a/pkg/feature/context_test.go
+++ b/pkg/feature/context_test.go
@@ -113,11 +113,11 @@ func TestContextBuilder(t *testing.T) {
 	t.Run("LoadFromKyma", func(t *testing.T) {
 		kyma := util.NewKymaUnstructured()
 		kyma.SetLabels(map[string]string{
-			"kyma-project.io/broker-plan-name":  "trial",
-			"kyma-project.io/global-account-id": "glob-123",
-			"kyma-project.io/subaccount-id":     "sub-456",
-			"kyma-project.io/region":            "us-east-1",
-			"kyma-project.io/shoot-name":        "shoot-67890",
+			cloudcontrolv1beta1.LabelScopeBrokerPlanName:  "trial",
+			cloudcontrolv1beta1.LabelScopeGlobalAccountId: "glob-123",
+			cloudcontrolv1beta1.LabelScopeSubaccountId:    "sub-456",
+			cloudcontrolv1beta1.LabelScopeRegion:          "us-east-1",
+			cloudcontrolv1beta1.LabelScopeShootName:       "shoot-67890",
 		})
 
 		ffCtx := ContextBuilderFromCtx(context.Background()).

--- a/pkg/kcp/scope/ensureScopeCommonFields.go
+++ b/pkg/kcp/scope/ensureScopeCommonFields.go
@@ -33,5 +33,13 @@ func ensureScopeCommonFields(ctx context.Context, st composed.State) (error, con
 	// set provider
 	state.ObjAsScope().Spec.Provider = state.provider
 
+	// copy kyma labels to scope that are used in metrics and features
+	if state.ObjAsScope().Labels == nil {
+		state.ObjAsScope().Labels = make(map[string]string, len(cloudcontrolv1beta1.ScopeLabels))
+	}
+	for _, label := range cloudcontrolv1beta1.ScopeLabels {
+		state.ObjAsScope().Labels[label] = state.kyma.GetLabels()[label]
+	}
+
 	return nil, nil
 }

--- a/pkg/kcp/scope/findShootName.go
+++ b/pkg/kcp/scope/findShootName.go
@@ -2,6 +2,7 @@ package scope
 
 import (
 	"context"
+	cloudcontrol1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 )
 
@@ -14,7 +15,7 @@ func findShootName(ctx context.Context, st composed.State) (error, context.Conte
 		return composed.StopAndForget, nil
 	}
 
-	state.shootName = state.kyma.GetLabels()["kyma-project.io/shoot-name"]
+	state.shootName = state.kyma.GetLabels()[cloudcontrol1beta1.LabelScopeShootName]
 
 	logger = logger.WithValues("shootName", state.shootName)
 	logger.Info("Shoot name found")

--- a/pkg/kcp/scope/loadKyma.go
+++ b/pkg/kcp/scope/loadKyma.go
@@ -19,21 +19,14 @@ func loadKyma(ctx context.Context, st composed.State) (error, context.Context) {
 	if apierrors.IsNotFound(err) {
 		logger.Info("Kyma CR does not exist")
 
-		// TODO: this needs refactoring since skrRuntime can not decrease proper metrics w/out kyma labels
-		// a quick fix is to provide crafted (not loaded) kyma like this, but long term fix is to copy
-		// over necessary labels from Kyma into the Scope so that data is available here even when Kyma
-		// is deleted
-		kyma := util.NewKymaUnstructured()
-		kyma.SetNamespace(state.Name().Namespace)
-		kyma.SetName(state.Name().Name)
-		state.activeSkrCollection.RemoveKymaUnstructured(kyma)
+		if !predicateScopeExists()(ctx, state) {
+			return composed.StopAndForget, ctx
+		}
+
+		state.activeSkrCollection.RemoveScope(state.ObjAsScope())
 
 		if !NukeScopesWithoutKyma {
 			return composed.StopAndForget, nil
-		}
-
-		if !predicateScopeExists()(ctx, state) {
-			return composed.StopAndForget, ctx
 		}
 
 		nuke := &cloudcontrolv1beta1.Nuke{

--- a/pkg/kcp/scope/predicates.go
+++ b/pkg/kcp/scope/predicates.go
@@ -55,9 +55,20 @@ func predicateScopeCreateOrUpdateNeeded() composed.Predicate {
 	return func(ctx context.Context, st composed.State) bool {
 		if predicateScopeExists()(ctx, st) {
 			state := st.(*State)
+
+			// check if kyma network reference is created
 			if state.kcpNetworkKyma == nil {
 				return true
 			}
+
+			// check if labels from Kyma are copied to Scope
+			for _, label := range cloudcontrolv1beta1.ScopeLabels {
+				if _, ok := state.ObjAsScope().Labels[label]; !ok {
+					return true
+				}
+			}
+
+			// check provider specific shapes
 			switch state.ObjAsScope().Spec.Provider {
 			case cloudcontrolv1beta1.ProviderGCP:
 				return state.ObjAsScope().Spec.Scope.Gcp.Workers == nil || len(state.ObjAsScope().Spec.Scope.Gcp.Workers) == 0

--- a/pkg/kcp/scope/skrActivate.go
+++ b/pkg/kcp/scope/skrActivate.go
@@ -13,7 +13,7 @@ func skrActivate(ctx context.Context, st composed.State) (error, context.Context
 		WithValues("skrKymaName", state.kyma.GetName()).
 		Info("Activating SKR")
 
-	state.activeSkrCollection.AddKymaUnstructured(state.kyma)
+	state.activeSkrCollection.AddScope(state.ObjAsScope())
 
 	return nil, nil
 }

--- a/pkg/kcp/scope/skrDeactivate.go
+++ b/pkg/kcp/scope/skrDeactivate.go
@@ -21,7 +21,7 @@ func skrDeactivate(ctx context.Context, st composed.State) (error, context.Conte
 
 	logger.Info("Stopping SKR and deleting Scope")
 
-	state.activeSkrCollection.RemoveKymaUnstructured(state.kyma)
+	state.activeSkrCollection.RemoveScope(state.ObjAsScope())
 
 	finalizerRemoved := controllerutil.RemoveFinalizer(state.Obj(), cloudcontrolv1beta1.FinalizerName)
 	if finalizerRemoved {

--- a/pkg/testinfra/dsl/kyma.go
+++ b/pkg/testinfra/dsl/kyma.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/testinfra"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -99,7 +100,7 @@ func CreateKymaCR(ctx context.Context, infra testinfra.Infra, kymaCR *unstructur
 	}
 
 	kymaCR.SetLabels(map[string]string{
-		"kyma-project.io/shoot-name": kymaCR.GetName(),
+		cloudcontrolv1beta1.LabelScopeShootName: kymaCR.GetName(),
 	})
 
 	err := infra.KCP().Client().Get(ctx, client.ObjectKeyFromObject(kymaCR), kymaCR)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The Kyma CR can be deleted while Scope still exists, like when SKR cluster is deleted. Then we need to deactive that scope and SKR from the skrLooper and decease the `cloud_manager_skr_runtime_module_active_count` metrics. That metrics has labels "kymaName", "globalAccountId", "subAccountId", "shootName", "region", "brokerPlanName", where all but the first are not accessible anymore since Kyma was deleted. Hence, we need to copy those Kyma labels to Scope so that data is available at the time Scope is deleted and SKR deactivated so the proper metric can be decreased. 

Changes proposed in this pull request:

- added in `scope.predicateScopeCreateOrUpdateNeeded` a check if Kyma labels are copied
- added in `scope.ensureScopeCommonFields` copying of Kyma labels
- replaced `skrruntime.ActiveSkrCollection`  methods `AddKymaUnstructured` and `RemoveKymaUnstructured`, with `AddScope` and `RemoveScope`
- 


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
