### PR TITLE
chore(AwsVpcPeering): route table tests

### DIFF
--- a/pkg/kcp/provider/aws/mock/vpcPeeringStore.go
+++ b/pkg/kcp/provider/aws/mock/vpcPeeringStore.go
@@ -55,6 +55,19 @@ func (s *vpcPeeringStore) CreateVpcPeeringConnection(ctx context.Context, vpcId,
 	return &item.peering, nil
 }
 
+func (s *vpcPeeringStore) DescribeVpcPeeringConnection(ctx context.Context, vpcPeeringConnectionId string) (*ec2types.VpcPeeringConnection, error) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	for _, x := range s.items {
+		if ptr.Equal(x.peering.VpcPeeringConnectionId, ptr.To(vpcPeeringConnectionId)) {
+			return &x.peering, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func (s *vpcPeeringStore) DescribeVpcPeeringConnections(ctx context.Context) ([]ec2types.VpcPeeringConnection, error) {
 	s.m.Lock()
 	defer s.m.Unlock()

--- a/pkg/kcp/provider/aws/vpcpeering/client/client.go
+++ b/pkg/kcp/provider/aws/vpcpeering/client/client.go
@@ -12,6 +12,7 @@ type Client interface {
 	DescribeVpc(ctx context.Context, vpcId string) (*types.Vpc, error)
 	DescribeVpcs(ctx context.Context, name string) ([]types.Vpc, error)
 	CreateVpcPeeringConnection(ctx context.Context, vpcId, remoteVpcId, remoteRegion, remoteAccountId *string, tag []types.Tag) (*types.VpcPeeringConnection, error)
+	DescribeVpcPeeringConnection(ctx context.Context, vpcPeeringConnectionId string) (*types.VpcPeeringConnection, error)
 	DescribeVpcPeeringConnections(ctx context.Context) ([]types.VpcPeeringConnection, error)
 	AcceptVpcPeeringConnection(ctx context.Context, connectionId *string) (*types.VpcPeeringConnection, error)
 	DeleteVpcPeeringConnection(ctx context.Context, connectionId *string) error
@@ -93,6 +94,20 @@ func (c *client) DescribeVpcPeeringConnections(ctx context.Context) ([]types.Vpc
 		return nil, err
 	}
 	return out.VpcPeeringConnections, err
+}
+
+func (c *client) DescribeVpcPeeringConnection(ctx context.Context, vpcPeeringConnectionId string) (*types.VpcPeeringConnection, error) {
+	out, err := c.svc.DescribeVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
+		VpcPeeringConnectionIds: []string{vpcPeeringConnectionId},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(out.VpcPeeringConnections) > 0 {
+		return &out.VpcPeeringConnections[0], nil
+	}
+	return nil, nil
 }
 
 func (c *client) AcceptVpcPeeringConnection(ctx context.Context, connectionId *string) (*types.VpcPeeringConnection, error) {

--- a/pkg/kcp/provider/aws/vpcpeering/loadRemoteVpcPeeringConnection.go
+++ b/pkg/kcp/provider/aws/vpcpeering/loadRemoteVpcPeeringConnection.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
-	"k8s.io/utils/ptr"
 )
 
 func loadRemoteVpcPeeringConnection(ctx context.Context, st composed.State) (error, context.Context) {
@@ -18,18 +17,13 @@ func loadRemoteVpcPeeringConnection(ctx context.Context, st composed.State) (err
 		return nil, nil
 	}
 
-	list, err := state.remoteClient.DescribeVpcPeeringConnections(ctx)
+	peering, err := state.remoteClient.DescribeVpcPeeringConnection(ctx, obj.Status.RemoteId)
 
 	if err != nil {
 		return awsmeta.LogErrorAndReturn(err, "Error listing AWS peering connections", ctx)
 	}
 
-	for _, c := range list {
-		if obj.Status.RemoteId == ptr.Deref(c.VpcPeeringConnectionId, "") {
-			state.remoteVpcPeering = &c
-			break
-		}
-	}
+	state.remoteVpcPeering = peering
 
 	ctx = composed.LoggerIntoCtx(ctx, logger.WithValues("remoteId", obj.Status.RemoteId))
 

--- a/pkg/kcp/provider/aws/vpcpeering/loadVpcPeeringConnection.go
+++ b/pkg/kcp/provider/aws/vpcpeering/loadVpcPeeringConnection.go
@@ -16,18 +16,13 @@ func loadVpcPeeringConnection(ctx context.Context, st composed.State) (error, co
 		return nil, nil
 	}
 
-	list, err := state.client.DescribeVpcPeeringConnections(ctx)
+	peering, err := state.client.DescribeVpcPeeringConnection(ctx, obj.Status.Id)
 
 	if err != nil {
 		return composed.LogErrorAndReturn(err, "Error listing AWS peering connections", composed.StopWithRequeue, ctx)
 	}
 
-	for _, c := range list {
-		if obj.Status.Id == ptr.Deref(c.VpcPeeringConnectionId, "") {
-			state.vpcPeering = &c
-			break
-		}
-	}
+	state.vpcPeering = peering
 
 	if state.vpcPeering == nil {
 		return nil, nil

--- a/pkg/testinfra/dsl/kcpVpcPeering.go
+++ b/pkg/testinfra/dsl/kcpVpcPeering.go
@@ -3,6 +3,7 @@ package dsl
 import (
 	"context"
 	"errors"
+	"fmt"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -75,5 +76,17 @@ func WithKcpVpcPeeringSpecGCP(remoteVpc, remoteProject, remotePeeringName string
 				}
 			}
 		},
+	}
+}
+
+func HavingKcpVpcPeeringStatusIdNotEmpty() ObjAssertion {
+	return func(obj client.Object) error {
+		if x, ok := obj.(*cloudcontrolv1beta1.VpcPeering); ok {
+			if x.Status.Id != "" {
+				return nil
+			}
+			return fmt.Errorf("the KCP VpcPeering expected status id to be not empty, but it is")
+		}
+		return fmt.Errorf("unhandled type %T", obj)
 	}
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Improve route table tests
- Moved inline string declaration to consts as they are being reused
- Added  DescribeVpcPeeringConnection to avoid looping every time to find connection by id
- Added helper methods GetRoute and GetRouteCount to improve test readablity