### PR TITLE
docs: Adds Cloud Manager service principal to Kyma landscape mapping

### DIFF
--- a/docs/user/resources/04-40-10-azure-vpc-peering.md
+++ b/docs/user/resources/04-40-10-azure-vpc-peering.md
@@ -13,11 +13,16 @@ the remote cloud provider subscription.
 
 Cloud Manager must be authorized in the remote cloud provider subscription to accept a VPC peering connection.
 
-Assign the following IAM roles to the Cloud Manager service principal `kyma-cloud-manager-peering-ENV` in the remote subscription: 
+Use the following table to identify Cloud Manager service principal based on your Kyma landscape:
+
+| Kyma Dashboard Url                     | Cloud Manager service principal  |
+|----------------------------------------|----------------------------------|
+| https://dashboard.stage.kyma.cloud.sap | kyma-cloud-manager-peering-stage |
+| https://dashboard.kyma.cloud.sap       | kyma-cloud-manager-peering-prod  |
+
+And assign the following IAM roles to the Cloud Manager service principal: 
 * Classic Network Contributor
 * Network Contributor
-
-**ENV** corresponds to **dev**, **stage**, or **prod**.
 
 ### Deleting `AzureVpcPeering`
 

--- a/docs/user/resources/04-40-10-azure-vpc-peering.md
+++ b/docs/user/resources/04-40-10-azure-vpc-peering.md
@@ -15,7 +15,7 @@ Cloud Manager must be authorized in the remote cloud provider subscription to ac
 
 Use the following table to identify Cloud Manager service principal based on your Kyma landscape:
 
-| Kyma Dashboard Url                     | Cloud Manager service principal  |
+| Kyma dashboard URL                     | Cloud Manager service principal  |
 |----------------------------------------|----------------------------------|
 | https://dashboard.stage.kyma.cloud.sap | kyma-cloud-manager-peering-stage |
 | https://dashboard.kyma.cloud.sap       | kyma-cloud-manager-peering-prod  |

--- a/docs/user/resources/04-40-10-azure-vpc-peering.md
+++ b/docs/user/resources/04-40-10-azure-vpc-peering.md
@@ -15,10 +15,10 @@ Cloud Manager must be authorized in the remote cloud provider subscription to ac
 
 Use the following table to identify Cloud Manager service principal based on your Kyma landscape:
 
-| Kyma dashboard URL                     | Cloud Manager service principal  |
-|----------------------------------------|----------------------------------|
-| https://dashboard.stage.kyma.cloud.sap | kyma-cloud-manager-peering-stage |
-| https://dashboard.kyma.cloud.sap       | kyma-cloud-manager-peering-prod  |
+| BTP cockpit URL                    | Kyma dashboard URL                     | Cloud Manager service principal  |
+|------------------------------------|----------------------------------------|----------------------------------|
+| https://canary.cockpit.btp.int.sap | https://dashboard.stage.kyma.cloud.sap | kyma-cloud-manager-peering-stage |
+| https://emea.cockpit.btp.cloud.sap | https://dashboard.kyma.cloud.sap       | kyma-cloud-manager-peering-prod  |
 
 And assign the following Identity and Access Management (IAM) roles to the Cloud Manager service principal: 
 * Classic Network Contributor

--- a/docs/user/resources/04-40-10-azure-vpc-peering.md
+++ b/docs/user/resources/04-40-10-azure-vpc-peering.md
@@ -20,7 +20,7 @@ Use the following table to identify Cloud Manager service principal based on you
 | https://dashboard.stage.kyma.cloud.sap | kyma-cloud-manager-peering-stage |
 | https://dashboard.kyma.cloud.sap       | kyma-cloud-manager-peering-prod  |
 
-And assign the following IAM roles to the Cloud Manager service principal: 
+And assign the following Identity and Access Management (IAM) roles to the Cloud Manager service principal: 
 * Classic Network Contributor
 * Network Contributor
 


### PR DESCRIPTION
**Description**

Customers finds hard to identify proper Cloud Manager service principal that needs to be authorised in remote subscription.

I have added a table that contains mappings between the Kyma Dashboard URL and Cloud Manager service principal.

Perhaps we should include BTP column in the mapping table as well.

Any feedback is welcome. 

Changes proposed in this pull request:
- Added mapping table that lists service principals based on the Kyma dashboard URL.
- Removed dev as it is for internal use only.