### PR TITLE
fix(AzureRedis): remove odd param causing panic

### DIFF
--- a/pkg/kcp/provider/azure/iprange/privateDnsZoneCreate.go
+++ b/pkg/kcp/provider/azure/iprange/privateDnsZoneCreate.go
@@ -38,7 +38,7 @@ func privateDnsZoneCreate(ctx context.Context, st composed.State) (error, contex
 	}
 
 	if err != nil {
-		logger.Error(err, "Error creating Azure KCP IpRange privateDnsZone", ctx)
+		logger.Error(err, "Error creating Azure KCP IpRange privateDnsZone")
 
 		state.ObjAsIpRange().Status.State = cloudcontrol1beta1.ErrorState
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove uneeded param in loging causing cernel panic.
