### PR TITLE
fix: kcp kyma network delete

### DIFF
--- a/internal/controller/cloud-control/network_reference_test.go
+++ b/internal/controller/cloud-control/network_reference_test.go
@@ -2,6 +2,7 @@ package cloudcontrol
 
 import (
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/common"
 	kcpiprange "github.com/kyma-project/cloud-manager/pkg/kcp/iprange"
 	scopePkg "github.com/kyma-project/cloud-manager/pkg/kcp/scope"
 	kcpvpcpeering "github.com/kyma-project/cloud-manager/pkg/kcp/vpcpeering"
@@ -379,4 +380,32 @@ var _ = Describe("Feature: KCP Network reference", func() {
 		})
 	})
 
+	It("Scenario: kyma Network reference will delete itself if its Scope does not exist", func() {
+		// doesn't exist
+		kymaName := "eb3aac05-dac0-4e99-924c-dbb717935b6d"
+		netObjName := common.KcpNetworkKymaCommonName(kymaName)
+		var net *cloudcontrolv1beta1.Network
+
+		awsAccount := "acc-123123"
+		awsRegion := "us-east-1"
+		netId := "net-345123"
+		netName := "my-net"
+
+		By("Given Scope does not exist", func() {})
+
+		By("When kyma Network reference is created", func() {
+			net = cloudcontrolv1beta1.NewNetworkBuilder().
+				WithType(cloudcontrolv1beta1.NetworkTypeKyma).
+				WithAwsRef(awsAccount, awsRegion, netId, netName).
+				Build()
+			Expect(CreateObj(infra.Ctx(), infra.KCP().Client(), net, WithName(netObjName), WithScope(kymaName))).
+				To(Succeed())
+		})
+
+		By("Then kyma Network reference does not exist", func() {
+			Eventually(IsDeleted).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), net).
+				Should(Succeed())
+		})
+	})
 })

--- a/pkg/common/actions/focal/loadKyma.go
+++ b/pkg/common/actions/focal/loadKyma.go
@@ -13,7 +13,7 @@ func loadKyma(ctx context.Context, st composed.State) (error, context.Context) {
 	logger := composed.LoggerFromCtx(ctx)
 
 	if state.Scope() == nil || len(state.Scope().Name) == 0 {
-		return nil, nil
+		return nil, ctx
 	}
 
 	kyma := util.NewKymaUnstructured()

--- a/pkg/common/actions/focal/new.go
+++ b/pkg/common/actions/focal/new.go
@@ -1,6 +1,9 @@
 package focal
 
-import "github.com/kyma-project/cloud-manager/pkg/composed"
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+)
 
 func New() composed.Action {
 	return composed.ComposeActions(
@@ -9,5 +12,20 @@ func New() composed.Action {
 		loadScopeFromRef,
 		loadKyma,
 		loadFeatureContext,
+	)
+}
+
+// NewWithOptionalScope is handling a special case KCP kyma Network
+// when it should be able to delete itself in case the Scope is deleted.
+// Restrain yourself from using this function.
+func NewWithOptionalScope() composed.Action {
+	return composed.ComposeActions(
+		"focalOptionalScope",
+		func(ctx context.Context, st composed.State) (error, context.Context) {
+			state := st.(State)
+			state.setScopeOptional()
+			return nil, ctx
+		},
+		New(),
 	)
 }

--- a/pkg/common/actions/focal/state.go
+++ b/pkg/common/actions/focal/state.go
@@ -13,6 +13,9 @@ type State interface {
 	Kyma() *unstructured.Unstructured
 	SetKyma(u *unstructured.Unstructured)
 	ObjAsCommonObj() CommonObject
+
+	setScopeOptional()
+	isScopeOptional() bool
 }
 
 type StateFactory interface {
@@ -38,6 +41,8 @@ type state struct {
 
 	scope *cloudcontrolv1beta1.Scope
 	kyma  *unstructured.Unstructured
+
+	_optionalScope bool
 }
 
 func (s *state) Scope() *cloudcontrolv1beta1.Scope {
@@ -58,4 +63,12 @@ func (s *state) SetKyma(u *unstructured.Unstructured) {
 
 func (s *state) ObjAsCommonObj() CommonObject {
 	return s.Obj().(CommonObject)
+}
+
+func (s *state) isScopeOptional() bool {
+	return s._optionalScope
+}
+
+func (s *state) setScopeOptional() {
+	s._optionalScope = true
 }

--- a/pkg/kcp/network/logLogicalErrorOnManagedNetworkMissing.go
+++ b/pkg/kcp/network/logLogicalErrorOnManagedNetworkMissing.go
@@ -3,7 +3,10 @@ package network
 import (
 	"context"
 	"errors"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // logLogicalErrorOnManagedNetworkMissing is a logical safeguard that is protecting the flow. All network references
@@ -12,6 +15,23 @@ import (
 func logLogicalErrorOnManagedNetworkMissing(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*state)
 	logger := composed.LoggerFromCtx(ctx)
+
+	if state.Scope() == nil || state.Scope().Name == "" {
+		err := errors.New("scope not found")
+		logger.Error(err, "Logical error")
+		state.ObjAsNetwork().Status.State = string(cloudcontrolv1beta1.ErrorState)
+		return composed.PatchStatus(state.ObjAsNetwork()).
+			SetExclusiveConditions(metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  cloudcontrolv1beta1.ReasonScopeNotFound,
+				Message: "Scope not found",
+			}).
+			ErrorLogMessage("Error patching KCP Network status with scope not found condition").
+			SuccessError(composed.StopAndForget).
+			FailedError(composed.StopWithRequeueDelay(util.Timing.T10000ms())).
+			Run(ctx, state)
+	}
 
 	if state.ObjAsNetwork().Spec.Network.Managed == nil {
 		err := errors.New("expected managed network, but none is present in state")

--- a/pkg/kcp/network/reconciler.go
+++ b/pkg/kcp/network/reconciler.go
@@ -59,7 +59,7 @@ func (r *networkReconciler) newAction() composed.Action {
 	return composed.ComposeActions(
 		"main",
 		feature.LoadFeatureContextFromObj(&cloudcontrolv1beta1.Network{}),
-		focal.New(),
+		focal.NewWithOptionalScope(),
 		func(ctx context.Context, st composed.State) (error, context.Context) {
 			return composed.ComposeActions(
 				"networkCommon",

--- a/pkg/kcp/scope/kymaNetworkReferenceCreate.go
+++ b/pkg/kcp/scope/kymaNetworkReferenceCreate.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func createKymaNetworkReference(ctx context.Context, st composed.State) (error, context.Context) {
+func kymaNetworkReferenceCreate(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
 
 	if state.kcpNetworkKyma != nil {

--- a/pkg/kcp/scope/kymaNetworkReferenceDelete.go
+++ b/pkg/kcp/scope/kymaNetworkReferenceDelete.go
@@ -1,0 +1,29 @@
+package scope
+
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func kymaNetworkReferenceDelete(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+
+	if state.kcpNetworkKyma == nil {
+		return nil, ctx
+	}
+	if !state.kcpNetworkKyma.DeletionTimestamp.IsZero() {
+		return nil, ctx
+	}
+
+	logger := composed.LoggerFromCtx(ctx)
+	logger.Info("Deleting Kyma Network Reference")
+
+	err := state.Cluster().K8sClient().Delete(ctx, state.kcpNetworkKyma)
+	if client.IgnoreNotFound(err) != nil {
+		return composed.LogErrorAndReturn(err, "Error deleting KCP kyma Network reference", composed.StopWithRequeueDelay(util.Timing.T10000ms()), ctx)
+	}
+
+	return nil, ctx
+}

--- a/pkg/kcp/scope/reconciler.go
+++ b/pkg/kcp/scope/reconciler.go
@@ -108,7 +108,7 @@ func (r *scopeReconciler) newAction() composed.Action {
 				loadGardenerCredentials,
 				scopeCreate,
 				ensureScopeCommonFields,
-				saveScope,
+				scopeSave,
 				kymaNetworkReferenceCreate,
 			),
 

--- a/pkg/kcp/scope/reconciler.go
+++ b/pkg/kcp/scope/reconciler.go
@@ -86,6 +86,8 @@ func (r *scopeReconciler) newAction() composed.Action {
 			predicateShouldDisable(),
 			removeKymaFinalizer,
 			skrDeactivate,
+			kymaNetworkReferenceDelete,
+			scopeDelete,
 			composed.StopAndForgetAction,
 		),
 
@@ -104,10 +106,10 @@ func (r *scopeReconciler) newAction() composed.Action {
 				findShootName,
 				loadShoot,
 				loadGardenerCredentials,
-				createScope,
+				scopeCreate,
 				ensureScopeCommonFields,
 				saveScope,
-				createKymaNetworkReference,
+				kymaNetworkReferenceCreate,
 			),
 
 			enableApis,

--- a/pkg/kcp/scope/scopeCreate.go
+++ b/pkg/kcp/scope/scopeCreate.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func createScope(ctx context.Context, st composed.State) (error, context.Context) {
+func scopeCreate(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
 
 	switch state.provider {

--- a/pkg/kcp/scope/scopeDelete.go
+++ b/pkg/kcp/scope/scopeDelete.go
@@ -1,0 +1,32 @@
+package scope
+
+import (
+	"context"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+)
+
+func scopeDelete(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	logger := composed.LoggerFromCtx(ctx)
+
+	if state.moduleState != util.KymaModuleStateNotPresent {
+		return nil, nil
+	}
+	if state.ObjAsScope() == nil || state.ObjAsScope().GetName() == "" {
+		return nil, nil
+	}
+
+	logger.Info("Deleting Scope")
+
+	if _, err := state.PatchObjRemoveFinalizer(ctx, cloudcontrolv1beta1.FinalizerName); err != nil {
+		return composed.LogErrorAndReturn(err, "Error updating Scope after finalizer removed", composed.StopWithRequeue, ctx)
+	}
+
+	if err := state.Cluster().K8sClient().Delete(ctx, state.Obj()); err != nil {
+		return composed.LogErrorAndReturn(err, "Error deleting Scope", composed.StopWithRequeue, ctx)
+	}
+
+	return nil, ctx
+}

--- a/pkg/kcp/scope/scopeSave.go
+++ b/pkg/kcp/scope/scopeSave.go
@@ -5,7 +5,7 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 )
 
-func saveScope(ctx context.Context, st composed.State) (error, context.Context) {
+func scopeSave(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
 
 	if state.Obj().GetResourceVersion() != "" {

--- a/pkg/kcp/scope/skrDeactivate.go
+++ b/pkg/kcp/scope/skrDeactivate.go
@@ -2,10 +2,8 @@ package scope
 
 import (
 	"context"
-	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/kyma-project/cloud-manager/pkg/util"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func skrDeactivate(ctx context.Context, st composed.State) (error, context.Context) {
@@ -19,20 +17,9 @@ func skrDeactivate(ctx context.Context, st composed.State) (error, context.Conte
 		return nil, nil
 	}
 
-	logger.Info("Stopping SKR and deleting Scope")
+	logger.Info("Stopping SKR")
 
 	state.activeSkrCollection.RemoveScope(state.ObjAsScope())
 
-	finalizerRemoved := controllerutil.RemoveFinalizer(state.Obj(), cloudcontrolv1beta1.FinalizerName)
-	if finalizerRemoved {
-		if err := state.UpdateObj(ctx); err != nil {
-			return composed.LogErrorAndReturn(err, "Error updating Scope after finalizer removed", composed.StopWithRequeue, ctx)
-		}
-	}
-
-	if err := state.Cluster().K8sClient().Delete(ctx, state.Obj()); err != nil {
-		return composed.LogErrorAndReturn(err, "Error deleting Scope", composed.StopWithRequeue, ctx)
-	}
-
-	return composed.StopAndForget, nil
+	return nil, ctx
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Issue #853 

Changes proposed in this pull request:

- added to the KCP Network reconciler a step that will delete the KCP Network if Scope does not exist
- added to the KCP Scope reconciler a step that will delete the KCP Network
- refactored in the KCP Scope reconciler out of the `skrDeactivate` a part that deletes Scope into own separate action `scopeDelete`
- renamed in the KCP Scope w/out changes:
  - `createKymaNetworkReference` to `kymaNetworkReferenceCreate`
  - `createScope` to `scopeCreate`
  - `saveScope` to `scopeSave`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
