### PR TITLE
feat(AwsRedisInstance): replace cacheNodeType with redisTIer; drop readReplicas from API

### DIFF
--- a/api/cloud-resources/v1beta1/awsredisinstance_types.go
+++ b/api/cloud-resources/v1beta1/awsredisinstance_types.go
@@ -22,6 +22,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// +kubebuilder:validation:Enum=S1;S2;S3;S4;S5;S6;S7;P1;P2;P3;P4;P5;P6
+type AwsRedisTier string
+
+const (
+	AwsRedisTierS1 AwsRedisTier = "S1"
+	AwsRedisTierS2 AwsRedisTier = "S2"
+	AwsRedisTierS3 AwsRedisTier = "S3"
+	AwsRedisTierS4 AwsRedisTier = "S4"
+	AwsRedisTierS5 AwsRedisTier = "S5"
+	AwsRedisTierS6 AwsRedisTier = "S6"
+	AwsRedisTierS7 AwsRedisTier = "S7"
+	AwsRedisTierS8 AwsRedisTier = "S8"
+
+	AwsRedisTierP1 AwsRedisTier = "P1"
+	AwsRedisTierP2 AwsRedisTier = "P2"
+	AwsRedisTierP3 AwsRedisTier = "P3"
+	AwsRedisTierP4 AwsRedisTier = "P4"
+	AwsRedisTierP5 AwsRedisTier = "P5"
+	AwsRedisTierP6 AwsRedisTier = "P6"
+)
+
 // AwsRedisInstanceSpec defines the desired state of AwsRedisInstance
 type AwsRedisInstanceSpec struct {
 	// +optional
@@ -31,8 +52,10 @@ type AwsRedisInstanceSpec struct {
 	// +kubebuilder:validation:XValidation:rule=(self == oldSelf), message="AuthSecret is immutable."
 	AuthSecret *AuthSecretSpec `json:"authSecret,omitempty"`
 
+	// Defines Service Tier and Capacity Tier. RedisTiers starting with 'S' are Standard service tier. RedisTiers starting with 'P' are premium servicetier. Number next to service tier represents capacity tier.
 	// +kubebuilder:validation:Required
-	CacheNodeType string `json:"cacheNodeType"`
+	// +kubebuilder:validation:XValidation:rule=(self.startsWith('S') && oldSelf.startsWith('S') || self.startsWith('P') && oldSelf.startsWith('P')), message="Service tier cannot be changed within redisTier. Only capacity tier can be changed."
+	RedisTier AwsRedisTier `json:"redisTier"`
 
 	// +optional
 	// +kubebuilder:default="7.0"
@@ -59,13 +82,6 @@ type AwsRedisInstanceSpec struct {
 
 	// +optional
 	Parameters map[string]string `json:"parameters,omitempty"`
-
-	// +optional
-	// +kubebuilder:default=0
-	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=1
-	// +kubebuilder:validation:XValidation:rule=(self == oldSelf), message="ReadReplicas is immutable."
-	ReadReplicas int32 `json:"readReplicas"`
 }
 
 // AwsRedisInstanceStatus defines the observed state of AwsRedisInstance

--- a/config/crd/bases/cloud-resources.kyma-project.io_awsredisinstances.yaml
+++ b/config/crd/bases/cloud-resources.kyma-project.io_awsredisinstances.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-    cloud-resources.kyma-project.io/version: v0.0.15
+    cloud-resources.kyma-project.io/version: v0.0.16
   name: awsredisinstances.cloud-resources.kyma-project.io
 spec:
   group: cloud-resources.kyma-project.io
@@ -68,8 +68,6 @@ spec:
                 autoMinorVersionUpgrade:
                   default: false
                   type: boolean
-                cacheNodeType:
-                  type: string
                 engineVersion:
                   default: "7.0"
                   type: string
@@ -99,17 +97,28 @@ spec:
 
                     Example: sun:23:00-mon:01:30
                   type: string
-                readReplicas:
-                  default: 0
-                  format: int32
-                  maximum: 1
-                  minimum: 0
-                  type: integer
+                redisTier:
+                  description: Defines Service Tier and Capacity Tier. RedisTiers starting with 'S' are Standard service tier. RedisTiers starting with 'P' are premium servicetier. Number next to service tier represents capacity tier.
+                  enum:
+                    - S1
+                    - S2
+                    - S3
+                    - S4
+                    - S5
+                    - S6
+                    - S7
+                    - P1
+                    - P2
+                    - P3
+                    - P4
+                    - P5
+                    - P6
+                  type: string
                   x-kubernetes-validations:
-                    - message: ReadReplicas is immutable.
-                      rule: (self == oldSelf)
+                    - message: Service tier cannot be changed within redisTier. Only capacity tier can be changed.
+                      rule: (self.startsWith('S') && oldSelf.startsWith('S') || self.startsWith('P') && oldSelf.startsWith('P'))
               required:
-                - cacheNodeType
+                - redisTier
               type: object
             status:
               description: AwsRedisInstanceStatus defines the observed state of AwsRedisInstance

--- a/config/dist/skr/crd/bases/providers/aws/cloud-resources.kyma-project.io_awsredisinstances.yaml
+++ b/config/dist/skr/crd/bases/providers/aws/cloud-resources.kyma-project.io_awsredisinstances.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-    cloud-resources.kyma-project.io/version: v0.0.15
+    cloud-resources.kyma-project.io/version: v0.0.16
   name: awsredisinstances.cloud-resources.kyma-project.io
 spec:
   group: cloud-resources.kyma-project.io
@@ -68,8 +68,6 @@ spec:
                 autoMinorVersionUpgrade:
                   default: false
                   type: boolean
-                cacheNodeType:
-                  type: string
                 engineVersion:
                   default: "7.0"
                   type: string
@@ -99,17 +97,28 @@ spec:
 
                     Example: sun:23:00-mon:01:30
                   type: string
-                readReplicas:
-                  default: 0
-                  format: int32
-                  maximum: 1
-                  minimum: 0
-                  type: integer
+                redisTier:
+                  description: Defines Service Tier and Capacity Tier. RedisTiers starting with 'S' are Standard service tier. RedisTiers starting with 'P' are premium servicetier. Number next to service tier represents capacity tier.
+                  enum:
+                    - S1
+                    - S2
+                    - S3
+                    - S4
+                    - S5
+                    - S6
+                    - S7
+                    - P1
+                    - P2
+                    - P3
+                    - P4
+                    - P5
+                    - P6
+                  type: string
                   x-kubernetes-validations:
-                    - message: ReadReplicas is immutable.
-                      rule: (self == oldSelf)
+                    - message: Service tier cannot be changed within redisTier. Only capacity tier can be changed.
+                      rule: (self.startsWith('S') && oldSelf.startsWith('S') || self.startsWith('P') && oldSelf.startsWith('P'))
               required:
-                - cacheNodeType
+                - redisTier
               type: object
             status:
               description: AwsRedisInstanceStatus defines the observed state of AwsRedisInstance

--- a/config/patchAfterMakeManifests.sh
+++ b/config/patchAfterMakeManifests.sh
@@ -8,7 +8,7 @@ echo "Patching CRDs..."
 yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.1.1"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_ipranges.yaml
 yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.3"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_awsnfsvolumes.yaml
 yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.3"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_awsnfsvolumebackups.yaml
-yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.15"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_awsredisinstances.yaml
+yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.16"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_awsredisinstances.yaml
 yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.5"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_gcpnfsvolumes.yaml
 yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.17"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_gcpredisinstances.yaml
 yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.2"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_azurevpcpeerings.yaml

--- a/config/samples/cloud-resources_v1beta1_awsredisinstance.yaml
+++ b/config/samples/cloud-resources_v1beta1_awsredisinstance.yaml
@@ -10,11 +10,10 @@ metadata:
   name: awsredisinstance-sample
 spec:
   # required fields
-  cacheNodeType: cache.t2.micro
+  redisTier: "P1"
 
   # optional fields
   engineVersion: "7.0"
-  readReplicas: 1
   autoMinorVersionUpgrade: true
   parameters:
     maxmemory-policy: volatile-lru

--- a/internal/api-tests/skr_awsredisinstance_test.go
+++ b/internal/api-tests/skr_awsredisinstance_test.go
@@ -1,0 +1,82 @@
+package api_tests
+
+import (
+	"github.com/google/uuid"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	. "github.com/kyma-project/cloud-manager/pkg/testinfra/dsl"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type testAwsRedisInstanceBuilder struct {
+	instance cloudresourcesv1beta1.AwsRedisInstance
+}
+
+func newTestAwsRedisInstanceBuilder() *testAwsRedisInstanceBuilder {
+	return &testAwsRedisInstanceBuilder{
+		instance: cloudresourcesv1beta1.AwsRedisInstance{
+			Spec: cloudresourcesv1beta1.AwsRedisInstanceSpec{
+				IpRange: cloudresourcesv1beta1.IpRangeRef{
+					Name: uuid.NewString(),
+				},
+				RedisTier:     "S1",
+				EngineVersion: "7.0",
+				AuthEnabled:   true,
+				Parameters: map[string]string{
+					"maxmemory-policy": "allkeys-lru",
+				},
+			},
+		},
+	}
+}
+
+func (b *testAwsRedisInstanceBuilder) Build() *cloudresourcesv1beta1.AwsRedisInstance {
+	return &b.instance
+}
+
+func (b *testAwsRedisInstanceBuilder) WithRedisTier(redisTier cloudresourcesv1beta1.AwsRedisTier) *testAwsRedisInstanceBuilder {
+	b.instance.Spec.RedisTier = redisTier
+	return b
+}
+
+var _ = Describe("Feature: SKR AwsRedisInstance", Ordered, func() {
+
+	It("Given SKR default namespace exists", func() {
+		Eventually(CreateNamespace).
+			WithArguments(infra.Ctx(), infra.SKR().Client(), &corev1.Namespace{}).
+			Should(Succeed())
+	})
+
+	canChangeSkr(
+		"AwsRedisInstance redisTier can be changed if category stays the same (standard->standard)",
+		newTestAwsRedisInstanceBuilder().WithRedisTier(cloudresourcesv1beta1.AwsRedisTierS1),
+		func(b Builder[*cloudresourcesv1beta1.AwsRedisInstance]) {
+			b.(*testAwsRedisInstanceBuilder).WithRedisTier(cloudresourcesv1beta1.AwsRedisTierS2)
+		},
+	)
+	canChangeSkr(
+		"AwsRedisInstance redisTier can be changed if category stays the same (premium->premium)",
+		newTestAwsRedisInstanceBuilder().WithRedisTier(cloudresourcesv1beta1.AwsRedisTierP1),
+		func(b Builder[*cloudresourcesv1beta1.AwsRedisInstance]) {
+			b.(*testAwsRedisInstanceBuilder).WithRedisTier(cloudresourcesv1beta1.AwsRedisTierP2)
+		},
+	)
+
+	canNotChangeSkr(
+		"AwsRedisInstance redisTier can not be changed if category changes (standard->premium)",
+		newTestAwsRedisInstanceBuilder().WithRedisTier(cloudresourcesv1beta1.AwsRedisTierS1),
+		func(b Builder[*cloudresourcesv1beta1.AwsRedisInstance]) {
+			b.(*testAwsRedisInstanceBuilder).WithRedisTier(cloudresourcesv1beta1.AwsRedisTierP2)
+		},
+		"Service tier cannot be changed within redisTier. Only capacity tier can be changed.",
+	)
+	canNotChangeSkr(
+		"AwsRedisInstance redisTier can not be changed if category changes (standard->premium)",
+		newTestAwsRedisInstanceBuilder().WithRedisTier(cloudresourcesv1beta1.AwsRedisTierP1),
+		func(b Builder[*cloudresourcesv1beta1.AwsRedisInstance]) {
+			b.(*testAwsRedisInstanceBuilder).WithRedisTier(cloudresourcesv1beta1.AwsRedisTierS2)
+		},
+		"Service tier cannot be changed within redisTier. Only capacity tier can be changed.",
+	)
+})

--- a/internal/controller/cloud-resources/awsredisinstance_test.go
+++ b/internal/controller/cloud-resources/awsredisinstance_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Feature: SKR AwsRedisInstance", func() {
 			"bar": "2",
 		}
 
-		cacheNodeType := "cache.m5.large"
+		redisTier := cloudresourcesv1beta1.AwsRedisTierP1
 		engineVersion := "6.x"
 		autoMinorVersionUpgrade := true
 		authEnabled := true
@@ -70,7 +70,6 @@ var _ = Describe("Feature: SKR AwsRedisInstance", func() {
 		parameters := map[string]string{
 			parameterKey: parameterValue,
 		}
-		readReplicas := 1
 
 		By("When AwsRedisInstance is created", func() {
 			Eventually(CreateAwsRedisInstance).
@@ -81,13 +80,12 @@ var _ = Describe("Feature: SKR AwsRedisInstance", func() {
 					WithAwsRedisInstanceAuthSecretName(authSecretName),
 					WithAwsRedisInstanceAuthSecretLabels(authSecretLabels),
 					WithAwsRedisInstanceAuthSecretAnnotations(authSecretAnnotations),
-					WithAwsRedisInstanceCacheNodeType(cacheNodeType),
+					WithAwsRedisInstanceRedisTier(redisTier),
 					WithAwsRedisInstanceEngineVersion(engineVersion),
 					WithAwsRedisInstanceAutoMinorVersionUpgrade(autoMinorVersionUpgrade),
 					WithAwsRedisInstanceAuthEnabled(authEnabled),
 					WithAwsRedisInstancePreferredMaintenanceWindow(preferredMaintenanceWindow),
 					WithAwsRedisInstanceParameters(parameters),
-					WithAwsRedisInstanceReadReplicas(int32(readReplicas)),
 				).
 				Should(Succeed())
 		})
@@ -135,7 +133,8 @@ var _ = Describe("Feature: SKR AwsRedisInstance", func() {
 			Expect(kcpRedisInstance.Spec.RemoteRef.Name).To(Equal(awsRedisInstance.Name))
 
 			By("And has spec.instance.aws equal to SKR AwsRedisInstance.spec values")
-			Expect(kcpRedisInstance.Spec.Instance.Aws.CacheNodeType).To(Equal(awsRedisInstance.Spec.CacheNodeType))
+			Expect(kcpRedisInstance.Spec.Instance.Aws.CacheNodeType).To(Not(Equal("")))
+			Expect(kcpRedisInstance.Spec.Instance.Aws.ReadReplicas).To(Equal(int32(1)))
 			Expect(kcpRedisInstance.Spec.Instance.Aws.EngineVersion).To(Equal(awsRedisInstance.Spec.EngineVersion))
 			Expect(kcpRedisInstance.Spec.Instance.Aws.AutoMinorVersionUpgrade).To(Equal(awsRedisInstance.Spec.AutoMinorVersionUpgrade))
 			Expect(kcpRedisInstance.Spec.Instance.Aws.PreferredMaintenanceWindow).To(Equal(awsRedisInstance.Spec.PreferredMaintenanceWindow))

--- a/pkg/skr/awsredisinstance/createKcpRedisInstance.go
+++ b/pkg/skr/awsredisinstance/createKcpRedisInstance.go
@@ -2,6 +2,7 @@ package awsredisinstance
 
 import (
 	"context"
+	"errors"
 
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
@@ -18,6 +19,28 @@ func createKcpRedisInstance(ctx context.Context, st composed.State) (error, cont
 	}
 
 	awsRedisInstance := state.ObjAsAwsRedisInstance()
+
+	cacheNodeType, err := redisTierToCacheNodeTypeConvertor(awsRedisInstance.Spec.RedisTier)
+
+	if err != nil {
+		errMsg := "failed to map redisTier to cacheNodeType"
+		logger.Error(errors.New(errMsg), errMsg, "redisTier", awsRedisInstance.Spec.RedisTier)
+		awsRedisInstance.Status.State = cloudresourcesv1beta1.StateError
+		return composed.UpdateStatus(awsRedisInstance).
+			SetCondition(metav1.Condition{
+				Type:    cloudresourcesv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  cloudresourcesv1beta1.ConditionReasonError,
+				Message: errMsg,
+			}).
+			RemoveConditions(cloudresourcesv1beta1.ConditionTypeReady).
+			ErrorLogMessage("Error: updating AwsRedisInstance status with not ready condition due to KCP error").
+			SuccessLogMsg("Updated and forgot SKR AwsRedisInstance status with Error condition").
+			SuccessError(composed.StopAndForget).
+			Run(ctx, state)
+	}
+
+	replicaCount := redisTierToReadReplicas(awsRedisInstance.Spec.RedisTier)
 
 	state.KcpRedisInstance = &cloudcontrolv1beta1.RedisInstance{
 		ObjectMeta: metav1.ObjectMeta{
@@ -42,19 +65,19 @@ func createKcpRedisInstance(ctx context.Context, st composed.State) (error, cont
 			},
 			Instance: cloudcontrolv1beta1.RedisInstanceInfo{
 				Aws: &cloudcontrolv1beta1.RedisInstanceAws{
-					CacheNodeType:              awsRedisInstance.Spec.CacheNodeType,
+					CacheNodeType:              cacheNodeType,
 					EngineVersion:              awsRedisInstance.Spec.EngineVersion,
 					AutoMinorVersionUpgrade:    awsRedisInstance.Spec.AutoMinorVersionUpgrade,
 					AuthEnabled:                awsRedisInstance.Spec.AuthEnabled,
 					PreferredMaintenanceWindow: awsRedisInstance.Spec.PreferredMaintenanceWindow,
 					Parameters:                 awsRedisInstance.Spec.Parameters,
-					ReadReplicas:               awsRedisInstance.Spec.ReadReplicas,
+					ReadReplicas:               replicaCount,
 				},
 			},
 		},
 	}
 
-	err := state.KcpCluster.K8sClient().Create(ctx, state.KcpRedisInstance)
+	err = state.KcpCluster.K8sClient().Create(ctx, state.KcpRedisInstance)
 	if err != nil {
 		return composed.LogErrorAndReturn(err, "Error creating KCP RedisInstance", composed.StopWithRequeue, ctx)
 	}

--- a/pkg/skr/awsredisinstance/modifyKcpRedisInstance.go
+++ b/pkg/skr/awsredisinstance/modifyKcpRedisInstance.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func modifyKcpRedisInstance(ctx context.Context, st composed.State) (error, context.Context) {
@@ -24,13 +26,33 @@ func modifyKcpRedisInstance(ctx context.Context, st composed.State) (error, cont
 		return nil, nil
 	}
 
+	cacheNodeType, err := redisTierToCacheNodeTypeConvertor(awsRedisInstance.Spec.RedisTier)
+
+	if err != nil {
+		errMsg := "failed to map redisTier to tier and memorySizeGb"
+		logger.Error(err, errMsg, "redisTier", awsRedisInstance.Spec.RedisTier)
+		awsRedisInstance.Status.State = cloudresourcesv1beta1.StateError
+		return composed.UpdateStatus(awsRedisInstance).
+			SetCondition(metav1.Condition{
+				Type:    cloudresourcesv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  cloudresourcesv1beta1.ConditionReasonError,
+				Message: errMsg,
+			}).
+			RemoveConditions(cloudresourcesv1beta1.ConditionTypeReady).
+			ErrorLogMessage("Error: updating AwsRedisInstance status with not ready condition due to KCP error").
+			SuccessLogMsg("Updated and forgot SKR AwsRedisInstance status with Error condition").
+			SuccessError(composed.StopAndForget).
+			Run(ctx, state)
+	}
+
 	state.KcpRedisInstance.Spec.Instance.Aws.Parameters = awsRedisInstance.Spec.Parameters
-	state.KcpRedisInstance.Spec.Instance.Aws.CacheNodeType = awsRedisInstance.Spec.CacheNodeType
+	state.KcpRedisInstance.Spec.Instance.Aws.CacheNodeType = cacheNodeType
 	state.KcpRedisInstance.Spec.Instance.Aws.AutoMinorVersionUpgrade = awsRedisInstance.Spec.AutoMinorVersionUpgrade
 	state.KcpRedisInstance.Spec.Instance.Aws.AuthEnabled = awsRedisInstance.Spec.AuthEnabled
 	state.KcpRedisInstance.Spec.Instance.Aws.PreferredMaintenanceWindow = awsRedisInstance.Spec.PreferredMaintenanceWindow
 
-	err := state.KcpCluster.K8sClient().Update(ctx, state.KcpRedisInstance)
+	err = state.KcpCluster.K8sClient().Update(ctx, state.KcpRedisInstance)
 	if err != nil {
 		return composed.LogErrorAndReturn(err, "Error updating KCP RedisInstance", composed.StopWithRequeue, ctx)
 	}

--- a/pkg/skr/awsredisinstance/state.go
+++ b/pkg/skr/awsredisinstance/state.go
@@ -68,7 +68,12 @@ func (s *State) ObjAsObjWithIpRangeRef() defaultiprange.ObjWithIpRangeRef {
 func (s *State) ShouldModifyKcp() bool {
 	awsRedisInstance := s.ObjAsAwsRedisInstance()
 
-	areCacheNodeTypesDifferent := s.KcpRedisInstance.Spec.Instance.Aws.CacheNodeType != awsRedisInstance.Spec.CacheNodeType
+	cacheNodeType, err := redisTierToCacheNodeTypeConvertor(awsRedisInstance.Spec.RedisTier)
+	if err != nil {
+		return true
+	}
+
+	areCacheNodeTypesDifferent := s.KcpRedisInstance.Spec.Instance.Aws.CacheNodeType != cacheNodeType
 	isAutoMinorVersionUpgradeDifferent := s.KcpRedisInstance.Spec.Instance.Aws.AutoMinorVersionUpgrade != awsRedisInstance.Spec.AutoMinorVersionUpgrade
 	isAuthEnabledDifferent := s.KcpRedisInstance.Spec.Instance.Aws.AuthEnabled != awsRedisInstance.Spec.AuthEnabled
 	arePreferredMaintenanceWindowDifferent := ptr.Deref(s.KcpRedisInstance.Spec.Instance.Aws.PreferredMaintenanceWindow, "") != ptr.Deref(awsRedisInstance.Spec.PreferredMaintenanceWindow, "")

--- a/pkg/skr/awsredisinstance/util.go
+++ b/pkg/skr/awsredisinstance/util.go
@@ -2,6 +2,7 @@ package awsredisinstance
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
@@ -112,4 +113,39 @@ func areByteMapsEqual(first, second map[string][]byte) bool {
 	}
 
 	return true
+}
+
+var awsRedisTierToCacheNodeTypeMap = map[cloudresourcesv1beta1.AwsRedisTier]string{
+	cloudresourcesv1beta1.AwsRedisTierS1: "cache.t4g.small",
+	cloudresourcesv1beta1.AwsRedisTierS2: "cache.t4g.medium",
+	cloudresourcesv1beta1.AwsRedisTierS3: "cache.m7g.large",
+	cloudresourcesv1beta1.AwsRedisTierS4: "cache.m7g.xlarge",
+	cloudresourcesv1beta1.AwsRedisTierS5: "cache.m7g.2xlarge",
+	cloudresourcesv1beta1.AwsRedisTierS6: "cache.m7g.4xlarge",
+	cloudresourcesv1beta1.AwsRedisTierS7: "cache.m7g.8xlarge",
+	cloudresourcesv1beta1.AwsRedisTierS8: "cache.m7g.16xlarge",
+
+	cloudresourcesv1beta1.AwsRedisTierP1: "cache.m7g.large",
+	cloudresourcesv1beta1.AwsRedisTierP2: "cache.m7g.xlarge",
+	cloudresourcesv1beta1.AwsRedisTierP3: "cache.m7g.2xlarge",
+	cloudresourcesv1beta1.AwsRedisTierP4: "cache.m7g.4xlarge",
+	cloudresourcesv1beta1.AwsRedisTierP5: "cache.m7g.8xlarge",
+	cloudresourcesv1beta1.AwsRedisTierP6: "cache.m7g.16xlarge",
+}
+
+func redisTierToCacheNodeTypeConvertor(awsRedisTier cloudresourcesv1beta1.AwsRedisTier) (string, error) {
+	cacheNode, exists := awsRedisTierToCacheNodeTypeMap[awsRedisTier]
+
+	if !exists {
+		return "", errors.New("unknown redis tier")
+	}
+
+	return cacheNode, nil
+}
+
+func redisTierToReadReplicas(awsRedisTier cloudresourcesv1beta1.AwsRedisTier) int32 {
+	if strings.HasPrefix(string(awsRedisTier), "P") {
+		return 1
+	}
+	return 0
 }

--- a/pkg/skr/awsredisinstance/util_test.go
+++ b/pkg/skr/awsredisinstance/util_test.go
@@ -1,0 +1,94 @@
+package awsredisinstance
+
+import (
+	"fmt"
+	"testing"
+
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/stretchr/testify/assert"
+)
+
+type converterTestCase struct {
+	InputRedisTier        cloudresourcesv1beta1.AwsRedisTier
+	ExpectedCacheNodeType string
+}
+
+func TestUtil(t *testing.T) {
+
+	t.Run("redisTierToCacheNodeTypeConvertor", func(t *testing.T) {
+
+		testCases := []converterTestCase{
+			{cloudresourcesv1beta1.AwsRedisTierS1, "cache.t4g.small"},
+			{cloudresourcesv1beta1.AwsRedisTierS2, "cache.t4g.medium"},
+			{cloudresourcesv1beta1.AwsRedisTierS3, "cache.m7g.large"},
+			{cloudresourcesv1beta1.AwsRedisTierS4, "cache.m7g.xlarge"},
+			{cloudresourcesv1beta1.AwsRedisTierS5, "cache.m7g.2xlarge"},
+			{cloudresourcesv1beta1.AwsRedisTierS6, "cache.m7g.4xlarge"},
+			{cloudresourcesv1beta1.AwsRedisTierS7, "cache.m7g.8xlarge"},
+			{cloudresourcesv1beta1.AwsRedisTierS8, "cache.m7g.16xlarge"},
+
+			{cloudresourcesv1beta1.AwsRedisTierP1, "cache.m7g.large"},
+			{cloudresourcesv1beta1.AwsRedisTierP2, "cache.m7g.xlarge"},
+			{cloudresourcesv1beta1.AwsRedisTierP3, "cache.m7g.2xlarge"},
+			{cloudresourcesv1beta1.AwsRedisTierP4, "cache.m7g.4xlarge"},
+			{cloudresourcesv1beta1.AwsRedisTierP5, "cache.m7g.8xlarge"},
+			{cloudresourcesv1beta1.AwsRedisTierP6, "cache.m7g.16xlarge"},
+		}
+
+		for _, testCase := range testCases {
+			t.Run(fmt.Sprintf("should return expected result for input (%s)", testCase.InputRedisTier), func(t *testing.T) {
+				cacheNodeType, err := redisTierToCacheNodeTypeConvertor(testCase.InputRedisTier)
+
+				assert.Equal(t, testCase.ExpectedCacheNodeType, cacheNodeType, "resulting cacheNodeType does not match expected cacheNodeType")
+				assert.Nil(t, err, "expected nil error, got an error")
+			})
+
+		}
+		t.Run("should return error for unknown input", func(t *testing.T) {
+			cacheNodeType, err := redisTierToCacheNodeTypeConvertor("unknown")
+
+			assert.NotNil(t, err, "expected defined error, got nil")
+			assert.Equal(t, "", cacheNodeType, "expected cacheNodeType to have zero value")
+		})
+	})
+
+	type replicaConverterTestCase struct {
+		InputRedisTier       cloudresourcesv1beta1.AwsRedisTier
+		ExpectedReadReplicas int32
+	}
+
+	t.Run("redisTierToReadReplicas", func(t *testing.T) {
+
+		testCases := []replicaConverterTestCase{
+			{cloudresourcesv1beta1.AwsRedisTierS1, int32(0)},
+			{cloudresourcesv1beta1.AwsRedisTierS2, int32(0)},
+			{cloudresourcesv1beta1.AwsRedisTierS3, int32(0)},
+			{cloudresourcesv1beta1.AwsRedisTierS4, int32(0)},
+			{cloudresourcesv1beta1.AwsRedisTierS5, int32(0)},
+			{cloudresourcesv1beta1.AwsRedisTierS6, int32(0)},
+			{cloudresourcesv1beta1.AwsRedisTierS7, int32(0)},
+			{cloudresourcesv1beta1.AwsRedisTierS8, int32(0)},
+
+			{cloudresourcesv1beta1.AwsRedisTierP1, int32(1)},
+			{cloudresourcesv1beta1.AwsRedisTierP2, int32(1)},
+			{cloudresourcesv1beta1.AwsRedisTierP3, int32(1)},
+			{cloudresourcesv1beta1.AwsRedisTierP4, int32(1)},
+			{cloudresourcesv1beta1.AwsRedisTierP5, int32(1)},
+			{cloudresourcesv1beta1.AwsRedisTierP6, int32(1)},
+		}
+
+		for _, testCase := range testCases {
+			t.Run(fmt.Sprintf("should return expected result for input (%s)", testCase.InputRedisTier), func(t *testing.T) {
+				readReplicas := redisTierToReadReplicas(testCase.InputRedisTier)
+
+				assert.Equal(t, testCase.ExpectedReadReplicas, readReplicas, "resulting readReplicas does not match expected readReplicas")
+			})
+
+		}
+		t.Run("should return 0 for unknown input", func(t *testing.T) {
+			readReplicas := redisTierToReadReplicas("unknown")
+
+			assert.Equal(t, int32(0), readReplicas, "resulting readReplicas does not match expected readReplicas")
+		})
+	})
+}

--- a/pkg/testinfra/dsl/awsRedisInstance.go
+++ b/pkg/testinfra/dsl/awsRedisInstance.go
@@ -31,11 +31,10 @@ func WithAwsRedisInstanceDefautSpecs() ObjAction {
 	return &objAction{
 		f: func(obj client.Object) {
 			if awsRedisInstance, ok := obj.(*cloudresourcesv1beta1.AwsRedisInstance); ok {
-				awsRedisInstance.Spec.CacheNodeType = "cache.m5.large"
+				awsRedisInstance.Spec.RedisTier = cloudresourcesv1beta1.AwsRedisTierP1
 				awsRedisInstance.Spec.EngineVersion = "6.x"
 				awsRedisInstance.Spec.AutoMinorVersionUpgrade = true
 				awsRedisInstance.Spec.AuthEnabled = false
-				awsRedisInstance.Spec.ReadReplicas = 0
 				return
 			}
 			panic(fmt.Errorf("unhandled type %T in WithAwsRedisInstanceDefautSpecs", obj))
@@ -43,14 +42,14 @@ func WithAwsRedisInstanceDefautSpecs() ObjAction {
 	}
 }
 
-func WithAwsRedisInstanceCacheNodeType(cacheNodeType string) ObjAction {
+func WithAwsRedisInstanceRedisTier(redisTier cloudresourcesv1beta1.AwsRedisTier) ObjAction {
 	return &objAction{
 		f: func(obj client.Object) {
 			if awsRedisInstance, ok := obj.(*cloudresourcesv1beta1.AwsRedisInstance); ok {
-				awsRedisInstance.Spec.CacheNodeType = cacheNodeType
+				awsRedisInstance.Spec.RedisTier = redisTier
 				return
 			}
-			panic(fmt.Errorf("unhandled type %T in WithAwsRedisInstanceCacheNodeType", obj))
+			panic(fmt.Errorf("unhandled type %T in WithAwsRedisInstanceRedisTier", obj))
 		},
 	}
 }
@@ -87,18 +86,6 @@ func WithAwsRedisInstanceAuthEnabled(authEnabled bool) ObjAction {
 				return
 			}
 			panic(fmt.Errorf("unhandled type %T in WithAwsRedisInstanceAuthEnabled", obj))
-		},
-	}
-}
-
-func WithAwsRedisInstanceReadReplicas(readReplicas int32) ObjAction {
-	return &objAction{
-		f: func(obj client.Object) {
-			if awsRedisInstance, ok := obj.(*cloudresourcesv1beta1.AwsRedisInstance); ok {
-				awsRedisInstance.Spec.ReadReplicas = readReplicas
-				return
-			}
-			panic(fmt.Errorf("unhandled type %T in WithAwsRedisInstanceReadReplicas", obj))
 		},
 	}
 }


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- replaces `cacheNodeType` with `redisTier` abstraction
- drops `readReplicas` field from SKR API.
  - read replicas are implicitly 0 for Standard tier
  - read replicas are implicitly 1 for Premium tier

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
