### PR TITLE
fix(AwsVpcPeering): waits pending acceptance status before accepting connection

### DIFF
--- a/internal/controller/cloud-control/vpcpeering_aws_test.go
+++ b/internal/controller/cloud-control/vpcpeering_aws_test.go
@@ -246,7 +246,6 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 				WithArguments(infra.Ctx(), infra.KCP().Client(), kcpPeering,
 					NewObjActions(),
 					HaveFinalizer(cloudcontrolv1beta1.FinalizerName),
-					HavingState(string(cloudcontrolv1beta1.ErrorState)),
 					HavingKcpVpcPeeringStatusIdNotEmpty(),
 				).Should(Succeed())
 		})
@@ -524,7 +523,6 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 				WithArguments(infra.Ctx(), infra.KCP().Client(), kcpPeering,
 					NewObjActions(),
 					HaveFinalizer(cloudcontrolv1beta1.FinalizerName),
-					HavingState(string(cloudcontrolv1beta1.ErrorState)),
 					HavingKcpVpcPeeringStatusIdNotEmpty(),
 				).Should(Succeed())
 		})

--- a/pkg/kcp/provider/aws/util/peering.go
+++ b/pkg/kcp/provider/aws/util/peering.go
@@ -1,0 +1,16 @@
+package util
+
+import ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+// Determinates whether VpcPeeringConnection can be deleted based on VPC peering connection lifecycle
+// https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-basics.html
+func CanDeletePeering(peering *ec2types.VpcPeeringConnection) bool {
+	code := peering.Status.Code
+	if code == ec2types.VpcPeeringConnectionStateReasonCodePendingAcceptance ||
+		code == ec2types.VpcPeeringConnectionStateReasonCodeDeleting ||
+		code == ec2types.VpcPeeringConnectionStateReasonCodeActive {
+		return true
+	}
+
+	return false
+}

--- a/pkg/kcp/provider/aws/util/peering.go
+++ b/pkg/kcp/provider/aws/util/peering.go
@@ -4,11 +4,12 @@ import ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 // Determinates whether VpcPeeringConnection can be deleted based on VPC peering connection lifecycle
 // https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-basics.html
-func CanDeletePeering(peering *ec2types.VpcPeeringConnection) bool {
+func IsTerminated(peering *ec2types.VpcPeeringConnection) bool {
 	code := peering.Status.Code
-	if code == ec2types.VpcPeeringConnectionStateReasonCodePendingAcceptance ||
-		code == ec2types.VpcPeeringConnectionStateReasonCodeDeleting ||
-		code == ec2types.VpcPeeringConnectionStateReasonCodeActive {
+	if code == ec2types.VpcPeeringConnectionStateReasonCodeFailed ||
+		code == ec2types.VpcPeeringConnectionStateReasonCodeExpired ||
+		code == ec2types.VpcPeeringConnectionStateReasonCodeRejected ||
+		code == ec2types.VpcPeeringConnectionStateReasonCodeDeleted {
 		return true
 	}
 

--- a/pkg/kcp/provider/aws/vpcpeering/createRemoteClient.go
+++ b/pkg/kcp/provider/aws/vpcpeering/createRemoteClient.go
@@ -59,12 +59,12 @@ func createRemoteClient(ctx context.Context, st composed.State) (error, context.
 		}
 
 		if !changed {
-			return composed.StopWithRequeueDelay(util.Timing.T300000ms()), nil
+			return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 		}
 
 		return composed.PatchStatus(state.ObjAsVpcPeering()).
 			ErrorLogMessage("Error patching KCP VpcPeering with error state after remote client creation failed").
-			SuccessError(composed.StopWithRequeueDelay(util.Timing.T300000ms())). // try again in 5mins
+			SuccessError(composed.StopWithRequeueDelay(util.Timing.T60000ms())). // try again in 1 min
 			Run(ctx, state)
 	}
 

--- a/pkg/kcp/provider/aws/vpcpeering/createRemoteRoutes.go
+++ b/pkg/kcp/provider/aws/vpcpeering/createRemoteRoutes.go
@@ -57,13 +57,13 @@ func createRemoteRoutes(ctx context.Context, st composed.State) (error, context.
 
 				// Do not update status if nothing is changed
 				if !changed {
-					return composed.StopWithRequeueDelay(util.Timing.T300000ms()), nil
+					return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 				}
 
 				// User can recover by modifying routes
 				return composed.PatchStatus(obj).
 					ErrorLogMessage("Error updating VpcPeering status when creating routes").
-					SuccessError(composed.StopWithRequeueDelay(util.Timing.T300000ms())).
+					SuccessError(composed.StopWithRequeueDelay(util.Timing.T60000ms())).
 					Run(ctx, state)
 			}
 		}

--- a/pkg/kcp/provider/aws/vpcpeering/createRoutes.go
+++ b/pkg/kcp/provider/aws/vpcpeering/createRoutes.go
@@ -71,6 +71,11 @@ func createRoutes(ctx context.Context, st composed.State) (error, context.Contex
 						SuccessError(composed.StopAndForget).
 						Run(ctx, state)
 				}
+
+				// prevents alternating error messages
+				if err != nil {
+					return composed.StopAndForget, nil
+				}
 			}
 		}
 	}

--- a/pkg/kcp/provider/aws/vpcpeering/createVpcPeeringConnection.go
+++ b/pkg/kcp/provider/aws/vpcpeering/createVpcPeeringConnection.go
@@ -45,7 +45,7 @@ func createVpcPeeringConnection(ctx context.Context, st composed.State) (error, 
 		},
 	}
 
-	remoteRegion := state.remoteNetwork.Spec.Network.Reference.Aws.Region
+	remoteRegion := state.remoteNetwork.Status.Network.Aws.Region
 
 	vpcPeering, err := state.client.CreateVpcPeeringConnection(
 		ctx,

--- a/pkg/kcp/provider/aws/vpcpeering/createVpcPeeringConnection.go
+++ b/pkg/kcp/provider/aws/vpcpeering/createVpcPeeringConnection.go
@@ -82,13 +82,13 @@ func createVpcPeeringConnection(ctx context.Context, st composed.State) (error, 
 		}
 
 		if !changed {
-			return composed.StopWithRequeueDelay(util.Timing.T300000ms()), nil
+			return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 		}
 
 		return composed.PatchStatus(state.ObjAsVpcPeering()).
 			ErrorLogMessage("Error updating VpcPeering status due to failed creating vpc peering connection").
 			FailedError(composed.StopWithRequeue).
-			SuccessError(composed.StopWithRequeueDelay(util.Timing.T300000ms())).
+			SuccessError(composed.StopWithRequeueDelay(util.Timing.T60000ms())).
 			Run(ctx, state)
 	}
 

--- a/pkg/kcp/provider/aws/vpcpeering/deleteRoutes.go
+++ b/pkg/kcp/provider/aws/vpcpeering/deleteRoutes.go
@@ -34,7 +34,7 @@ func deleteRoutes(ctx context.Context, st composed.State) (error, context.Contex
 
 				if err != nil {
 					lll.Error(err, "Error deleting route")
-					return composed.StopWithRequeueDelay(util.Timing.T300000ms()), nil
+					return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 				}
 
 				lll.Info("Route deleted")

--- a/pkg/kcp/provider/aws/vpcpeering/deleteVpcPeering.go
+++ b/pkg/kcp/provider/aws/vpcpeering/deleteVpcPeering.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/utils/ptr"
 )
 
 func deleteVpcPeering(ctx context.Context, st composed.State) (error, context.Context) {
@@ -15,18 +18,19 @@ func deleteVpcPeering(ctx context.Context, st composed.State) (error, context.Co
 		return nil, nil
 	}
 
+	if !awsutil.CanDeletePeering(state.vpcPeering) {
+		logger.Info("VpcPeering can't be deleted at this stage",
+			"peeringStatusCode", string(state.vpcPeering.Status.Code),
+			"peeringStatusMessage", ptr.Deref(state.vpcPeering.Status.Message, ""))
+		return nil, nil
+	}
+
 	logger.Info("Deleting VpcPeering")
 
 	err := state.client.DeleteVpcPeeringConnection(ctx, state.vpcPeering.VpcPeeringConnectionId)
 
-	if err != nil {
-
-		if awsmeta.IsNotFound(err) {
-			logger.Info("VpcPeeringConnection not found")
-			return nil, nil
-		}
-
-		return awsmeta.LogErrorAndReturn(err, "Error deleting vpc peering", ctx)
+	if awsmeta.IsErrorRetryable(err) {
+		return composed.StopWithRequeueDelay(util.Timing.T10000ms()), nil
 	}
 
 	logger.Info("VpcPeering deleted")

--- a/pkg/kcp/provider/aws/vpcpeering/deleteVpcPeering.go
+++ b/pkg/kcp/provider/aws/vpcpeering/deleteVpcPeering.go
@@ -18,7 +18,7 @@ func deleteVpcPeering(ctx context.Context, st composed.State) (error, context.Co
 		return nil, nil
 	}
 
-	if !awsutil.CanDeletePeering(state.vpcPeering) {
+	if awsutil.IsTerminated(state.vpcPeering) {
 		logger.Info("VpcPeering can't be deleted at this stage",
 			"peeringStatusCode", string(state.vpcPeering.Status.Code),
 			"peeringStatusMessage", ptr.Deref(state.vpcPeering.Status.Message, ""))

--- a/pkg/kcp/provider/aws/vpcpeering/loadRemoteVpc.go
+++ b/pkg/kcp/provider/aws/vpcpeering/loadRemoteVpc.go
@@ -20,7 +20,7 @@ func loadRemoteVpc(ctx context.Context, st composed.State) (error, context.Conte
 		return nil, nil
 	}
 
-	remoteVpcId := state.remoteNetwork.Spec.Network.Reference.Aws.VpcId
+	remoteVpcId := state.remoteNetwork.Status.Network.Aws.VpcId
 
 	vpc, err := state.remoteClient.DescribeVpc(ctx, remoteVpcId)
 

--- a/pkg/kcp/provider/aws/vpcpeering/loadVpcPeeringConnection.go
+++ b/pkg/kcp/provider/aws/vpcpeering/loadVpcPeeringConnection.go
@@ -25,7 +25,7 @@ func loadVpcPeeringConnection(ctx context.Context, st composed.State) (error, co
 	}
 
 	if err != nil {
-		return composed.LogErrorAndReturn(err, "Error listing AWS peering connections", composed.StopWithRequeue, ctx)
+		return awsmeta.LogErrorAndReturn(err, "Error listing AWS peering connections", ctx)
 	}
 
 	state.vpcPeering = peering

--- a/pkg/kcp/provider/aws/vpcpeering/loadVpcPeeringConnection.go
+++ b/pkg/kcp/provider/aws/vpcpeering/loadVpcPeeringConnection.go
@@ -3,6 +3,7 @@ package vpcpeering
 import (
 	"context"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
 	"k8s.io/utils/ptr"
 )
 
@@ -17,6 +18,11 @@ func loadVpcPeeringConnection(ctx context.Context, st composed.State) (error, co
 	}
 
 	peering, err := state.client.DescribeVpcPeeringConnection(ctx, obj.Status.Id)
+
+	if awsmeta.IsNotFound(err) {
+		logger.Info("Local AWS Peering not found for KCP VpcPeering")
+		return nil, nil
+	}
 
 	if err != nil {
 		return composed.LogErrorAndReturn(err, "Error listing AWS peering connections", composed.StopWithRequeue, ctx)

--- a/pkg/kcp/provider/aws/vpcpeering/new.go
+++ b/pkg/kcp/provider/aws/vpcpeering/new.go
@@ -47,6 +47,7 @@ func New(stateFactory StateFactory) composed.Action {
 					actions.PatchAddFinalizer,
 					checkNetworkTag,
 					createVpcPeeringConnection,
+					waitPendingAcceptance,
 					acceptVpcPeeringConnection,
 					waitVpcPeeringActive,
 					createRoutes,

--- a/pkg/kcp/provider/aws/vpcpeering/remotePeeringDelete.go
+++ b/pkg/kcp/provider/aws/vpcpeering/remotePeeringDelete.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/utils/ptr"
 )
 
 func remotePeeringDelete(ctx context.Context, st composed.State) (error, context.Context) {
@@ -19,18 +22,19 @@ func remotePeeringDelete(ctx context.Context, st composed.State) (error, context
 		return nil, nil
 	}
 
+	if !awsutil.CanDeletePeering(state.remoteVpcPeering) {
+		logger.Info("Remote VpcPeering can't be deleted at this stage",
+			"peeringStatusCode", string(state.remoteVpcPeering.Status.Code),
+			"peeringStatusMessage", ptr.Deref(state.remoteVpcPeering.Status.Message, ""))
+		return nil, nil
+	}
+
 	logger.Info("Deleting remote VpcPeering")
 
 	err := state.remoteClient.DeleteVpcPeeringConnection(ctx, state.remoteVpcPeering.VpcPeeringConnectionId)
 
-	if err != nil {
-
-		if awsmeta.IsNotFound(err) {
-			logger.Info("VpcPeeringConnection not found")
-			return nil, nil
-		}
-
-		return awsmeta.LogErrorAndReturn(err, "Error deleting vpc peering", ctx)
+	if awsmeta.IsErrorRetryable(err) {
+		return composed.StopWithRequeueDelay(util.Timing.T10000ms()), nil
 	}
 
 	logger.Info("Remote VpcPeering deleted")

--- a/pkg/kcp/provider/aws/vpcpeering/remotePeeringDelete.go
+++ b/pkg/kcp/provider/aws/vpcpeering/remotePeeringDelete.go
@@ -22,7 +22,7 @@ func remotePeeringDelete(ctx context.Context, st composed.State) (error, context
 		return nil, nil
 	}
 
-	if !awsutil.CanDeletePeering(state.remoteVpcPeering) {
+	if awsutil.IsTerminated(state.remoteVpcPeering) {
 		logger.Info("Remote VpcPeering can't be deleted at this stage",
 			"peeringStatusCode", string(state.remoteVpcPeering.Status.Code),
 			"peeringStatusMessage", ptr.Deref(state.remoteVpcPeering.Status.Message, ""))

--- a/pkg/kcp/provider/aws/vpcpeering/remoteRoutesDelete.go
+++ b/pkg/kcp/provider/aws/vpcpeering/remoteRoutesDelete.go
@@ -37,7 +37,7 @@ func remoteRoutesDelete(ctx context.Context, st composed.State) (error, context.
 
 				if err != nil {
 					lll.Error(err, "Error deleting remote route")
-					return composed.StopWithRequeueDelay(util.Timing.T300000ms()), nil
+					return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 				}
 
 				lll.Info("Remote route deleted")

--- a/pkg/kcp/provider/aws/vpcpeering/waitPendingAcceptance.go
+++ b/pkg/kcp/provider/aws/vpcpeering/waitPendingAcceptance.go
@@ -1,0 +1,65 @@
+package vpcpeering
+
+import (
+	"context"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+)
+
+func waitPendingAcceptance(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+
+	code := state.vpcPeering.Status.Code
+
+	if code == ec2Types.VpcPeeringConnectionStateReasonCodeActive ||
+		code == ec2Types.VpcPeeringConnectionStateReasonCodeProvisioning ||
+		code == ec2Types.VpcPeeringConnectionStateReasonCodePendingAcceptance {
+		return nil, nil
+	}
+
+	changed := false
+
+	if state.ObjAsVpcPeering().Status.State != string(code) {
+		state.ObjAsVpcPeering().Status.State = string(code)
+		changed = true
+	}
+
+	if code == ec2Types.VpcPeeringConnectionStateReasonCodeFailed ||
+		code == ec2Types.VpcPeeringConnectionStateReasonCodeExpired ||
+		code == ec2Types.VpcPeeringConnectionStateReasonCodeRejected ||
+		code == ec2Types.VpcPeeringConnectionStateReasonCodeDeleted ||
+		code == ec2Types.VpcPeeringConnectionStateReasonCodeDeleting {
+
+		condition := metav1.Condition{
+			Type:    cloudcontrolv1beta1.ConditionTypeError,
+			Status:  metav1.ConditionTrue,
+			Reason:  cloudcontrolv1beta1.ReasonFailedAcceptingVpcPeeringConnection,
+			Message: ptr.Deref(state.vpcPeering.Status.Message, ""),
+		}
+
+		if composed.AnyConditionChanged(state.ObjAsVpcPeering(), condition) ||
+			changed {
+			return composed.PatchStatus(state.ObjAsVpcPeering()).
+				SetExclusiveConditions(condition).
+				ErrorLogMessage("Error updating VpcPeering status while waiting for AWS VPC peering pending-acceptance").
+				SuccessError(composed.StopAndForget).
+				Run(ctx, state)
+		}
+
+		return composed.StopAndForget, nil
+	}
+
+	// code initiating-request
+	if changed {
+		return composed.PatchStatus(state.ObjAsVpcPeering()).
+			ErrorLogMessage("Error setting KCP VpcPeering status state").
+			SuccessError(composed.StopWithRequeue).
+			Run(ctx, state)
+	}
+
+	return composed.StopWithRequeue, nil
+}

--- a/pkg/kcp/provider/aws/vpcpeering/waitVpcPeeringActive.go
+++ b/pkg/kcp/provider/aws/vpcpeering/waitVpcPeeringActive.go
@@ -20,8 +20,8 @@ func waitVpcPeeringActive(ctx context.Context, st composed.State) (error, contex
 
 		changed := false
 
-		if state.ObjAsVpcPeering().Status.State != string(ec2types.VpcPeeringConnectionStateReasonCodeInitiatingRequest) {
-			state.ObjAsVpcPeering().Status.State = string(ec2types.VpcPeeringConnectionStateReasonCodeInitiatingRequest)
+		if state.ObjAsVpcPeering().Status.State != string(state.vpcPeering.Status.Code) {
+			state.ObjAsVpcPeering().Status.State = string(state.vpcPeering.Status.Code)
 			changed = true
 		}
 
@@ -34,7 +34,7 @@ func waitVpcPeeringActive(ctx context.Context, st composed.State) (error, contex
 
 		if changed {
 			return composed.PatchStatus(state.ObjAsVpcPeering()).
-				ErrorLogMessage("Error patching KCP VpcPeering status when state initiating-request on wait peering active").
+				ErrorLogMessage("Error patching KCP VpcPeering status on waiting peering active").
 				SuccessError(composed.StopWithRequeueDelay(util.Timing.T1000ms())).
 				Run(ctx, state)
 		}


### PR DESCRIPTION
**Description**

According to AWS VPC Peering lifecycle VPC peering connection can only be accepted in certain stages.

Changes proposed in this pull request:

- fixes accepting connection reconciliation loop
- fixes deletion of connection that is in one of the terminating statuses
