### PR TITLE
fix(AzureRedis): retry creating/updating private end point when it is in failed state

### DIFF
--- a/internal/controller/cloud-control/redisinstance_azure_test.go
+++ b/internal/controller/cloud-control/redisinstance_azure_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis"
 	azurecommon "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/common"
+	azuremeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/meta"
 	"k8s.io/utils/ptr"
 	"time"
 
@@ -194,9 +195,10 @@ var _ = Describe("Feature: KCP RedisInstance", func() {
 		})
 
 		By("Then Private Private End Point is deleted", func() {
-			dnsZoneGroup, err := azureMock.GetPrivateEndPoint(infra.Ctx(), resourceGroupName, redisInstance.Name)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(dnsZoneGroup).To(BeNil())
+			privateEndPoint, err := azureMock.GetPrivateEndPoint(infra.Ctx(), resourceGroupName, redisInstance.Name)
+			Expect(err).To(HaveOccurred())
+			Expect(azuremeta.IsNotFound(err)).To(BeTrue())
+			Expect(privateEndPoint).To(BeNil())
 		})
 	})
 

--- a/pkg/kcp/provider/azure/mock/privateEndPointStore.go
+++ b/pkg/kcp/provider/azure/mock/privateEndPointStore.go
@@ -36,12 +36,12 @@ func (s *privateEndPointsStore) GetPrivateEndPoint(ctx context.Context, resource
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	privateDnsZone, err := s.getPrivateEndPointNonLocking(resourceGroupName, privateEndPointName)
+	privateEndPoint, err := s.getPrivateEndPointNonLocking(resourceGroupName, privateEndPointName)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := util.JsonClone(privateDnsZone)
+	res, err := util.JsonClone(privateEndPoint)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (s *privateEndPointsStore) DeletePrivateEndPoint(ctx context.Context, resou
 		return err
 	}
 
-	s.items[resourceGroupName][privateEndPointName] = nil
+	delete(s.items[resourceGroupName], privateEndPointName)
 
 	return nil
 }

--- a/pkg/kcp/provider/azure/redisinstance/createPrivateEndPoint.go
+++ b/pkg/kcp/provider/azure/redisinstance/createPrivateEndPoint.go
@@ -18,7 +18,7 @@ import (
 func createPrivateEndPoint(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
 	logger := composed.LoggerFromCtx(ctx)
-	if state.privateEndPoint != nil {
+	if state.privateEndPoint != nil && ptr.Deref(state.privateEndPoint.Properties.ProvisioningState, "") != armnetwork.ProvisioningStateFailed {
 		return nil, nil
 	}
 	logger.Info("Creating Azure Private EndPoint")

--- a/pkg/kcp/provider/azure/redisinstance/loadPrivateEndPoint.go
+++ b/pkg/kcp/provider/azure/redisinstance/loadPrivateEndPoint.go
@@ -44,7 +44,7 @@ func loadPrivateEndPoint(ctx context.Context, st composed.State) (error, context
 		}
 		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 	}
-	logger.Info("Azure Private EndPoint instance loaded", "provisioning state", privateEndPointInstance.Properties.ProvisioningState)
+	logger.Info("Azure Private EndPoint instance loaded", "provisioningState", privateEndPointInstance.Properties.ProvisioningState)
 	state.privateEndPoint = privateEndPointInstance
 	return nil, nil
 }

--- a/pkg/kcp/provider/azure/redisinstance/loadPrivateEndPoint.go
+++ b/pkg/kcp/provider/azure/redisinstance/loadPrivateEndPoint.go
@@ -44,6 +44,7 @@ func loadPrivateEndPoint(ctx context.Context, st composed.State) (error, context
 		}
 		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 	}
+	logger.Info("Azure Private EndPoint instance loaded", "provisioning state", privateEndPointInstance.Properties.ProvisioningState)
 	state.privateEndPoint = privateEndPointInstance
 	return nil, nil
 }

--- a/pkg/kcp/provider/azure/redisinstance/new.go
+++ b/pkg/kcp/provider/azure/redisinstance/new.go
@@ -44,6 +44,7 @@ func New(stateFactory StateFactory) composed.Action {
 					updateStatusId,
 					waitRedisAvailable,
 					createPrivateEndPoint,
+					waitPrivateEndPointAvailable,
 					createPrivateDnsZoneGroup,
 					modifyRedis,
 					updateStatus,

--- a/pkg/kcp/provider/azure/redisinstance/waitPrivateEndPointAvailable.go
+++ b/pkg/kcp/provider/azure/redisinstance/waitPrivateEndPointAvailable.go
@@ -32,7 +32,7 @@ func waitPrivateEndPointAvailable(ctx context.Context, st composed.State) (error
 	if ptr.Deref(state.privateEndPoint.Properties.ProvisioningState, "") == armnetwork.ProvisioningStateSucceeded {
 		return nil, nil
 	}
-	logger.Info("Azure Private End Point is not ready yet", "provisioning state", state.privateEndPoint.Properties.ProvisioningState)
+	logger.Info("Azure Private End Point is not ready yet", "provisioningState", state.privateEndPoint.Properties.ProvisioningState)
 
 	return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 }

--- a/pkg/kcp/provider/azure/redisinstance/waitPrivateEndPointAvailable.go
+++ b/pkg/kcp/provider/azure/redisinstance/waitPrivateEndPointAvailable.go
@@ -1,0 +1,38 @@
+package redisinstance
+
+import (
+	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
+	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func waitPrivateEndPointAvailable(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	if state.privateEndPoint == nil {
+		errorMsg := "Error: private end point is not loaded"
+		redisInstance := st.Obj().(*v1beta1.RedisInstance)
+		return composed.UpdateStatus(redisInstance).
+			SetExclusiveConditions(metav1.Condition{
+				Type:    v1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  v1beta1.ConditionTypeError,
+				Message: errorMsg,
+			}).
+			SuccessError(composed.StopAndForget).
+			SuccessLogMsg(errorMsg).
+			Run(ctx, st)
+	}
+
+	if ptr.Deref(state.privateEndPoint.Properties.ProvisioningState, "") == armnetwork.ProvisioningStateSucceeded {
+		return nil, nil
+	}
+	logger.Info("Azure Private End Point is not ready yet", "provisioning state", state.privateEndPoint.Properties.ProvisioningState)
+
+	return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
+}


### PR DESCRIPTION
Changes proposed in this pull request:

- If PrivateEndPoint is loaded but in "Failed" state, try to update it. Intention is to fix the use case when PEP do not suceed to connect to Redis instance (long running exception from Azure side). 

