### PR TITLE
fix(AwsVpcPeering): fixes deletion issues when role is unauthorized

### DIFF
--- a/pkg/kcp/provider/aws/vpcpeering/loadRemoteRouteTables.go
+++ b/pkg/kcp/provider/aws/vpcpeering/loadRemoteRouteTables.go
@@ -14,9 +14,19 @@ func loadRemoteRouteTables(ctx context.Context, st composed.State) (error, conte
 		return nil, nil
 	}
 
+	if state.remoteVpc == nil {
+		return nil, nil
+	}
+
 	routeTables, err := state.remoteClient.DescribeRouteTables(ctx, *state.remoteVpc.VpcId)
 
 	if err != nil {
+		if composed.IsMarkedForDeletion(state.Obj()) {
+			return composed.LogErrorAndReturn(err,
+				"Error loading AWS remote route tables but skipping as marked for deletion",
+				nil,
+				ctx)
+		}
 		return awsmeta.LogErrorAndReturn(err, "Error loading AWS remote route tables", ctx)
 	}
 

--- a/pkg/kcp/provider/aws/vpcpeering/loadRemoteVpcPeeringConnection.go
+++ b/pkg/kcp/provider/aws/vpcpeering/loadRemoteVpcPeeringConnection.go
@@ -25,6 +25,12 @@ func loadRemoteVpcPeeringConnection(ctx context.Context, st composed.State) (err
 	peering, err := state.remoteClient.DescribeVpcPeeringConnection(ctx, obj.Status.RemoteId)
 
 	if err != nil {
+		if composed.IsMarkedForDeletion(state.Obj()) {
+			return composed.LogErrorAndReturn(err,
+				"Error listing AWS peering connections but skipping as marked for deletion",
+				nil,
+				ctx)
+		}
 		return awsmeta.LogErrorAndReturn(err, "Error listing AWS peering connections", ctx)
 	}
 

--- a/pkg/kcp/provider/aws/vpcpeering/remotePeeringDelete.go
+++ b/pkg/kcp/provider/aws/vpcpeering/remotePeeringDelete.go
@@ -16,6 +16,7 @@ func remotePeeringDelete(ctx context.Context, st composed.State) (error, context
 	if !state.ObjAsVpcPeering().Spec.Details.DeleteRemotePeering {
 		return nil, nil
 	}
+
 	if state.remoteVpcPeering == nil {
 		logger.Info("VpcPeering deleted before AWS peering is created")
 		return nil, nil
@@ -32,17 +33,8 @@ func remotePeeringDelete(ctx context.Context, st composed.State) (error, context
 
 	err := state.remoteClient.DeleteVpcPeeringConnection(ctx, state.remoteVpcPeering.VpcPeeringConnectionId)
 
-	if err != nil {
-		if composed.IsMarkedForDeletion(state.Obj()) {
-			return composed.LogErrorAndReturn(err,
-				"Error deleting AWS VPC peering connection but skipping as marked for deletion",
-				nil,
-				ctx)
-		}
-
-		if awsmeta.IsErrorRetryable(err) {
-			return composed.StopWithRequeueDelay(util.Timing.T10000ms()), nil
-		}
+	if awsmeta.IsErrorRetryable(err) {
+		return composed.StopWithRequeueDelay(util.Timing.T10000ms()), nil
 	}
 
 	logger.Info("Remote VpcPeering deleted")


### PR DESCRIPTION
**Description**

This is the fix for the AwsVpcPeering deletion issue when Cloud Manager permissions are removed from remote account after VPC peering connection was already established. 

Steps to reproduce this issue would be:
- Assign appropriate Cloud Manager permissions in remote account
- Create AwsVpcPeering and wait to become Ready
- Remove the Cloud Manager permissions from remote account
- Delete AwsVpcPeering and observe that it doesn't get deleted.

Changes proposed in this pull request:

- fixes deletion issues when role is unauthorized