### PR TITLE
refactor(GcpNfsVolume): remove obsolete methods validateCapacity and validateFileShareName

### DIFF
--- a/pkg/skr/gcpnfsvolume/reconciler.go
+++ b/pkg/skr/gcpnfsvolume/reconciler.go
@@ -2,6 +2,7 @@ package gcpnfsvolume
 
 import (
 	"context"
+
 	"github.com/kyma-project/cloud-manager/pkg/skr/common/defaultiprange"
 
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
@@ -42,7 +43,7 @@ func (r *Reconciler) newAction() composed.Action {
 		composed.IfElse(EmptyLocationPredicate(), loadScope, nil),
 		composed.ComposeActions(
 			"crGcpNfsVolumeValidateSpec",
-			validateIpRange, validateFileShareName, validateCapacity, validatePV, validatePVC, validateLocation),
+			validateIpRange, validatePV, validatePVC, validateLocation),
 		setProcessing,
 		defaultiprange.New(),
 		addFinalizer,

--- a/pkg/skr/gcpnfsvolume/validateSpec.go
+++ b/pkg/skr/gcpnfsvolume/validateSpec.go
@@ -12,12 +12,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type capacityRange struct {
-	min        int
-	max        int
-	increments int
-}
-
 func validateIpRange(ctx context.Context, st composed.State) (error, context.Context) {
 	if composed.MarkedForDeletionPredicate(ctx, st) {
 		return nil, nil

--- a/pkg/skr/gcpnfsvolume/validateSpec.go
+++ b/pkg/skr/gcpnfsvolume/validateSpec.go
@@ -2,97 +2,20 @@ package gcpnfsvolume
 
 import (
 	"context"
-	"fmt"
+	"time"
+
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/kyma-project/cloud-manager/pkg/feature"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
-	"time"
 )
-
-func validateCapacity(ctx context.Context, st composed.State) (error, context.Context) {
-	state := st.(*State)
-	if composed.MarkedForDeletionPredicate(ctx, st) {
-		return nil, nil
-	}
-	// Capacity hasn't changed. No need to validate
-	if state.ObjAsGcpNfsVolume().Spec.CapacityGb == state.ObjAsGcpNfsVolume().Status.CapacityGb {
-		return nil, nil
-	}
-	tier := state.ObjAsGcpNfsVolume().Spec.Tier
-	capacity := state.ObjAsGcpNfsVolume().Spec.CapacityGb
-	switch tier {
-	case cloudresourcesv1beta1.BASIC_SSD, cloudresourcesv1beta1.PREMIUM:
-		return validateCapacityForTier(ctx, st, capacity, capacityRange{2560, 65400, 1})
-	case cloudresourcesv1beta1.HIGH_SCALE_SSD:
-		return validateCapacityForTier(ctx, st, capacity, capacityRange{10240, 102400, 1})
-	case cloudresourcesv1beta1.ZONAL:
-		return validateCapacityForTier(ctx, st, capacity, capacityRange{1024, 9984, 256}, capacityRange{10240, 102400, 2560})
-	case cloudresourcesv1beta1.ENTERPRISE:
-		return validateCapacityForTier(ctx, st, capacity, capacityRange{1024, 10240, 256})
-	case cloudresourcesv1beta1.REGIONAL:
-		return validateCapacityForTier(ctx, st, capacity, capacityRange{1024, 9984, 256}, capacityRange{10240, 102400, 2560})
-	case cloudresourcesv1beta1.BASIC_HDD, cloudresourcesv1beta1.STANDARD:
-		return validateCapacityForTier(ctx, st, capacity, capacityRange{1024, 65400, 1})
-	default:
-		state.ObjAsGcpNfsVolume().Status.State = cloudresourcesv1beta1.GcpNfsVolumeError
-		return composed.PatchStatus(state.ObjAsGcpNfsVolume()).
-			SetExclusiveConditions(metav1.Condition{
-				Type:    cloudresourcesv1beta1.ConditionTypeError,
-				Status:  metav1.ConditionTrue,
-				Reason:  cloudresourcesv1beta1.ConditionReasonTierInvalid,
-				Message: "Tier is not valid",
-			}).
-			ErrorLogMessage("Error updating GcpNfsVolume status with invalid capacity").
-			Run(ctx, state)
-	}
-}
 
 type capacityRange struct {
 	min        int
 	max        int
 	increments int
-}
-
-func validateCapacityForTier(ctx context.Context, st composed.State, capacity int, validRanges ...capacityRange) (error, context.Context) {
-	state := st.(*State)
-	valid := false
-	var rangesString []string
-	for _, validRange := range validRanges {
-		if capacity >= validRange.min && capacity <= validRange.max && (capacity-validRange.min)%validRange.increments == 0 {
-			valid = true
-		}
-		if validRange.increments == 1 {
-			rangesString = append(rangesString, fmt.Sprintf("%d to %d", validRange.min, validRange.max))
-		} else {
-			rangesString = append(rangesString, fmt.Sprintf("%d to %d scaling in increments of %d", validRange.min, validRange.max, validRange.increments))
-		}
-	}
-	if valid {
-		// Capacity is the only mutable field. If it succeeds, we should remove the error condition if the reason was invalid capacity
-		return composed.PatchStatus(state.ObjAsGcpNfsVolume()).
-			RemoveConditionIfReasonMatched(cloudresourcesv1beta1.ConditionTypeError, cloudresourcesv1beta1.ConditionReasonCapacityInvalid).
-			ErrorLogMessage("Error removing conditionType Error").
-			OnUpdateSuccess(func(ctx context.Context) (error, context.Context) {
-				return nil, nil
-			}).
-			Run(ctx, state)
-
-	} else {
-		state.ObjAsGcpNfsVolume().Status.State = cloudresourcesv1beta1.GcpNfsVolumeError
-		return composed.PatchStatus(state.ObjAsGcpNfsVolume()).
-			SetExclusiveConditions(metav1.Condition{
-				Type:    cloudresourcesv1beta1.ConditionTypeError,
-				Status:  metav1.ConditionTrue,
-				Reason:  cloudresourcesv1beta1.ConditionReasonCapacityInvalid,
-				Message: fmt.Sprintf("CapacityGb for this tier must be between %s", strings.Join(rangesString, " or ")),
-			}).
-			ErrorLogMessage("Error updating GcpNfsVolume status with invalid capacity").
-			Run(ctx, state)
-	}
 }
 
 func validateIpRange(ctx context.Context, st composed.State) (error, context.Context) {
@@ -156,49 +79,6 @@ func validateIpRange(ctx context.Context, st composed.State) (error, context.Con
 			return nil, nil
 		}).
 		Run(ctx, state)
-}
-
-func validateFileShareName(ctx context.Context, st composed.State) (error, context.Context) {
-	state := st.(*State)
-	if composed.MarkedForDeletionPredicate(ctx, st) {
-		return nil, nil
-	}
-	tier := state.ObjAsGcpNfsVolume().Spec.Tier
-	fileShareName := state.ObjAsGcpNfsVolume().Spec.FileShareName
-	switch tier {
-	case cloudresourcesv1beta1.BASIC_SSD, cloudresourcesv1beta1.PREMIUM, cloudresourcesv1beta1.BASIC_HDD, cloudresourcesv1beta1.STANDARD:
-		if len(fileShareName) > 16 {
-			state.ObjAsGcpNfsVolume().Status.State = cloudresourcesv1beta1.GcpNfsVolumeError
-			return composed.PatchStatus(state.ObjAsGcpNfsVolume()).
-				SetExclusiveConditions(metav1.Condition{
-					Type:    cloudresourcesv1beta1.ConditionTypeError,
-					Status:  metav1.ConditionTrue,
-					Reason:  cloudresourcesv1beta1.ConditionReasonFileShareNameInvalid,
-					Message: "FileShareName for this tier must be 16 characters or less",
-				}).
-				ErrorLogMessage("Error updating GcpNfsVolume status with invalid fileShareName").
-				Run(ctx, state)
-		} else {
-			// if validation succeeds, we don't need to update the status
-			return nil, nil
-		}
-	default:
-		if len(fileShareName) > 64 {
-			state.ObjAsGcpNfsVolume().Status.State = cloudresourcesv1beta1.GcpNfsVolumeError
-			return composed.PatchStatus(state.ObjAsGcpNfsVolume()).
-				SetExclusiveConditions(metav1.Condition{
-					Type:    cloudresourcesv1beta1.ConditionTypeError,
-					Status:  metav1.ConditionTrue,
-					Reason:  cloudresourcesv1beta1.ConditionReasonFileShareNameInvalid,
-					Message: "FileShareName for this tier must be 64 characters or less",
-				}).
-				ErrorLogMessage("Error updating GcpNfsVolume status with invalid fileShareName").
-				Run(ctx, state)
-		} else {
-			// if validation succeeds, we don't need to update the status
-			return nil, nil
-		}
-	}
 }
 
 func validateLocation(ctx context.Context, st composed.State) (error, context.Context) {

--- a/pkg/skr/gcpnfsvolume/validateSpec_test.go
+++ b/pkg/skr/gcpnfsvolume/validateSpec_test.go
@@ -2,6 +2,9 @@ package gcpnfsvolume
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/go-logr/logr"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
@@ -10,9 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
-	"testing"
-	"time"
 )
 
 type validateSpecSuite struct {
@@ -22,167 +22,6 @@ type validateSpecSuite struct {
 
 func (suite *validateSpecSuite) SetupTest() {
 	suite.ctx = log.IntoContext(context.Background(), logr.Discard())
-}
-
-func (suite *validateSpecSuite) TestDoNotValidateCapacity() {
-	factory, err := newTestStateFactory()
-	assert.Nil(suite.T(), err)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	state := factory.newState()
-
-	//Invoke validateSpec
-	err, _ctx := validateCapacity(ctx, state)
-	assert.Nil(suite.T(), err)
-	assert.Nil(suite.T(), _ctx)
-}
-
-func (suite *validateSpecSuite) TestValidCapacityBasicHDD() {
-	suite.checkCapacity(2049, cloudresourcesv1beta1.BASIC_HDD, true)
-}
-
-func (suite *validateSpecSuite) TestLowCapacityBasicHDD() {
-	suite.checkCapacity(600, cloudresourcesv1beta1.BASIC_HDD, false)
-}
-
-func (suite *validateSpecSuite) TestHighCapacityBasicHDD() {
-	suite.checkCapacity(66000, cloudresourcesv1beta1.BASIC_HDD, false)
-}
-
-func (suite *validateSpecSuite) TestValidCapacityBasicSSD() {
-	suite.checkCapacity(2561, cloudresourcesv1beta1.BASIC_SSD, true)
-}
-
-func (suite *validateSpecSuite) TestLowCapacityBasicSSD() {
-	suite.checkCapacity(512, cloudresourcesv1beta1.BASIC_SSD, false)
-}
-
-func (suite *validateSpecSuite) TestHighCapacityBasicSSD() {
-	suite.checkCapacity(66000, cloudresourcesv1beta1.BASIC_SSD, false)
-}
-
-func (suite *validateSpecSuite) TestValidCapacityHighScaleSSD() {
-	suite.checkCapacity(10240, cloudresourcesv1beta1.HIGH_SCALE_SSD, true)
-}
-
-func (suite *validateSpecSuite) TestLowCapacityHighScaleSSD() {
-	suite.checkCapacity(2560, cloudresourcesv1beta1.HIGH_SCALE_SSD, false)
-}
-
-func (suite *validateSpecSuite) TestHighCapacityHighScaleSSD() {
-	suite.checkCapacity(120000, cloudresourcesv1beta1.HIGH_SCALE_SSD, false)
-}
-
-func (suite *validateSpecSuite) TestValidCapacityEnterprise() {
-	suite.checkCapacity(2560, cloudresourcesv1beta1.ENTERPRISE, true)
-}
-
-func (suite *validateSpecSuite) TestLowCapacityEnterprise() {
-	suite.checkCapacity(512, cloudresourcesv1beta1.ENTERPRISE, false)
-}
-
-func (suite *validateSpecSuite) TestHighCapacityEnterprise() {
-	suite.checkCapacity(120000, cloudresourcesv1beta1.ENTERPRISE, false)
-}
-
-func (suite *validateSpecSuite) TestValidCapacityLowZonal() {
-	suite.checkCapacity(2560, cloudresourcesv1beta1.ZONAL, true)
-}
-
-func (suite *validateSpecSuite) TestValidCapacityHighZonal() {
-	suite.checkCapacity(20480, cloudresourcesv1beta1.ZONAL, true)
-}
-
-func (suite *validateSpecSuite) TestLowCapacityZonal() {
-	suite.checkCapacity(512, cloudresourcesv1beta1.ZONAL, false)
-}
-
-func (suite *validateSpecSuite) TestHighCapacityZonal() {
-	suite.checkCapacity(102401, cloudresourcesv1beta1.ZONAL, false)
-}
-
-func (suite *validateSpecSuite) TestMediumCapacityZonal() {
-	suite.checkCapacity(10000, cloudresourcesv1beta1.ZONAL, false)
-}
-
-func (suite *validateSpecSuite) TestLowCapacityZonalBadIncrement() {
-	suite.checkCapacity(1233, cloudresourcesv1beta1.ZONAL, false)
-}
-
-func (suite *validateSpecSuite) TestHighCapacityZonalBadIncrement() {
-	suite.checkCapacity(20483, cloudresourcesv1beta1.ZONAL, false)
-}
-
-func (suite *validateSpecSuite) TestLowCapacityRegionalBadIncrement() {
-	suite.checkCapacity(1233, cloudresourcesv1beta1.REGIONAL, false)
-}
-
-func (suite *validateSpecSuite) TestHighCapacityRegionalBadIncrement() {
-	suite.checkCapacity(20483, cloudresourcesv1beta1.REGIONAL, false)
-}
-
-func (suite *validateSpecSuite) TestCapacityEnterpriseBadIncrement() {
-	suite.checkCapacity(1233, cloudresourcesv1beta1.ENTERPRISE, false)
-}
-
-func (suite *validateSpecSuite) TestInvalidTier() {
-	suite.checkCapacity(2048, "UNSPECIFIED", false)
-}
-
-func (suite *validateSpecSuite) checkCapacity(capacityGb int, tier cloudresourcesv1beta1.GcpFileTier, valid bool) {
-	factory, err := newTestStateFactory()
-	assert.Nil(suite.T(), err)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	//Set the capacity in GcpNfsVolume spec
-	nfsVol := gcpNfsVolume.DeepCopy()
-	nfsVol.Spec.Tier = tier
-	nfsVol.Spec.CapacityGb = capacityGb
-
-	err = factory.skrCluster.K8sClient().Update(ctx, nfsVol)
-	assert.Nil(suite.T(), err)
-
-	//Update Status and remove conditions.
-	nfsVol.Status.Conditions = nil
-	err = factory.skrCluster.K8sClient().Status().Update(ctx, nfsVol)
-	assert.Nil(suite.T(), err)
-
-	state := factory.newStateWith(nfsVol)
-
-	//Invoke validateSpec
-	err, _ = validateCapacity(ctx, state)
-
-	//validate expected return values
-	if valid {
-		assert.Nil(suite.T(), err)
-	} else {
-		assert.Equal(suite.T(), composed.StopAndForget, err)
-	}
-
-	//Get the modified GcpNfsVolume object
-	nfsVol = &cloudresourcesv1beta1.GcpNfsVolume{}
-	err = factory.skrCluster.K8sClient().Get(ctx,
-		types.NamespacedName{Name: gcpNfsVolume.Name, Namespace: gcpNfsVolume.Namespace}, nfsVol)
-	assert.Nil(suite.T(), err)
-
-	//Validate GcpNfsVolume status.
-	if valid {
-		assert.Equal(suite.T(), 0, len(nfsVol.Status.Conditions))
-	} else {
-		assert.Equal(suite.T(), metav1.ConditionTrue, nfsVol.Status.Conditions[0].Status)
-		assert.Equal(suite.T(), cloudresourcesv1beta1.ConditionTypeError, nfsVol.Status.Conditions[0].Type)
-		if tier == "UNSPECIFIED" {
-			assert.Equal(suite.T(), cloudresourcesv1beta1.ConditionReasonTierInvalid, nfsVol.Status.Conditions[0].Reason)
-
-		} else {
-			assert.Equal(suite.T(), cloudresourcesv1beta1.ConditionReasonCapacityInvalid, nfsVol.Status.Conditions[0].Reason)
-		}
-	}
-
 }
 
 func (suite *validateSpecSuite) TestIpRangeWhenNotExist() {
@@ -304,71 +143,6 @@ func (suite *validateSpecSuite) TestIpRangeWhenReady() {
 
 	//Validate GcpNfsVolume status.
 	assert.Nil(suite.T(), nfsVol.Status.Conditions)
-}
-
-func (suite *validateSpecSuite) checkFileShare(fsName string, tier cloudresourcesv1beta1.GcpFileTier, valid bool) {
-	factory, err := newTestStateFactory()
-	assert.Nil(suite.T(), err)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	//Set the fileShareName in GcpNfsVolume spec
-	nfsVol := gcpNfsVolume.DeepCopy()
-	nfsVol.Spec.FileShareName = fsName
-	nfsVol.Spec.Tier = tier
-
-	err = factory.skrCluster.K8sClient().Update(ctx, nfsVol)
-	assert.Nil(suite.T(), err)
-
-	//Update Status and remove conditions.
-	nfsVol.Status.Conditions = nil
-	err = factory.skrCluster.K8sClient().Status().Update(ctx, nfsVol)
-	assert.Nil(suite.T(), err)
-
-	state := factory.newStateWith(nfsVol)
-
-	//Invoke validateSpec
-	err, _ = validateFileShareName(ctx, state)
-
-	//validate expected return values
-	if valid {
-		assert.Nil(suite.T(), err)
-	} else {
-		assert.Equal(suite.T(), composed.StopAndForget, err)
-	}
-
-	//Get the modified GcpNfsVolume object
-	nfsVol = &cloudresourcesv1beta1.GcpNfsVolume{}
-	err = factory.skrCluster.K8sClient().Get(ctx,
-		types.NamespacedName{Name: gcpNfsVolume.Name, Namespace: gcpNfsVolume.Namespace}, nfsVol)
-	assert.Nil(suite.T(), err)
-
-	//Validate GcpNfsVolume status.
-	if valid {
-		assert.Equal(suite.T(), 0, len(nfsVol.Status.Conditions))
-	} else {
-		assert.Equal(suite.T(), metav1.ConditionTrue, nfsVol.Status.Conditions[0].Status)
-		assert.Equal(suite.T(), cloudresourcesv1beta1.ConditionTypeError, nfsVol.Status.Conditions[0].Type)
-		assert.Equal(suite.T(), cloudresourcesv1beta1.ConditionReasonFileShareNameInvalid, nfsVol.Status.Conditions[0].Reason)
-		assert.Equal(suite.T(), cloudresourcesv1beta1.GcpNfsVolumeError, nfsVol.Status.State)
-	}
-}
-
-func (suite *validateSpecSuite) TestValidFileShareSSD() {
-	suite.checkFileShare("vol1", cloudresourcesv1beta1.BASIC_SSD, true)
-}
-
-func (suite *validateSpecSuite) TestInvalidFileShareSSD() {
-	suite.checkFileShare("abcdefghijklmnopqrstuvwxyz", cloudresourcesv1beta1.BASIC_SSD, false)
-}
-
-func (suite *validateSpecSuite) TestValidFileShareEnterprise() {
-	suite.checkFileShare("abcdefghijklmnopqrstuvwxyz", cloudresourcesv1beta1.ENTERPRISE, true)
-}
-func (suite *validateSpecSuite) TestInvalidFileShareEnterprise() {
-	name := strings.Repeat("abcdefghij1234567890", 4)
-	suite.checkFileShare(name, cloudresourcesv1beta1.ENTERPRISE, false)
 }
 
 func (suite *validateSpecSuite) checkTier(tier cloudresourcesv1beta1.GcpFileTier, valid bool) {


### PR DESCRIPTION


<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- remove obsolete methods `validateCapacity` and `validateFileShareName`
- validation was moved to API level with this PR https://github.com/kyma-project/cloud-manager/pull/791

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
