### PR TITLE
fix(AzureVpcPeering): handles Azure error InvalidAuthenticationTokenTenant

### DIFF
--- a/internal/controller/cloud-control/vpcpeering_azure_test.go
+++ b/internal/controller/cloud-control/vpcpeering_azure_test.go
@@ -600,7 +600,7 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 					NewObjActions(),
 					HavingCondition(cloudcontrolv1beta1.ConditionTypeError,
 						metav1.ConditionTrue,
-						cloudcontrolv1beta1.ReasonFailedCreatingVpcPeeringConnection,
+						cloudcontrolv1beta1.ReasonUnauthorized,
 						"Not authorized to perform action."),
 				).
 				Should(Succeed())

--- a/pkg/kcp/provider/azure/meta/metadata.go
+++ b/pkg/kcp/provider/azure/meta/metadata.go
@@ -3,7 +3,6 @@ package meta
 import (
 	"context"
 	"errors"
-	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/kyma-project/cloud-manager/pkg/util"
@@ -24,6 +23,8 @@ const (
 	InvalidResourceNameMessage                           = "Resource name is invalid. The name can be up to 80 characters long. It must begin with a word character, and it must end with a word character. The name may contain word characters or '.', '-'."
 	VnetAddressSpacesOverlap                             = "VnetAddressSpacesOverlap"
 	VnetAddressSpacesOverlapMessage                      = "Cannot create or update peering. Virtual networks cannot be peered because their address spaces overlap. "
+	InvalidAuthenticationTokenTenant                     = "InvalidAuthenticationTokenTenant"
+	InvalidAuthenticationTokenTenantMessage              = "Authentication failed"
 )
 
 func IsTooManyRequests(err error) bool {
@@ -88,7 +89,7 @@ func LogErrorAndReturn(err error, msg string, ctx context.Context) (error, conte
 	return composed.LogErrorAndReturn(err, msg, result, ctx)
 }
 
-func GetErrorMessage(err error) (string, bool) {
+func GetErrorMessage(err error, def string) (string, bool) {
 	var respErr *azcore.ResponseError
 
 	if errors.As(err, &respErr) {
@@ -106,8 +107,10 @@ func GetErrorMessage(err error) (string, bool) {
 		case VnetAddressSpacesOverlap:
 			r := regexp.MustCompile(`Overlapping address prefixes:[^\"]*`)
 			return VnetAddressSpacesOverlapMessage + r.FindString(respErr.Error()), true
+		case InvalidAuthenticationTokenTenant:
+			return InvalidAuthenticationTokenTenantMessage, true
 		}
 	}
 
-	return fmt.Sprintf("Failed creating VpcPeerings %s", err), false
+	return def, false
 }

--- a/pkg/kcp/provider/azure/vpcpeering/peeringLocalCreate.go
+++ b/pkg/kcp/provider/azure/vpcpeering/peeringLocalCreate.go
@@ -38,7 +38,7 @@ func peeringLocalCreate(ctx context.Context, st composed.State) (error, context.
 			)
 		}
 
-		message, isWarning := azuremeta.GetErrorMessage(err)
+		message, isWarning := azuremeta.GetErrorMessage(err, "Error creating VPC peering")
 
 		changed := false
 

--- a/pkg/kcp/provider/azure/vpcpeering/peeringRemoteCreate.go
+++ b/pkg/kcp/provider/azure/vpcpeering/peeringRemoteCreate.go
@@ -39,7 +39,7 @@ func peeringRemoteCreate(ctx context.Context, st composed.State) (error, context
 			)
 		}
 
-		message, isWarning := azuremeta.GetErrorMessage(err)
+		message, isWarning := azuremeta.GetErrorMessage(err, "Error creating remote VPC peering")
 
 		if isWarning {
 			state.ObjAsVpcPeering().Status.State = string(cloudcontrolv1beta1.StateWarning)

--- a/pkg/kcp/provider/azure/vpcpeering/vpcRemoteLoad.go
+++ b/pkg/kcp/provider/azure/vpcpeering/vpcRemoteLoad.go
@@ -23,7 +23,7 @@ func vpcRemoteLoad(ctx context.Context, st composed.State) (error, context.Conte
 	if err != nil {
 		logger.Error(err, "Error loading remote network")
 
-		message, isWarning := azuremeta.GetErrorMessage(err)
+		message, isWarning := azuremeta.GetErrorMessage(err, "Error loading remote network")
 
 		successError := composed.StopWithRequeueDelay(util.Timing.T60000ms())
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- handles Azure error InvalidAuthenticationTokenTenant and hides API error from the user

**Related issue(s)**
#892 