### PR TITLE
docs: Adds Cloud Manager principal to Kyma landscape mapping

### DIFF
--- a/docs/user/resources/04-70-10-aws-vpc-peering.md
+++ b/docs/user/resources/04-70-10-aws-vpc-peering.md
@@ -17,7 +17,7 @@ Use the following table to identify Cloud Manager principal based on your Kyma l
 
 | BTP cockpit URL                    | Kyma dashboard URL                     | Cloud Manager principal                                    |
 |------------------------------------|----------------------------------------|------------------------------------------------------------|
-| https://canary.cockpit.btp.int.sap | https://dashboard.stage.kyma.cloud.sap | arn:aws:iam::194230256199:user/cloud-manager-peering-stage |
+| https://canary.cockpit.btp.int.sap | https://dashboard.stage.kyma.cloud.sap | `arn:aws:iam::194230256199:user/cloud-manager-peering-stage` |
 | https://emea.cockpit.btp.cloud.sap | https://dashboard.kyma.cloud.sap       | arn:aws:iam::194230256199:user/cloud-manager-peering-prod  |
 
 1.  Create a new role named **CloudManagerPeeringRole** with a trust policy that allows Cloud Manager principal to assume the role:

--- a/docs/user/resources/04-70-10-aws-vpc-peering.md
+++ b/docs/user/resources/04-70-10-aws-vpc-peering.md
@@ -18,7 +18,7 @@ Use the following table to identify Cloud Manager principal based on your Kyma l
 | BTP cockpit URL                    | Kyma dashboard URL                     | Cloud Manager principal                                    |
 |------------------------------------|----------------------------------------|------------------------------------------------------------|
 | https://canary.cockpit.btp.int.sap | https://dashboard.stage.kyma.cloud.sap | `arn:aws:iam::194230256199:user/cloud-manager-peering-stage` |
-| https://emea.cockpit.btp.cloud.sap | https://dashboard.kyma.cloud.sap       | arn:aws:iam::194230256199:user/cloud-manager-peering-prod  |
+| https://emea.cockpit.btp.cloud.sap | https://dashboard.kyma.cloud.sap       | `arn:aws:iam::194230256199:user/cloud-manager-peering-prod`  |
 
 1.  Create a new role named **CloudManagerPeeringRole** with a trust policy that allows Cloud Manager principal to assume the role:
 

--- a/docs/user/resources/04-70-10-aws-vpc-peering.md
+++ b/docs/user/resources/04-70-10-aws-vpc-peering.md
@@ -29,7 +29,7 @@ Use the following table to identify Cloud Manager principal based on your Kyma l
             {
                 "Effect": "Allow",
                 "Principal": {
-                    "AWS": "<Cloud Manager principal>"
+                    "AWS": "{CLOUD_MANAGER_PRINCIPAL}"
                 },
                 "Action": "sts:AssumeRole"
             }

--- a/docs/user/resources/04-70-10-aws-vpc-peering.md
+++ b/docs/user/resources/04-70-10-aws-vpc-peering.md
@@ -15,10 +15,10 @@ Cloud Manager uses [`AssumeRole`](https://awscli.amazonaws.com/v2/documentation/
 
 Use the following table to identify Cloud Manager principal based on your Kyma landscape:
 
-| BTP cockpit URL                    | Kyma dashboard URL                     | Cloud Manager principal     |
-|------------------------------------|----------------------------------------|-----------------------------|
-| https://canary.cockpit.btp.int.sap | https://dashboard.stage.kyma.cloud.sap | cloud-manager-peering-stage |
-| https://emea.cockpit.btp.cloud.sap | https://dashboard.kyma.cloud.sap       | cloud-manager-peering-prod  |
+| BTP cockpit URL                    | Kyma dashboard URL                     | Cloud Manager principal                                    |
+|------------------------------------|----------------------------------------|------------------------------------------------------------|
+| https://canary.cockpit.btp.int.sap | https://dashboard.stage.kyma.cloud.sap | arn:aws:iam::194230256199:user/cloud-manager-peering-stage |
+| https://emea.cockpit.btp.cloud.sap | https://dashboard.kyma.cloud.sap       | arn:aws:iam::194230256199:user/cloud-manager-peering-prod  |
 
 1.  Create a new role named **CloudManagerPeeringRole** with a trust policy that allows Cloud Manager principal to assume the role:
 
@@ -29,7 +29,7 @@ Use the following table to identify Cloud Manager principal based on your Kyma l
             {
                 "Effect": "Allow",
                 "Principal": {
-                    "AWS": "arn:aws:iam::194230256199:user/cloud-manager-peering-ENV"
+                    "AWS": "<Cloud Manager principal>"
                 },
                 "Action": "sts:AssumeRole"
             }

--- a/docs/user/resources/04-70-10-aws-vpc-peering.md
+++ b/docs/user/resources/04-70-10-aws-vpc-peering.md
@@ -13,9 +13,14 @@ the Kyma cluster underlying cloud provider account and accepts VPC peering conne
 Cloud Manager must be authorized in the remote cloud provider account to accept VPC peering connection. For cross-account access,
 Cloud Manager uses [`AssumeRole`](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sts/assume-role.html).
 
-1.  Create a new role named **CloudManagerPeeringRole** with a trust policy that allows Cloud Manager principal `arn:aws:iam::{194230256199}:user/cloud-manager-peering-ENV` to assume the role.
+Use the following table to identify Cloud Manager principal based on your Kyma landscape:
 
-    **ENV** corresponds to **dev**, **stage**, or **prod**.
+| BTP cockpit URL                    | Kyma dashboard URL                     | Cloud Manager principal     |
+|------------------------------------|----------------------------------------|-----------------------------|
+| https://canary.cockpit.btp.int.sap | https://dashboard.stage.kyma.cloud.sap | cloud-manager-peering-stage |
+| https://emea.cockpit.btp.cloud.sap | https://dashboard.kyma.cloud.sap       | cloud-manager-peering-prod  |
+
+1.  Create a new role named **CloudManagerPeeringRole** with a trust policy that allows Cloud Manager principal to assume the role:
 
     ```json
     {
@@ -55,7 +60,7 @@ Cloud Manager uses [`AssumeRole`](https://awscli.amazonaws.com/v2/documentation/
     }
     ```
 
-3.  Attach the **CloudManagerPeeringAccess** policy to the **CloudManagerPeeringRole**.
+3.  Attach the **CloudManagerPeeringAccess** policy to the **CloudManagerPeeringRole**:
 
 ### Deleting `AwsVpcPeering`
 


### PR DESCRIPTION
Description

Customers finds hard to identify proper Cloud Manager principal that needs to be authorised in remote account.

I have added a table that contains mappings between BTP Cockpit URL, Kyma Dashboard URL, and Cloud Manager principal.

Changes proposed in this pull request:

- Added mapping table that lists principals based on the Kyma dashboard URL.
- Removed dev as it is for internal use only.