### PR TITLE
chore(GCP Vpc Peering) setting "Deleting" state to the peering object

### DIFF
--- a/api/cloud-control/v1beta1/vpcpeering_types.go
+++ b/api/cloud-control/v1beta1/vpcpeering_types.go
@@ -34,6 +34,7 @@ const (
 	VirtualNetworkPeeringStateConnected    = "Connected"
 	VirtualNetworkPeeringStateDisconnected = "Disconnected"
 	VirtualNetworkPeeringStateInitiated    = "Initiated"
+	VirtualNetworkPeeringStateDeleting     = "Deleting"
 )
 
 // VpcPeeringSpec defines the desired state of VpcPeering

--- a/config/dist/skr/crd/bases/providers/gcp/cloud-resources.kyma-project.io_gcpvpcpeerings_ui.yaml
+++ b/config/dist/skr/crd/bases/providers/gcp/cloud-resources.kyma-project.io_gcpvpcpeerings_ui.yaml
@@ -81,6 +81,8 @@ data:
          - Initiated
         critical:
          - Disconnected
+        warning:
+         - Deleting
   translations: |-
     en:
       configuration: Configuration

--- a/config/ui-extensions/gcpvpcpeerings/cloud-resources.kyma-project.io_gcpvpcpeerings_ui.yaml
+++ b/config/ui-extensions/gcpvpcpeerings/cloud-resources.kyma-project.io_gcpvpcpeerings_ui.yaml
@@ -81,6 +81,8 @@ data:
          - Initiated
         critical:
          - Disconnected
+        warning:
+         - Deleting
   translations: |-
     en:
       configuration: Configuration

--- a/config/ui-extensions/gcpvpcpeerings/list
+++ b/config/ui-extensions/gcpvpcpeerings/list
@@ -21,3 +21,5 @@
      - Initiated
     critical:
      - Disconnected
+    warning:
+     - Deleting


### PR DESCRIPTION
**Description**
This will introduce a 4th vpc peering state to improve usability.
Scenario
When deleting the peering object it was being displayed as Connected until it vanishes,
with this change the state will be set to Deleting providing a better feedback to the user, specially on Bussola since
there was no feedback at all once the user pressed the delete button.

Changes proposed in this pull request:

- status.state => "Deleting"
