### PR TITLE
fix(AzureIpRange): panic - odd number of parameters passed

### DIFF
--- a/pkg/kcp/provider/azure/iprange/virtualNetworkLinkCreate.go
+++ b/pkg/kcp/provider/azure/iprange/virtualNetworkLinkCreate.go
@@ -47,7 +47,7 @@ func virtualNetworkLinkCreate(ctx context.Context, st composed.State) (error, co
 	}
 
 	if err != nil {
-		logger.Error(err, "Error creating Azure KCP IpRange virtualNetworkLink", ctx)
+		logger.Error(err, "Error creating Azure KCP IpRange virtualNetworkLink")
 
 		state.ObjAsIpRange().Status.State = cloudcontrol1beta1.ErrorState
 


### PR DESCRIPTION
Changes proposed in this pull request:

- fix "panic - odd number of parameters passed"
