### PR TITLE
test(AwsRedisInstance): refactor elastiCacheClientFake to use single mutex

### DIFF
--- a/pkg/kcp/provider/aws/mock/elastiCacheClientFake.go
+++ b/pkg/kcp/provider/aws/mock/elastiCacheClientFake.go
@@ -45,38 +45,28 @@ func getDefaultParams() map[string]elasticacheTypes.Parameter {
 }
 
 type elastiCacheClientFake struct {
-	subnetGroupMutex    *sync.Mutex
-	parameterGroupMutex *sync.Mutex
-	elasticacheMutex    *sync.Mutex
-	secretStoreMutex    *sync.Mutex
-	userGroupsMutex     *sync.Mutex
-	securityGroupsMutex *sync.Mutex
-	replicationGroups   map[string]*elasticacheTypes.ReplicationGroup
-	cacheClusters       map[string]*elasticacheTypes.CacheCluster
-	parameters          map[string]map[string]elasticacheTypes.Parameter
-	parameterGroups     map[string]*elasticacheTypes.CacheParameterGroup
-	subnetGroups        map[string]*elasticacheTypes.CacheSubnetGroup
-	userGroups          map[string]*elasticacheTypes.UserGroup
-	secretStore         map[string]*secretsmanager.GetSecretValueOutput
-	securityGroups      []*ec2Types.SecurityGroup
+	mutex             *sync.Mutex
+	replicationGroups map[string]*elasticacheTypes.ReplicationGroup
+	cacheClusters     map[string]*elasticacheTypes.CacheCluster
+	parameters        map[string]map[string]elasticacheTypes.Parameter
+	parameterGroups   map[string]*elasticacheTypes.CacheParameterGroup
+	subnetGroups      map[string]*elasticacheTypes.CacheSubnetGroup
+	userGroups        map[string]*elasticacheTypes.UserGroup
+	secretStore       map[string]*secretsmanager.GetSecretValueOutput
+	securityGroups    []*ec2Types.SecurityGroup
 }
 
 func newElastiCacheClientFake() *elastiCacheClientFake {
 	return &elastiCacheClientFake{
-		elasticacheMutex:    &sync.Mutex{},
-		subnetGroupMutex:    &sync.Mutex{},
-		parameterGroupMutex: &sync.Mutex{},
-		secretStoreMutex:    &sync.Mutex{},
-		userGroupsMutex:     &sync.Mutex{},
-		securityGroupsMutex: &sync.Mutex{},
-		replicationGroups:   map[string]*elasticacheTypes.ReplicationGroup{},
-		cacheClusters:       map[string]*elasticacheTypes.CacheCluster{},
-		subnetGroups:        map[string]*elasticacheTypes.CacheSubnetGroup{},
-		parameterGroups:     map[string]*elasticacheTypes.CacheParameterGroup{},
-		parameters:          map[string]map[string]elasticacheTypes.Parameter{},
-		secretStore:         map[string]*secretsmanager.GetSecretValueOutput{},
-		userGroups:          map[string]*elasticacheTypes.UserGroup{},
-		securityGroups:      []*ec2Types.SecurityGroup{},
+		mutex:             &sync.Mutex{},
+		replicationGroups: map[string]*elasticacheTypes.ReplicationGroup{},
+		cacheClusters:     map[string]*elasticacheTypes.CacheCluster{},
+		subnetGroups:      map[string]*elasticacheTypes.CacheSubnetGroup{},
+		parameterGroups:   map[string]*elasticacheTypes.CacheParameterGroup{},
+		parameters:        map[string]map[string]elasticacheTypes.Parameter{},
+		secretStore:       map[string]*secretsmanager.GetSecretValueOutput{},
+		userGroups:        map[string]*elasticacheTypes.UserGroup{},
+		securityGroups:    []*ec2Types.SecurityGroup{},
 	}
 }
 
@@ -97,15 +87,15 @@ func (client *elastiCacheClientFake) SetAwsElastiCacheUserGroupLifeCycleState(na
 }
 
 func (client *elastiCacheClientFake) DeleteAwsElastiCacheByName(name string) {
-	client.elasticacheMutex.Lock()
-	defer client.elasticacheMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	delete(client.replicationGroups, name)
 }
 
 func (client *elastiCacheClientFake) DeleteAwsElastiCacheUserGroupByName(name string) {
-	client.userGroupsMutex.Lock()
-	defer client.userGroupsMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	delete(client.userGroups, name)
 }
@@ -121,8 +111,8 @@ func (client *elastiCacheClientFake) DescribeAwsElastiCacheParametersByName(grou
 }
 
 func (client *elastiCacheClientFake) DescribeElastiCacheSubnetGroup(ctx context.Context, name string) ([]elasticacheTypes.CacheSubnetGroup, error) {
-	client.subnetGroupMutex.Lock()
-	defer client.subnetGroupMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	subnetGroup := client.subnetGroups[name]
 
@@ -134,8 +124,8 @@ func (client *elastiCacheClientFake) DescribeElastiCacheSubnetGroup(ctx context.
 }
 
 func (client *elastiCacheClientFake) CreateElastiCacheSubnetGroup(ctx context.Context, name string, subnetIds []string, tags []elasticacheTypes.Tag) (*elasticache.CreateCacheSubnetGroupOutput, error) {
-	client.subnetGroupMutex.Lock()
-	defer client.subnetGroupMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	client.subnetGroups[name] = &elasticacheTypes.CacheSubnetGroup{
 		CacheSubnetGroupName: ptr.To(name),
@@ -147,8 +137,8 @@ func (client *elastiCacheClientFake) CreateElastiCacheSubnetGroup(ctx context.Co
 }
 
 func (client *elastiCacheClientFake) DeleteElastiCacheSubnetGroup(ctx context.Context, name string) error {
-	client.subnetGroupMutex.Lock()
-	defer client.subnetGroupMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	delete(client.subnetGroups, name)
 
@@ -156,8 +146,8 @@ func (client *elastiCacheClientFake) DeleteElastiCacheSubnetGroup(ctx context.Co
 }
 
 func (client *elastiCacheClientFake) DescribeElastiCacheParameterGroup(ctx context.Context, name string) ([]elasticacheTypes.CacheParameterGroup, error) {
-	client.parameterGroupMutex.Lock()
-	defer client.parameterGroupMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	parameterGroup := client.parameterGroups[name]
 
@@ -169,8 +159,8 @@ func (client *elastiCacheClientFake) DescribeElastiCacheParameterGroup(ctx conte
 }
 
 func (client *elastiCacheClientFake) CreateElastiCacheParameterGroup(ctx context.Context, name, family string, tags []elasticacheTypes.Tag) (*elasticache.CreateCacheParameterGroupOutput, error) {
-	client.parameterGroupMutex.Lock()
-	defer client.parameterGroupMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	client.parameterGroups[name] = &elasticacheTypes.CacheParameterGroup{
 		CacheParameterGroupName:   ptr.To(name),
@@ -185,8 +175,8 @@ func (client *elastiCacheClientFake) CreateElastiCacheParameterGroup(ctx context
 }
 
 func (client *elastiCacheClientFake) DeleteElastiCacheParameterGroup(ctx context.Context, name string) error {
-	client.parameterGroupMutex.Lock()
-	defer client.parameterGroupMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	delete(client.parameterGroups, name)
 
@@ -194,15 +184,15 @@ func (client *elastiCacheClientFake) DeleteElastiCacheParameterGroup(ctx context
 }
 
 func (client *elastiCacheClientFake) DescribeElastiCacheParameters(ctx context.Context, groupName string) ([]elasticacheTypes.Parameter, error) {
-	client.parameterGroupMutex.Lock()
-	defer client.parameterGroupMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	return pie.Values(client.parameters[groupName]), nil
 }
 
 func (client *elastiCacheClientFake) ModifyElastiCacheParameterGroup(ctx context.Context, groupName string, parameters []elasticacheTypes.ParameterNameValue) error {
-	client.parameterGroupMutex.Lock()
-	defer client.parameterGroupMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	for _, parameter := range parameters {
 		client.parameters[groupName][ptr.Deref(parameter.ParameterName, "")] = elasticacheTypes.Parameter{ParameterName: parameter.ParameterName, ParameterValue: parameter.ParameterValue}
@@ -216,15 +206,15 @@ func (client *elastiCacheClientFake) DescribeEngineDefaultParameters(ctx context
 }
 
 func (client *elastiCacheClientFake) GetAuthTokenSecretValue(ctx context.Context, secretName string) (*secretsmanager.GetSecretValueOutput, error) {
-	client.secretStoreMutex.Lock()
-	defer client.secretStoreMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	return client.secretStore[secretName], nil
 }
 
 func (client *elastiCacheClientFake) CreateAuthTokenSecret(ctx context.Context, secretName string, tags []secretsmanagerTypes.Tag) error {
-	client.secretStoreMutex.Lock()
-	defer client.secretStoreMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	client.secretStore[secretName] = &secretsmanager.GetSecretValueOutput{
 		Name:         ptr.To(secretName),
@@ -235,8 +225,8 @@ func (client *elastiCacheClientFake) CreateAuthTokenSecret(ctx context.Context, 
 }
 
 func (client *elastiCacheClientFake) DeleteAuthTokenSecret(ctx context.Context, secretName string) error {
-	client.secretStoreMutex.Lock()
-	defer client.secretStoreMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	delete(client.secretStore, secretName)
 
@@ -244,8 +234,8 @@ func (client *elastiCacheClientFake) DeleteAuthTokenSecret(ctx context.Context, 
 }
 
 func (client *elastiCacheClientFake) DescribeElastiCacheReplicationGroup(ctx context.Context, clusterId string) ([]elasticacheTypes.ReplicationGroup, error) {
-	client.elasticacheMutex.Lock()
-	defer client.elasticacheMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	cacheCluster := client.replicationGroups[clusterId]
 
@@ -257,8 +247,8 @@ func (client *elastiCacheClientFake) DescribeElastiCacheReplicationGroup(ctx con
 }
 
 func (client *elastiCacheClientFake) CreateElastiCacheReplicationGroup(ctx context.Context, tags []elasticacheTypes.Tag, options awsclient.CreateElastiCacheClusterOptions) (*elasticache.CreateReplicationGroupOutput, error) {
-	client.elasticacheMutex.Lock()
-	defer client.elasticacheMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	client.cacheClusters[options.Name] = &elasticacheTypes.CacheCluster{
 		CacheClusterId:             ptr.To(options.Name),
@@ -300,8 +290,8 @@ func (client *elastiCacheClientFake) CreateElastiCacheReplicationGroup(ctx conte
 }
 
 func (client *elastiCacheClientFake) ModifyElastiCacheReplicationGroup(ctx context.Context, id string, options awsclient.ModifyElastiCacheClusterOptions) (*elasticache.ModifyReplicationGroupOutput, error) {
-	client.elasticacheMutex.Lock()
-	defer client.elasticacheMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	if instance, ok := client.replicationGroups[id]; ok {
 		instance.Status = ptr.To("modifying")
@@ -341,8 +331,8 @@ func (client *elastiCacheClientFake) ModifyElastiCacheReplicationGroup(ctx conte
 }
 
 func (client *elastiCacheClientFake) DeleteElastiCacheReplicationGroup(ctx context.Context, id string) error {
-	client.elasticacheMutex.Lock()
-	defer client.elasticacheMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	if instance, ok := client.replicationGroups[id]; ok {
 		instance.Status = ptr.To("deleting")
@@ -352,8 +342,8 @@ func (client *elastiCacheClientFake) DeleteElastiCacheReplicationGroup(ctx conte
 }
 
 func (client *elastiCacheClientFake) DescribeElastiCacheCluster(ctx context.Context, id string) ([]elasticacheTypes.CacheCluster, error) {
-	client.elasticacheMutex.Lock()
-	defer client.elasticacheMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	cacheCluster := client.cacheClusters[id]
 
@@ -365,8 +355,8 @@ func (client *elastiCacheClientFake) DescribeElastiCacheCluster(ctx context.Cont
 }
 
 func (client *elastiCacheClientFake) DescribeUserGroup(ctx context.Context, id string) (*elasticacheTypes.UserGroup, error) {
-	client.userGroupsMutex.Lock()
-	defer client.userGroupsMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	userGroup := client.userGroups[id]
 
@@ -374,8 +364,8 @@ func (client *elastiCacheClientFake) DescribeUserGroup(ctx context.Context, id s
 }
 
 func (client *elastiCacheClientFake) CreateUserGroup(ctx context.Context, id string, tags []elasticacheTypes.Tag) (*elasticache.CreateUserGroupOutput, error) {
-	client.userGroupsMutex.Lock()
-	defer client.userGroupsMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	client.userGroups[id] = &elasticacheTypes.UserGroup{
 		Engine:      ptr.To("redis"),
@@ -388,8 +378,8 @@ func (client *elastiCacheClientFake) CreateUserGroup(ctx context.Context, id str
 }
 
 func (client *elastiCacheClientFake) DeleteUserGroup(ctx context.Context, id string) error {
-	client.userGroupsMutex.Lock()
-	defer client.userGroupsMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	if instance, ok := client.userGroups[id]; ok {
 		instance.Status = ptr.To("deleting")
@@ -399,8 +389,8 @@ func (client *elastiCacheClientFake) DeleteUserGroup(ctx context.Context, id str
 }
 
 func (client *elastiCacheClientFake) DescribeElastiCacheSecurityGroups(ctx context.Context, filters []ec2Types.Filter, groupIds []string) ([]ec2Types.SecurityGroup, error) {
-	client.securityGroupsMutex.Lock()
-	defer client.securityGroupsMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	list := append([]*ec2Types.SecurityGroup{}, client.securityGroups...)
 	if groupIds != nil {
@@ -421,8 +411,8 @@ func (client *elastiCacheClientFake) DescribeElastiCacheSecurityGroups(ctx conte
 }
 
 func (client *elastiCacheClientFake) CreateElastiCacheSecurityGroup(ctx context.Context, vpcId string, name string, tags []ec2Types.Tag) (string, error) {
-	client.securityGroupsMutex.Lock()
-	defer client.securityGroupsMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	tags = append(tags, ec2Types.Tag{
 		Key:   ptr.To("vpc-id"),
@@ -440,8 +430,8 @@ func (client *elastiCacheClientFake) CreateElastiCacheSecurityGroup(ctx context.
 }
 
 func (client *elastiCacheClientFake) AuthorizeElastiCacheSecurityGroupIngress(ctx context.Context, groupId string, ipPermissions []ec2Types.IpPermission) error {
-	client.securityGroupsMutex.Lock()
-	defer client.securityGroupsMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	var securityGroup *ec2Types.SecurityGroup
 	for _, sg := range client.securityGroups {
@@ -458,8 +448,8 @@ func (client *elastiCacheClientFake) AuthorizeElastiCacheSecurityGroupIngress(ct
 }
 
 func (client *elastiCacheClientFake) DeleteElastiCacheSecurityGroup(ctx context.Context, id string) error {
-	client.securityGroupsMutex.Lock()
-	defer client.securityGroupsMutex.Unlock()
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
 
 	client.securityGroups = pie.Filter(client.securityGroups, func(sg *ec2Types.SecurityGroup) bool {
 		return ptr.Deref(sg.GroupId, "") != id

--- a/pkg/kcp/provider/aws/mock/elastiCacheClientFake.go
+++ b/pkg/kcp/provider/aws/mock/elastiCacheClientFake.go
@@ -45,7 +45,7 @@ func getDefaultParams() map[string]elasticacheTypes.Parameter {
 }
 
 type elastiCacheClientFake struct {
-	mutex             *sync.Mutex
+	mutex             sync.Mutex
 	replicationGroups map[string]*elasticacheTypes.ReplicationGroup
 	cacheClusters     map[string]*elasticacheTypes.CacheCluster
 	parameters        map[string]map[string]elasticacheTypes.Parameter
@@ -58,7 +58,7 @@ type elastiCacheClientFake struct {
 
 func newElastiCacheClientFake() *elastiCacheClientFake {
 	return &elastiCacheClientFake{
-		mutex:             &sync.Mutex{},
+		mutex:             sync.Mutex{},
 		replicationGroups: map[string]*elasticacheTypes.ReplicationGroup{},
 		cacheClusters:     map[string]*elasticacheTypes.CacheCluster{},
 		subnetGroups:      map[string]*elasticacheTypes.CacheSubnetGroup{},


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- multiple mutexes were unnecessary, so they are replaced by a single mutex to improve readability

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
