### PR TITLE
fix(AwsVpcPeering): fixes alternating message during route creation failures

### DIFF
--- a/pkg/kcp/provider/aws/vpcpeering/createRoutes.go
+++ b/pkg/kcp/provider/aws/vpcpeering/createRoutes.go
@@ -71,6 +71,10 @@ func createRoutes(ctx context.Context, st composed.State) (error, context.Contex
 						SuccessError(composed.StopAndForget).
 						Run(ctx, state)
 				}
+
+				if err != nil {
+					break
+				}
 			}
 		}
 	}

--- a/pkg/kcp/provider/aws/vpcpeering/createRoutes.go
+++ b/pkg/kcp/provider/aws/vpcpeering/createRoutes.go
@@ -72,8 +72,9 @@ func createRoutes(ctx context.Context, st composed.State) (error, context.Contex
 						Run(ctx, state)
 				}
 
+				// prevents alternating error messages
 				if err != nil {
-					break
+					return composed.StopAndForget, nil
 				}
 			}
 		}

--- a/pkg/kcp/provider/aws/vpcpeering/loadVpcPeeringConnection.go
+++ b/pkg/kcp/provider/aws/vpcpeering/loadVpcPeeringConnection.go
@@ -3,6 +3,7 @@ package vpcpeering
 import (
 	"context"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
 	"k8s.io/utils/ptr"
 )
 
@@ -19,7 +20,7 @@ func loadVpcPeeringConnection(ctx context.Context, st composed.State) (error, co
 	peering, err := state.client.DescribeVpcPeeringConnection(ctx, obj.Status.Id)
 
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error listing AWS peering connections", composed.StopWithRequeue, ctx)
+		return awsmeta.LogErrorAndReturn(err, "Error listing AWS peering connections", ctx)
 	}
 
 	state.vpcPeering = peering


### PR DESCRIPTION
**Description**

During VPC peering reconciliation Cloud Manger will try to create appropriate route entries for all routing tables related to local network. In situation when Cloud Manager is unable to create route entries across multiple routing tables error message will alternate based on the route table name and trigger reconcile loop over and over.

Solution is to stop on first route table entry and forget.

Probability for this to happen is really low but I bumped into an issue while messing around in dev env. It probably happened when I manually deleted local AWS VPC peering connection.

Changes proposed in this pull request:

- fixes alternating message during route creation failures
- relaxing requeues on loading local peering failures 