### PR TITLE
fix(AzureVpcPeering): fixes deletion of local VPC peering

### DIFF
--- a/api/cloud-control/v1beta1/vpcpeering_builder.go
+++ b/api/cloud-control/v1beta1/vpcpeering_builder.go
@@ -108,6 +108,11 @@ func (b *VpcPeeringBuilder) WithDetails(localName, localNamespace, remoteName, r
 	return b
 }
 
+func (b *VpcPeeringBuilder) WithLocalPeeringName(localPeeringName string) *VpcPeeringBuilder {
+	b.Obj.Spec.Details.LocalPeeringName = localPeeringName
+	return b
+}
+
 func (b *VpcPeeringBuilder) Build() *VpcPeering {
 	return &b.Obj
 }

--- a/internal/controller/cloud-control/vpcpeering_azure_test.go
+++ b/internal/controller/cloud-control/vpcpeering_azure_test.go
@@ -28,6 +28,7 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 			remoteResourceGroup = "MyResourceGroup"
 			remoteVnetName      = "MyVnet"
 			remotePeeringName   = "my-peering"
+			localPeeringName    = "kyma-peering"
 		)
 
 		scope := &cloudcontrolv1beta1.Scope{}
@@ -67,6 +68,7 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 				WithScope(kymaName).
 				WithRemoteRef("skr-namespace", "skr-azure-vpcpeering").
 				WithDetails(localKcpNetworkName, infra.KCP().Namespace(), remoteKcpNetworkName, infra.KCP().Namespace(), remotePeeringName, true, true).
+				WithLocalPeeringName(localPeeringName).
 				Build()
 
 			Eventually(CreateObj).
@@ -157,7 +159,7 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 
 		By("Then local Azure VPC Peering is created", func() {
 			Eventually(func() error {
-				p, err := azureMockLocal.GetPeering(infra.Ctx(), localResourceGroupName, localVirtualNetworkName, kcpPeeringName)
+				p, err := azureMockLocal.GetPeering(infra.Ctx(), localResourceGroupName, localVirtualNetworkName, localPeeringName)
 				if err != nil {
 					return err
 				}
@@ -206,12 +208,12 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 		// Ready ==========================================================
 
 		By("When Azure VPC Peering is Connected", func() {
-			err := azureMockLocal.SetPeeringStateConnected(infra.Ctx(), localResourceGroupName, localVirtualNetworkName, kcpPeeringName)
+			err := azureMockLocal.SetPeeringStateConnected(infra.Ctx(), localResourceGroupName, localVirtualNetworkName, localPeeringName)
 			Expect(err).ToNot(HaveOccurred())
 			err = azureMockRemote.SetPeeringStateConnected(infra.Ctx(), remoteResourceGroup, remoteVnetName, remotePeeringName)
 			Expect(err).ToNot(HaveOccurred())
 
-			p, err := azureMockLocal.GetPeering(infra.Ctx(), localResourceGroupName, localVirtualNetworkName, kcpPeeringName)
+			p, err := azureMockLocal.GetPeering(infra.Ctx(), localResourceGroupName, localVirtualNetworkName, localPeeringName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(p).ToNot(BeNil())
 			localAzurePeering = p
@@ -264,7 +266,7 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 		})
 
 		By("And Then local Azure peering does not exist", func() {
-			peering, err := azureMockLocal.GetPeering(infra.Ctx(), localResourceGroupName, localVirtualNetworkName, kcpPeeringName)
+			peering, err := azureMockLocal.GetPeering(infra.Ctx(), localResourceGroupName, localVirtualNetworkName, localPeeringName)
 			Expect(err).To(HaveOccurred())
 			Expect(azuremeta.IsNotFound(err)).To(BeTrue())
 			Expect(peering).To(BeNil())

--- a/pkg/kcp/provider/azure/vpcpeering/deleteVpcPeering.go
+++ b/pkg/kcp/provider/azure/vpcpeering/deleteVpcPeering.go
@@ -24,7 +24,7 @@ func deleteVpcPeering(ctx context.Context, st composed.State) (error, context.Co
 		ctx,
 		resourceGroupName,
 		state.Scope().Spec.Scope.Azure.VpcNetwork,
-		obj.Name,
+		obj.GetLocalPeeringName(),
 	)
 
 	if err != nil {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- fixes the issue with deleing local VPC peering connection when LocalPeeringName is used.