### PR TITLE
fix: unable to delete VPC peering when network is in Warning state

### DIFF
--- a/pkg/kcp/provider/aws/vpcpeering/createRemoteClient.go
+++ b/pkg/kcp/provider/aws/vpcpeering/createRemoteClient.go
@@ -19,8 +19,8 @@ func createRemoteClient(ctx context.Context, st composed.State) (error, context.
 		return nil, nil
 	}
 
-	remoteAccountId := state.remoteNetwork.Spec.Network.Reference.Aws.AwsAccountId
-	remoteRegion := state.remoteNetwork.Spec.Network.Reference.Aws.Region
+	remoteAccountId := state.remoteNetwork.Status.Network.Aws.AwsAccountId
+	remoteRegion := state.remoteNetwork.Status.Network.Aws.Region
 
 	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", remoteAccountId, state.roleName)
 

--- a/pkg/kcp/provider/aws/vpcpeering/kcpNetworkLocalLoad.go
+++ b/pkg/kcp/provider/aws/vpcpeering/kcpNetworkLocalLoad.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -50,7 +49,7 @@ func kcpNetworkLocalLoad(ctx context.Context, st composed.State) (error, context
 			Run(ctx, state)
 	}
 
-	if !meta.IsStatusConditionTrue(*net.Conditions(), cloudcontrolv1beta1.ConditionTypeReady) {
+	if net.Status.Network == nil {
 		state.ObjAsVpcPeering().Status.State = string(cloudcontrolv1beta1.ErrorState)
 		return composed.PatchStatus(state.ObjAsVpcPeering()).
 			SetExclusiveConditions(metav1.Condition{

--- a/pkg/kcp/provider/aws/vpcpeering/kcpNetworkRemoteLoad.go
+++ b/pkg/kcp/provider/aws/vpcpeering/kcpNetworkRemoteLoad.go
@@ -47,7 +47,7 @@ func kcpNetworkRemoteLoad(ctx context.Context, st composed.State) (error, contex
 			Run(ctx, state)
 	}
 
-	if net.Status.State != string(cloudcontrolv1beta1.ReadyState) {
+	if net.Status.Network == nil {
 		state.ObjAsVpcPeering().Status.State = string(cloudcontrolv1beta1.ErrorState)
 		return composed.PatchStatus(state.ObjAsVpcPeering()).
 			SetExclusiveConditions(metav1.Condition{

--- a/pkg/kcp/provider/azure/vpcpeering/kcpNetworkLocalLoad.go
+++ b/pkg/kcp/provider/azure/vpcpeering/kcpNetworkLocalLoad.go
@@ -8,7 +8,6 @@ import (
 	azureutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/util"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -51,7 +50,7 @@ func kcpNetworkLocalLoad(ctx context.Context, st composed.State) (error, context
 			Run(ctx, state)
 	}
 
-	if !meta.IsStatusConditionTrue(*net.Conditions(), cloudcontrolv1beta1.ConditionTypeReady) {
+	if net.Status.Network == nil {
 		state.ObjAsVpcPeering().Status.State = string(cloudcontrolv1beta1.ErrorState)
 		return composed.PatchStatus(state.ObjAsVpcPeering()).
 			SetExclusiveConditions(metav1.Condition{

--- a/pkg/kcp/provider/azure/vpcpeering/kcpNetworkRemoteLoad.go
+++ b/pkg/kcp/provider/azure/vpcpeering/kcpNetworkRemoteLoad.go
@@ -48,7 +48,7 @@ func kcpNetworkRemoteLoad(ctx context.Context, st composed.State) (error, contex
 			Run(ctx, state)
 	}
 
-	if net.Status.State != string(cloudcontrolv1beta1.ReadyState) {
+	if net.Status.Network == nil {
 		state.ObjAsVpcPeering().Status.State = string(cloudcontrolv1beta1.ErrorState)
 		return composed.PatchStatus(state.ObjAsVpcPeering()).
 			SetExclusiveConditions(metav1.Condition{


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- fixes the issue with deleting VPC peering when remote or local network is in Warning state