### PR TITLE
feat(Nuke): nuke orphaned gcp filestore backups

### DIFF
--- a/api/cloud-control/v1beta1/labels.go
+++ b/api/cloud-control/v1beta1/labels.go
@@ -1,5 +1,6 @@
 package v1beta1
 
+// Used for K8s labels
 const (
 	LabelKymaName        = "cloud-manager.kyma-project.io/kymaName"
 	LabelRemoteName      = "cloud-manager.kyma-project.io/remoteName"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -314,7 +314,12 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Network")
 		os.Exit(1)
 	}
-	if err = cloudcontrolcontroller.SetupNukeReconciler(mgr, skrLoop); err != nil {
+	if err = cloudcontrolcontroller.SetupNukeReconciler(
+		mgr,
+		skrLoop,
+		gcpnfsbackupclient.NewFileBackupClientProvider(),
+		env,
+	); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Nuke")
 		os.Exit(1)
 	}

--- a/config/crd/bases/cloud-control.kyma-project.io_nukes.yaml
+++ b/config/crd/bases/cloud-control.kyma-project.io_nukes.yaml
@@ -147,6 +147,9 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    resourceType:
+                      default: KCP
+                      type: string
                   required:
                   - kind
                   - objects

--- a/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_nukes.yaml
+++ b/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_nukes.yaml
@@ -147,6 +147,9 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    resourceType:
+                      default: KCP
+                      type: string
                   required:
                   - kind
                   - objects

--- a/internal/controller/cloud-control/nuke_controller.go
+++ b/internal/controller/cloud-control/nuke_controller.go
@@ -2,7 +2,12 @@ package cloudcontrol
 
 import (
 	"context"
+	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
 	kcpnuke "github.com/kyma-project/cloud-manager/pkg/kcp/nuke"
+	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	gcpfilebackupclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsbackup/client"
+	gcpnuke "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nuke"
 	skrruntime "github.com/kyma-project/cloud-manager/pkg/skr/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -13,11 +18,15 @@ import (
 func SetupNukeReconciler(
 	kcpManager manager.Manager,
 	activeSkrCollection skrruntime.ActiveSkrCollection,
+	gcpFileBackupClientProvider gcpclient.ClientProvider[gcpfilebackupclient.FileBackupClient],
+	env abstractions.Environment,
 ) error {
+	baseStateFactory := composed.NewStateFactory(composed.NewStateClusterFromCluster(kcpManager))
 	return NewNukeReconciler(
 		kcpnuke.New(
-			kcpManager,
+			baseStateFactory,
 			activeSkrCollection,
+			gcpnuke.NewStateFactory(gcpFileBackupClientProvider, env),
 		),
 	).SetupWithManager(kcpManager)
 }

--- a/internal/controller/cloud-control/nuke_gcp_test.go
+++ b/internal/controller/cloud-control/nuke_gcp_test.go
@@ -1,0 +1,270 @@
+package cloudcontrol
+
+import (
+	"fmt"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/common"
+	"github.com/kyma-project/cloud-manager/pkg/common/actions/focal"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	kcpiprange "github.com/kyma-project/cloud-manager/pkg/kcp/iprange"
+	kcpnetwork "github.com/kyma-project/cloud-manager/pkg/kcp/network"
+	kcpnfsinstance "github.com/kyma-project/cloud-manager/pkg/kcp/nfsinstance"
+	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	scopePkg "github.com/kyma-project/cloud-manager/pkg/kcp/scope"
+	. "github.com/kyma-project/cloud-manager/pkg/testinfra/dsl"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/api/file/v1"
+)
+
+var _ = Describe("Feature: Cleanup orphan resources", func() {
+
+	It("Scenario: KCP Nuke deletes GCP provider resources in the Scope", func() {
+		const kymaName = "c2467bcb-ee77-46ab-8f68-f4176ed7eb27"
+
+		scope := &cloudcontrolv1beta1.Scope{}
+		backupClient, err := infra.GcpMock().FileBackupClientProvider()(infra.Ctx(), "")
+		Expect(err).To(Succeed())
+
+		By("Given Scope exists", func() {
+			// Tell Scope reconciler to ignore this kymaName
+			scopePkg.Ignore.AddName(kymaName)
+
+			Expect(CreateScopeGcp(infra.Ctx(), infra, scope, WithName(kymaName))).
+				To(Succeed(), "failed creating scope")
+		})
+
+		cmNetwork := cloudcontrolv1beta1.NewNetworkBuilder().
+			WithName("ec2c020f-edec-4bb3-8147-190e27e67ffd").
+			WithType(cloudcontrolv1beta1.NetworkTypeCloudResources).
+			WithScope(kymaName).
+			WithCidr(common.DefaultCloudManagerCidr).
+			Build()
+
+		By("And Given CM Network exists", func() {
+			kcpnetwork.Ignore.AddName(cmNetwork.Name)
+
+			Expect(CreateObj(infra.Ctx(), infra.KCP().Client(), cmNetwork,
+				AddFinalizer(cloudcontrolv1beta1.FinalizerName),
+			)).To(Succeed(), "failed creating cm network")
+		})
+
+		ipRangeName := "e1b0d66d-4990-4ebf-ad2c-25caab3d2002"
+		ipRange := &cloudcontrolv1beta1.IpRange{}
+
+		By("And Given IpRange exists", func() {
+			kcpiprange.Ignore.AddName(ipRangeName)
+
+			Eventually(CreateKcpIpRange).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), ipRange,
+					WithName(ipRangeName),
+					AddFinalizer(cloudcontrolv1beta1.FinalizerName),
+					WithKcpIpRangeNetwork(cmNetwork.Name),
+					WithScope(kymaName),
+					WithRemoteRef("foo"),
+					WithKcpIpRangeSpecCidr(common.DefaultCloudManagerCidr),
+				).
+				Should(Succeed(), "failed creating IpRange")
+		})
+
+		nfsInstanceName := "87104076-d151-4566-8534-40d913a71569"
+		nfsInstance := &cloudcontrolv1beta1.NfsInstance{}
+
+		By("And Given NfsInstance exists", func() {
+			kcpnfsinstance.Ignore.AddName(nfsInstanceName)
+
+			Expect(CreateNfsInstance(infra.Ctx(), infra.KCP().Client(), nfsInstance,
+				WithName(nfsInstanceName),
+				AddFinalizer(cloudcontrolv1beta1.FinalizerName),
+				WithRemoteRef("foo"),
+				WithScope(kymaName),
+				WithIpRange(ipRange.Name),
+				WithNfsInstanceGcp(scope.Spec.Region),
+				AddFinalizer(cloudcontrolv1beta1.FinalizerName),
+			)).To(Succeed(), "failed creating NfsInstance")
+		})
+
+		filestoreBackupName := "03b42b69-3ef4-44cc-aa44-fd2f1522784e"
+		filestoreBackup := &file.Backup{}
+		filestoreBackup.Name = filestoreBackupName
+		filestoreBackup.Labels = map[string]string{
+			gcpclient.ScopeNameKey: scope.Name,
+			gcpclient.ManagedByKey: gcpclient.ManagedByValue,
+		}
+		anotherBackupName := "42720e1d-91f1-4b77-bee7-53e6f20a6853"
+		anotherBackup := &file.Backup{}
+		anotherBackup.Name = anotherBackupName
+		const anotherScopeName = "238bc7ac-7119-4d88-8a46-850819b7c981"
+		anotherBackup.Labels = map[string]string{
+			gcpclient.ScopeNameKey: anotherScopeName,
+			gcpclient.ManagedByKey: gcpclient.ManagedByValue,
+		}
+		By(" And Given GcpFilestoreBackup exits for the same scope", func() {
+			Expect(
+				CreateGcpFileBackupDirectly(
+					infra.Ctx(),
+					backupClient,
+					scope.Spec.Scope.Gcp.Project,
+					"any-location",
+					filestoreBackup,
+				)).
+				To(Succeed(), "failed creating GcpFilestoreBackup directly")
+		})
+
+		By(" And Given another GcpFilestoreBackup exits for another scope", func() {
+			Expect(
+				CreateGcpFileBackupDirectly(
+					infra.Ctx(),
+					backupClient,
+					scope.Spec.Scope.Gcp.Project,
+					"any-location",
+					anotherBackup,
+				)).
+				To(Succeed(), "failed creating another GcpFilestoreBackup directly")
+		})
+		nuke := &cloudcontrolv1beta1.Nuke{}
+
+		By("When Nuke for the Scope is created", func() {
+			Expect(CreateObj(infra.Ctx(), infra.KCP().Client(), nuke,
+				WithName("0e5e1799-f627-4237-b6f0-6adea42131f8"),
+				WithScope(kymaName),
+			)).To(Succeed())
+		})
+
+		By("Then Nuke status state is Deleting", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), nuke, NewObjActions(),
+					HavingState("Deleting"),
+				).
+				Should(Succeed())
+		})
+
+		resources := map[string]focal.CommonObject{
+			"NfsInstance": nfsInstance,
+			"IpRange":     ipRange,
+			"Network":     cmNetwork,
+		}
+
+		for kind, obj := range resources {
+			By(fmt.Sprintf("And Then Nuke status resource %s has Deleting status", kind), func() {
+				sk := nuke.Status.GetKindNoCreate(kind)
+				Expect(sk).NotTo(BeNil())
+				Expect(sk.Kind).To(Equal(kind))
+				Expect(sk.Objects).To(HaveLen(1))
+				Expect(sk.Objects).To(HaveKeyWithValue(obj.GetName(), cloudcontrolv1beta1.NukeResourceStatusDeleting))
+			})
+
+			By(fmt.Sprintf("And Then resource %s has deletion timestamp", kind), func() {
+				Expect(LoadAndCheck(infra.Ctx(), infra.KCP().Client(), obj, NewObjActions())).
+					To(Succeed())
+				Expect(obj.GetDeletionTimestamp()).NotTo(BeNil())
+			})
+		}
+
+		for kind, obj := range resources {
+			By(fmt.Sprintf("When resource %s finalizer is removed", kind), func() {
+				removed, err := composed.PatchObjRemoveFinalizer(infra.Ctx(), cloudcontrolv1beta1.FinalizerName, obj, infra.KCP().Client())
+				Expect(err).To(Succeed())
+				Expect(removed).To(BeTrue())
+			})
+
+			By(fmt.Sprintf("Then resource %s does not exist", kind), func() {
+				Eventually(IsDeleted).
+					WithArguments(infra.Ctx(), infra.KCP().Client(), obj).
+					Should(Succeed())
+			})
+
+			By(fmt.Sprintf("And Then Nuke status resource %s has state Deleted", kind), func() {
+				Eventually(func() error {
+					if err := LoadAndCheck(infra.Ctx(), infra.KCP().Client(), nuke, NewObjActions()); err != nil {
+						return err
+					}
+					sk := nuke.Status.GetKindNoCreate(kind)
+					if sk == nil {
+						return fmt.Errorf("kind %s not found in Nuke status", kind)
+					}
+					actual := sk.Objects[obj.GetName()]
+					if actual == cloudcontrolv1beta1.NukeResourceStatusDeleted {
+						return nil
+					}
+					return fmt.Errorf("expected resource %s/%s to have status Deleted, but found %s", kind, obj.GetName(), actual)
+				}).Should(Succeed())
+			})
+		}
+
+		providerResources := map[string]file.Backup{
+			"FilestoreBackup": *filestoreBackup,
+		}
+
+		for kind, backup := range providerResources {
+			By(fmt.Sprintf("And Then Provider Nuke status resource %s has Deleting status", kind), func() {
+				sk := nuke.Status.GetKindNoCreate(kind)
+				Expect(sk).NotTo(BeNil())
+				Expect(sk.Kind).To(Equal(kind))
+				Expect(sk.Objects).To(HaveLen(1))
+				Expect(sk.Objects).To(Or(
+					HaveKeyWithValue(backup.Name, cloudcontrolv1beta1.NukeResourceStatusDeleting),
+					HaveKeyWithValue(backup.Name, cloudcontrolv1beta1.NukeResourceStatusDeleted)))
+			})
+		}
+
+		for kind, backup := range providerResources {
+			By(fmt.Sprintf("And Then provider resource %s does not exist", kind), func() {
+				Eventually(func() error {
+					backupsOnGcp, err := ListGcpFileBackups(infra.Ctx(), backupClient, scope.Spec.Scope.Gcp.Project, scope.Name)
+					if err != nil {
+						return err
+					}
+					Expect(backupsOnGcp).To(HaveLen(0))
+					return nil
+				}).Should(Succeed())
+			})
+
+			By(fmt.Sprintf("And Then Nuke status resource %s has state Deleted", kind), func() {
+				Eventually(func() error {
+					if err := LoadAndCheck(infra.Ctx(), infra.KCP().Client(), nuke, NewObjActions()); err != nil {
+						return err
+					}
+					sk := nuke.Status.GetKindNoCreate(kind)
+					if sk == nil {
+						return fmt.Errorf("kind %s not found in Nuke status", kind)
+					}
+					actual := sk.Objects[backup.Name]
+					if actual == cloudcontrolv1beta1.NukeResourceStatusDeleted {
+						return nil
+					}
+					return fmt.Errorf("expected resource %s/%s to have status Deleted, but found %s", kind, backup.Name, actual)
+				}).Should(Succeed())
+			})
+		}
+		By("And Then other Backup for other Scope still exists", func() {
+			Eventually(func() error {
+				backupsOnGcp, err := ListGcpFileBackups(infra.Ctx(), backupClient, scope.Spec.Scope.Gcp.Project, anotherScopeName)
+				if err != nil {
+					return err
+				}
+				Expect(backupsOnGcp).To(HaveLen(1))
+				return nil
+			}).Should(Succeed())
+		})
+
+		By("And Then Nuke status state is Completed", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), nuke, NewObjActions(),
+					HavingState("Completed"),
+				).Should(Succeed())
+		})
+
+		By("And Then Scope is deleted", func() {
+			Eventually(IsDeleted).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), scope).
+				Should(Succeed())
+		})
+
+		By("// cleanup: Delete Nuke", func() {
+			Expect(Delete(infra.Ctx(), infra.KCP().Client(), nuke)).
+				To(Succeed())
+		})
+
+	})
+})

--- a/internal/controller/cloud-control/suite_test.go
+++ b/internal/controller/cloud-control/suite_test.go
@@ -126,6 +126,8 @@ var _ = BeforeSuite(func() {
 	Expect(SetupNukeReconciler(
 		infra.KcpManager(),
 		infra.ActiveSkrCollection(),
+		infra.GcpMock().FileBackupClientProvider(),
+		env,
 	)).To(Succeed())
 
 	// Start controllers

--- a/pkg/kcp/nuke/checkIfAllDeleted.go
+++ b/pkg/kcp/nuke/checkIfAllDeleted.go
@@ -10,7 +10,7 @@ func checkIfAllDeleted(ctx context.Context, st composed.State) (error, context.C
 	state := st.(*State)
 	logger := composed.LoggerFromCtx(ctx)
 
-	// check if some resources have be loaded to state, if none is loaded then they are all deleted
+	// check if some resources have been loaded to state, if none is loaded then they are all deleted
 	allDeleted := true
 	for _, rks := range state.Resources {
 		if len(rks.Objects) > 0 {

--- a/pkg/kcp/nuke/loadResources.go
+++ b/pkg/kcp/nuke/loadResources.go
@@ -6,6 +6,7 @@ import (
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common/actions/focal"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	nuketypes "github.com/kyma-project/cloud-manager/pkg/kcp/nuke/types"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +18,7 @@ func loadResources(ctx context.Context, st composed.State) (error, context.Conte
 	state := st.(*State)
 	logger := composed.LoggerFromCtx(ctx)
 
-	state.Resources = []*ResourceKindState{
+	state.Resources = []*nuketypes.ResourceKindState{
 		{
 			Kind: "VpcPeering",
 			List: &cloudcontrolv1beta1.VpcPeeringList{},
@@ -70,7 +71,7 @@ func loadResources(ctx context.Context, st composed.State) (error, context.Conte
 	return nil, ctx
 }
 
-func _listResources(ctx context.Context, scopeName, namespace string, rks *ResourceKindState, clnt client.Client) error {
+func _listResources(ctx context.Context, scopeName, namespace string, rks *nuketypes.ResourceKindState, clnt client.Client) error {
 	list := rks.List.DeepCopyObject().(client.ObjectList)
 	err := clnt.List(ctx, list, client.InNamespace(namespace))
 	if meta.IsNoMatchError(err) {

--- a/pkg/kcp/nuke/resourceStatusDeleted.go
+++ b/pkg/kcp/nuke/resourceStatusDeleted.go
@@ -12,13 +12,15 @@ func resourceStatusDeleted(ctx context.Context, st composed.State) (error, conte
 	changed := false
 
 	for _, sk := range state.ObjAsNuke().Status.Resources {
-		for objName, objStatus := range sk.Objects {
-			if objStatus == cloudcontrolv1beta1.NukeResourceStatusDeleted {
-				continue
-			}
-			if !state.ObjectExists(sk.Kind, objName) {
-				changed = true
-				sk.Objects[objName] = cloudcontrolv1beta1.NukeResourceStatusDeleted
+		if sk.GetResourceType() == cloudcontrolv1beta1.KcpManagedResource {
+			for objName, objStatus := range sk.Objects {
+				if objStatus == cloudcontrolv1beta1.NukeResourceStatusDeleted {
+					continue
+				}
+				if !state.ObjectExists(sk.Kind, objName) {
+					changed = true
+					sk.Objects[objName] = cloudcontrolv1beta1.NukeResourceStatusDeleted
+				}
 			}
 		}
 	}

--- a/pkg/kcp/nuke/resourceStatusDeleting.go
+++ b/pkg/kcp/nuke/resourceStatusDeleting.go
@@ -12,7 +12,7 @@ func resourceStatusDeleting(ctx context.Context, st composed.State) (error, cont
 	changed := false
 
 	for _, rks := range state.Resources {
-		kindStatus, created := state.ObjAsNuke().Status.GetKind(rks.Kind)
+		kindStatus, created := state.ObjAsNuke().Status.GetKind(rks.Kind, cloudcontrolv1beta1.KcpManagedResource)
 		if created {
 			changed = true
 		}

--- a/pkg/kcp/nuke/resourceStatusDiscovered.go
+++ b/pkg/kcp/nuke/resourceStatusDiscovered.go
@@ -25,7 +25,7 @@ func resourceStatusDiscovered(ctx context.Context, st composed.State) (error, co
 	}
 
 	for _, rks := range state.Resources {
-		kindStatus, created := state.ObjAsNuke().Status.GetKind(rks.Kind)
+		kindStatus, created := state.ObjAsNuke().Status.GetKind(rks.Kind, cloudcontrolv1beta1.KcpManagedResource)
 		if created {
 			changed = true
 		}

--- a/pkg/kcp/nuke/shortCircuitCompleted.go
+++ b/pkg/kcp/nuke/shortCircuitCompleted.go
@@ -2,7 +2,6 @@ package nuke
 
 import (
 	"context"
-
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 )
 

--- a/pkg/kcp/nuke/statusCompleted.go
+++ b/pkg/kcp/nuke/statusCompleted.go
@@ -2,7 +2,6 @@ package nuke
 
 import (
 	"context"
-
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/kcp/nuke/types/state.go
+++ b/pkg/kcp/nuke/types/state.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/common/actions/focal"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ResourceKindState struct {
+	Kind    string
+	List    client.ObjectList
+	Objects []focal.CommonObject
+}
+
+type ProviderResourceKindState struct {
+	Kind     string
+	Provider cloudcontrolv1beta1.ProviderType
+	Objects  []ProviderResourceObject
+}
+
+type ProviderResourceObject interface {
+	GetId() string
+	GetObject() interface{}
+}
+
+type State interface {
+	focal.State
+	ObjAsNuke() *cloudcontrolv1beta1.Nuke
+}

--- a/pkg/kcp/provider/gcp/nuke/checkIfAllProviderResourcesDeleted.go
+++ b/pkg/kcp/provider/gcp/nuke/checkIfAllProviderResourcesDeleted.go
@@ -1,0 +1,31 @@
+package nuke
+
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+)
+
+func checkIfAllProviderResourcesDeleted(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	// check if some provider resources have been loaded to state, if none is loaded then they are all deleted
+	allDeleted := true
+	for _, prks := range state.ProviderResources {
+		if len(prks.Objects) > 0 {
+			allDeleted = false
+			break
+		}
+	}
+
+	if allDeleted {
+		logger.Info("All orphan provided resources nuke deleted")
+
+		return nil, ctx
+	}
+
+	logger.Info("Waiting for orphan provider resources to get nuke deleted")
+
+	return composed.StopWithRequeueDelay(util.Timing.T10000ms()), ctx
+}

--- a/pkg/kcp/provider/gcp/nuke/deleteNfsBackups.go
+++ b/pkg/kcp/provider/gcp/nuke/deleteNfsBackups.go
@@ -1,0 +1,32 @@
+package nuke
+
+import (
+	"context"
+	"fmt"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+)
+
+func deleteNfsBackup(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	for _, rks := range state.ProviderResources {
+		if rks.Kind == "FilestoreBackup" && rks.Provider == cloudcontrolv1beta1.ProviderGCP {
+			for _, obj := range rks.Objects {
+				backup := obj.(GcpBackup)
+				if backup.State == "DELETING" {
+					continue
+				}
+				project, location, name := client.GetProjectLocationNameFromFileBackupPath(backup.Name)
+				_, err := state.fileBackupClient.DeleteFileBackup(ctx, project, location, name)
+				if err != nil {
+					logger.Error(err, fmt.Sprintf("Error requesting Gcp Filestore Backup deletion %s", backup.GetId()))
+				}
+			}
+		}
+
+	}
+	return nil, nil
+}

--- a/pkg/kcp/provider/gcp/nuke/loadNfsBackups.go
+++ b/pkg/kcp/provider/gcp/nuke/loadNfsBackups.go
@@ -1,0 +1,45 @@
+package nuke
+
+import (
+	"context"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	nuketypes "github.com/kyma-project/cloud-manager/pkg/kcp/nuke/types"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func loadNfsBackups(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	backups, err := state.fileBackupClient.ListFilesBackups(ctx, state.State.Scope().Spec.Scope.Gcp.Project, client.GetSkrBackupsFilter(state.State.Scope().Name))
+	if err != nil {
+		logger.Error(err, "Error listing Gcp Filestore Backups")
+
+		state.ObjAsNuke().Status.State = string(cloudcontrolv1beta1.ErrorState)
+
+		return composed.PatchStatus(state.ObjAsNuke()).
+			SetExclusiveConditions(metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  "ErrorListingGcpFilestoreBackups",
+				Message: err.Error(),
+			}).
+			ErrorLogMessage("Error patching KCP Nuke status after list GCP Filestore Backups error").
+			SuccessError(composed.StopWithRequeueDelay(util.Timing.T10000ms())).
+			Run(ctx, state)
+	}
+	gcpBackups := make([]nuketypes.ProviderResourceObject, len(backups))
+	for i, backup := range backups {
+		gcpBackups[i] = GcpBackup{backup}
+	}
+
+	state.ProviderResources = append(state.ProviderResources, &nuketypes.ProviderResourceKindState{
+		Kind:     "FilestoreBackup",
+		Provider: cloudcontrolv1beta1.ProviderGCP,
+		Objects:  gcpBackups,
+	})
+	return nil, ctx
+}

--- a/pkg/kcp/provider/gcp/nuke/new.go
+++ b/pkg/kcp/provider/gcp/nuke/new.go
@@ -1,0 +1,44 @@
+package nuke
+
+import (
+	"context"
+	"fmt"
+	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	nuketypes "github.com/kyma-project/cloud-manager/pkg/kcp/nuke/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func New(stateFactory StateFactory) composed.Action {
+	return func(ctx context.Context, st composed.State) (error, context.Context) {
+		logger := composed.LoggerFromCtx(ctx)
+		state, err := stateFactory.NewState(ctx, st.(nuketypes.State))
+		if err != nil {
+			err = fmt.Errorf("error creating new Gcp Nuke state: %w", err)
+			logger.Error(err, "Error")
+			obj := st.Obj().(*v1beta1.Nuke)
+			return composed.PatchStatus(obj).
+				SetExclusiveConditions(metav1.Condition{
+					Type:    v1beta1.ConditionTypeError,
+					Status:  metav1.ConditionTrue,
+					Reason:  v1beta1.ReasonGcpError,
+					Message: err.Error(),
+				}).
+				SuccessError(composed.StopAndForget).
+				Run(ctx, st)
+		}
+		return composed.ComposeActions(
+			"gcpNuke",
+			loadNfsBackups,
+			providerResourceStatusDiscovered,
+			deleteNfsBackup,
+			providerResourceStatusDeleting,
+			providerResourceStatusDeleted,
+			checkIfAllProviderResourcesDeleted,
+			// continue to parent action
+			func(ctx context.Context, state composed.State) (error, context.Context) {
+				return nil, ctx
+			},
+		)(ctx, state)
+	}
+}

--- a/pkg/kcp/provider/gcp/nuke/providerResourceStatusDeleted.go
+++ b/pkg/kcp/provider/gcp/nuke/providerResourceStatusDeleted.go
@@ -1,0 +1,49 @@
+package nuke
+
+import (
+	"context"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+)
+
+func providerResourceStatusDeleted(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+
+	changed := false
+
+	for _, sk := range state.ObjAsNuke().Status.Resources {
+		if sk.GetResourceType() == cloudcontrolv1beta1.ProviderResource {
+			for objId, objStatus := range sk.Objects {
+				if objStatus == cloudcontrolv1beta1.NukeResourceStatusDeleted {
+					continue
+				}
+				if !state.ProviderObjectExists(sk.Kind, objId) {
+					changed = true
+					sk.Objects[objId] = cloudcontrolv1beta1.NukeResourceStatusDeleted
+				}
+			}
+		}
+	}
+
+	if !changed {
+		return nil, ctx
+	}
+
+	return composed.PatchStatus(state.ObjAsNuke()).
+		ErrorLogMessage("Error patching KCP Nuke status with deleted provider resources").
+		SuccessErrorNil().
+		Run(ctx, state)
+}
+
+func (s *State) ProviderObjectExists(kind, id string) bool {
+	for _, res := range s.ProviderResources {
+		if res.Kind == kind {
+			for _, obj := range res.Objects {
+				if obj.GetId() == id {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/pkg/kcp/provider/gcp/nuke/providerResourceStatusDeleting.go
+++ b/pkg/kcp/provider/gcp/nuke/providerResourceStatusDeleting.go
@@ -1,0 +1,41 @@
+package nuke
+
+import (
+	"context"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+)
+
+func providerResourceStatusDeleting(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+
+	changed := false
+
+	for _, prks := range state.ProviderResources {
+		kindStatus, created := state.ObjAsNuke().Status.GetKind(prks.Kind, cloudcontrolv1beta1.ProviderResource)
+		if created {
+			changed = true
+		}
+
+		for _, obj := range prks.Objects {
+			if kindStatus.Objects[obj.GetId()] != cloudcontrolv1beta1.NukeResourceStatusDeleting {
+				kindStatus.Objects[obj.GetId()] = cloudcontrolv1beta1.NukeResourceStatusDeleting
+				changed = true
+			}
+		}
+	}
+
+	if state.ObjAsNuke().Status.State != "Deleting" {
+		changed = true
+		state.ObjAsNuke().Status.State = "Deleting"
+	}
+
+	if !changed {
+		return nil, ctx
+	}
+
+	return composed.PatchStatus(state.ObjAsNuke()).
+		ErrorLogMessage("Error patching KCP Nuke status with deleting provider resources").
+		SuccessErrorNil().
+		Run(ctx, state)
+}

--- a/pkg/kcp/provider/gcp/nuke/providerResourceStatusDiscovered.go
+++ b/pkg/kcp/provider/gcp/nuke/providerResourceStatusDiscovered.go
@@ -1,0 +1,37 @@
+package nuke
+
+import (
+	"context"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+)
+
+func providerResourceStatusDiscovered(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+
+	changed := false
+
+	for _, prks := range state.ProviderResources {
+		kindStatus, created := state.ObjAsNuke().Status.GetKind(prks.Kind, cloudcontrolv1beta1.ProviderResource)
+		if created {
+			changed = true
+		}
+
+		for _, obj := range prks.Objects {
+			_, exists := kindStatus.Objects[obj.GetId()]
+			if !exists {
+				changed = true
+				kindStatus.Objects[obj.GetId()] = cloudcontrolv1beta1.NukeResourceStatusDiscovered
+			}
+		}
+	}
+
+	if !changed {
+		return nil, ctx
+	}
+
+	return composed.PatchStatus(state.ObjAsNuke()).
+		ErrorLogMessage("Error patching KCP Nuke status with discovered provider resources").
+		SuccessErrorNil().
+		Run(ctx, state)
+}

--- a/pkg/kcp/provider/gcp/nuke/state.go
+++ b/pkg/kcp/provider/gcp/nuke/state.go
@@ -1,0 +1,66 @@
+package nuke
+
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
+	"github.com/kyma-project/cloud-manager/pkg/common/actions/focal"
+	nuketypes "github.com/kyma-project/cloud-manager/pkg/kcp/nuke/types"
+	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	backupclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsbackup/client"
+	"google.golang.org/api/file/v1"
+)
+
+type StateFactory interface {
+	NewState(ctx context.Context, nukeState nuketypes.State) (focal.State, error)
+}
+
+func NewStateFactory(
+	fileBackupClientProvider gcpclient.ClientProvider[backupclient.FileBackupClient],
+	env abstractions.Environment) StateFactory {
+	return stateFactory{
+		fileBackupClientProvider: fileBackupClientProvider,
+		env:                      env,
+	}
+}
+
+type stateFactory struct {
+	fileBackupClientProvider gcpclient.ClientProvider[backupclient.FileBackupClient]
+	env                      abstractions.Environment
+}
+
+func (f stateFactory) NewState(ctx context.Context, nukeState nuketypes.State) (focal.State, error) {
+	fbc, err := f.fileBackupClientProvider(
+		ctx,
+		f.env.Get("GCP_SA_JSON_KEY_PATH"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &State{
+		State:            nukeState,
+		fileBackupClient: fbc,
+	}, nil
+}
+
+type State struct {
+	nuketypes.State
+	fileBackupClient  backupclient.FileBackupClient
+	ProviderResources []*nuketypes.ProviderResourceKindState
+}
+
+type GcpBackup struct {
+	*file.Backup
+}
+
+func (b GcpBackup) GetId() string {
+	return b.Name
+}
+
+func (b GcpBackup) GetObject() interface{} {
+	return b.Backup
+}
+
+type ProviderNukeStatus struct {
+	v1beta1.NukeStatus
+}

--- a/pkg/skr/gcpnfsvolumebackup/addLabelsToNfsBackup.go
+++ b/pkg/skr/gcpnfsvolumebackup/addLabelsToNfsBackup.go
@@ -1,0 +1,58 @@
+package gcpnfsvolumebackup
+
+import (
+	"context"
+	"fmt"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+)
+
+func addLabelsToNfsBackup(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+	backup := state.ObjAsGcpNfsVolumeBackup()
+
+	//If the backup not already exists, return
+	if state.fileBackup == nil {
+		return nil, nil
+	}
+
+	//If deleting, return.
+	if composed.IsMarkedForDeletion(state.Obj()) {
+		return nil, nil
+	}
+
+	//If a backup is not ready, return as it might be unsafe to patch it
+	if backup.Status.State != cloudresourcesv1beta1.GcpNfsBackupReady {
+		return nil, nil
+	}
+
+	if state.fileBackup.Labels != nil && state.fileBackup.Labels[gcpclient.ManagedByKey] == gcpclient.ManagedByValue && state.fileBackup.Labels[gcpclient.ScopeNameKey] == state.Scope.Name {
+		// Labels have been already set, return
+		return nil, nil
+	}
+
+	logger.WithValues("NfsBackup name", backup.Name, "NfsBackup namespace", backup.Namespace).Info("Adding missing labels to GCP File Backup")
+
+	//Get GCP details.
+	project := state.Scope.Spec.Scope.Gcp.Project
+	location := backup.Status.Location
+	name := fmt.Sprintf("cm-%.60s", backup.Status.Id)
+
+	if state.fileBackup.Labels == nil {
+		state.fileBackup.Labels = make(map[string]string)
+	}
+	state.fileBackup.Labels[gcpclient.ManagedByKey] = gcpclient.ManagedByValue
+	state.fileBackup.Labels[gcpclient.ScopeNameKey] = state.Scope.Name
+
+	_, err := state.fileBackupClient.PatchFileBackup(ctx, project, location, name, "Labels", state.fileBackup)
+
+	if err != nil {
+		// Log and retry. This is not an essential action as it only impacts nuke on non prod envs that might already
+		// have backups without necessary labels.
+		logger.Error(err, "Error adding missing labels to File backup object in GCP")
+	}
+
+	return composed.StopWithRequeueDelay(gcpclient.GcpConfig.GcpOperationWaitTime), nil
+}

--- a/pkg/skr/gcpnfsvolumebackup/addLabelsToNfsBackup_test.go
+++ b/pkg/skr/gcpnfsvolumebackup/addLabelsToNfsBackup_test.go
@@ -1,0 +1,130 @@
+package gcpnfsvolumebackup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/go-logr/logr"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/file/v1"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+type addLabelsToNfsBackupSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (suite *addLabelsToNfsBackupSuite) SetupTest() {
+	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
+}
+
+func (suite *addLabelsToNfsBackupSuite) TestAddLabelsToNfsBackup() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+
+		case http.MethodPatch:
+			fmt.Println(r.URL.Path)
+			b, err := io.ReadAll(r.Body)
+			assert.Nil(suite.T(), err)
+			//create filestore instance from byte[] and check if it is equal to the expected filestore instance
+			obj := &file.Backup{}
+			err = json.Unmarshal(b, obj)
+			suite.Nil(err)
+			suite.Equal("cloud-manager", obj.Labels["managed-by"])
+			suite.Equal(scope.Name, obj.Labels["scope-name"])
+		default:
+			assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+		}
+	}))
+	defer fakeHttpServer.Close()
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	state.Scope = &scope
+	assert.Nil(suite.T(), err)
+	state.fileBackup = &file.Backup{}
+	err, _ = addLabelsToNfsBackup(ctx, state)
+	assert.Equal(suite.T(), composed.StopWithRequeueDelay(gcpclient.GcpConfig.GcpOperationWaitTime), err)
+}
+
+func (suite *addLabelsToNfsBackupSuite) TestDoNotAddLabelsToNfsBackupOnDeletingObject() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	deletingObj := deletingGpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, deletingObj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	state, err := factory.newStateWith(deletingObj)
+	assert.Nil(suite.T(), err)
+	state.fileBackup = &file.Backup{}
+	state.Scope = &scope
+
+	//Call addLabelsToNfsBackup
+	err, _ = addLabelsToNfsBackup(ctx, state)
+	assert.Nil(suite.T(), err)
+}
+
+func (suite *addLabelsToNfsBackupSuite) TestDoNotAddLabelsToNfsBackupNoBackup() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	assert.Nil(suite.T(), err)
+	state.Scope = &scope
+	err, _ = addLabelsToNfsBackup(ctx, state)
+	assert.Nil(suite.T(), err)
+}
+
+func (suite *addLabelsToNfsBackupSuite) TestDoNotAddLabelsToNfsBackupNotReady() {
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(suite.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	obj := gcpNfsVolumeBackup.DeepCopy()
+	obj.Status.State = cloudresourcesv1beta1.GcpNfsBackupError
+	factory, err := newTestStateFactoryWithObj(fakeHttpServer, obj)
+	assert.Nil(suite.T(), err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	//Get state object with GcpNfsVolume
+	state, err := factory.newStateWith(obj)
+	assert.Nil(suite.T(), err)
+	state.fileBackup = &file.Backup{}
+	state.Scope = &scope
+	err, _ = addLabelsToNfsBackup(ctx, state)
+	assert.Nil(suite.T(), err)
+}
+
+func TestAddLabelsToNfsBackup(t *testing.T) {
+	suite.Run(t, new(addLabelsToNfsBackupSuite))
+}

--- a/pkg/skr/gcpnfsvolumebackup/createNfsBackup.go
+++ b/pkg/skr/gcpnfsvolumebackup/createNfsBackup.go
@@ -72,6 +72,7 @@ func createNfsBackup(ctx context.Context, st composed.State) (error, context.Con
 		SourceFileShare:    state.GcpNfsVolume.Spec.FileShareName,
 		SourceInstance:     client.GetFilestoreInstancePath(project, state.GcpNfsVolume.Status.Location, nfsInstanceName),
 		SourceInstanceTier: string(state.GcpNfsVolume.Spec.Tier),
+		Labels:             map[string]string{gcpclient.ManagedByKey: gcpclient.ManagedByValue, gcpclient.ScopeNameKey: state.Scope.Name},
 	}
 	op, err := state.fileBackupClient.CreateFileBackup(ctx, project, backup.Status.Location, name, fileBackup)
 

--- a/pkg/skr/gcpnfsvolumebackup/createNfsBackup_test.go
+++ b/pkg/skr/gcpnfsvolumebackup/createNfsBackup_test.go
@@ -191,6 +191,8 @@ func (suite *createNfsBackupSuite) TestWhenCreateBackupSuccessful() {
 			err = json.Unmarshal(b, obj)
 			suite.Nil(err)
 			suite.Equal("projects/test-project/locations/us-west1/instances/cm-test-gcp-nfs-instance", obj.SourceInstance)
+			suite.Equal("cloud-manager", obj.Labels["managed-by"])
+			suite.Equal(scope.Name, obj.Labels["scope-name"])
 			if strings.HasSuffix(r.URL.Path, "/projects/test-project/locations/us-west1/backups") && strings.Contains(r.URL.RawQuery, "backupId=cm-") {
 				//Return 200
 				w.WriteHeader(http.StatusOK)

--- a/pkg/skr/gcpnfsvolumebackup/reconciler.go
+++ b/pkg/skr/gcpnfsvolumebackup/reconciler.go
@@ -54,6 +54,7 @@ func (r *Reconciler) newAction() composed.Action {
 		validateLocation,
 		loadNfsBackup,
 		loadGcpNfsVolume,
+		addLabelsToNfsBackup,
 		createNfsBackup,
 		deleteNfsBackup,
 		checkBackupOperation,

--- a/pkg/testinfra/dsl/gcpNfsVolumeBackup.go
+++ b/pkg/testinfra/dsl/gcpNfsVolumeBackup.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	backupclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsbackup/client"
+	"google.golang.org/api/file/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -21,6 +24,16 @@ func WithGcpNfsVolume(name string) ObjAction {
 			panic(fmt.Errorf("unhandled type %T in WithGcpNfsVolume", obj))
 		},
 	}
+}
+
+func CreateGcpFileBackupDirectly(ctx context.Context, backupClient backupclient.FileBackupClient, project, location string, backup *file.Backup) error {
+	_, err := backupClient.CreateFileBackup(ctx, project, location, backup.Name, backup)
+	return err
+}
+
+func ListGcpFileBackups(ctx context.Context, backupClient backupclient.FileBackupClient, project, scopeName string) ([]*file.Backup, error) {
+	filter := gcpclient.GetSkrBackupsFilter(scopeName)
+	return backupClient.ListFilesBackups(ctx, project, filter)
 }
 
 func CreateGcpNfsVolumeBackup(ctx context.Context, clnt client.Client, obj *cloudresourcesv1beta1.GcpNfsVolumeBackup, opts ...ObjAction) error {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Gcp Filestore Backup Nuke
- Skeleton for future resources without KCP reconciler
- Integration test for Gcp Filestore Backup Nuke

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #828 