### PR TITLE
chore(AzureVpcPeering): skip status update while waiting local peering connected

### DIFF
--- a/internal/controller/cloud-control/vpcpeering_azure_test.go
+++ b/internal/controller/cloud-control/vpcpeering_azure_test.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-var _ = Describe("Feature: KCP VpcPeering", Focus, func() {
+var _ = Describe("Feature: KCP VpcPeering", func() {
 
 	It("Scenario: KCP Azure VpcPeering is created and deleted", func() {
 		const (

--- a/pkg/kcp/provider/azure/vpcpeering/peeringLocalWaitReady.go
+++ b/pkg/kcp/provider/azure/vpcpeering/peeringLocalWaitReady.go
@@ -3,10 +3,8 @@ package vpcpeering
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
-	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/kyma-project/cloud-manager/pkg/util"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/utils/ptr"
 )
 
@@ -14,39 +12,12 @@ func peeringLocalWaitReady(ctx context.Context, st composed.State) (error, conte
 	state := st.(*State)
 	logger := composed.LoggerFromCtx(ctx)
 
-	if state.localPeering == nil {
-		return composed.StopWithRequeue, nil
+	if state.localPeering != nil &&
+		ptr.Deref(state.localPeering.Properties.PeeringState, "") == armnetwork.VirtualNetworkPeeringStateConnected {
+		return nil, nil
 	}
 
-	if ptr.Deref(state.localPeering.Properties.PeeringState, "") != armnetwork.VirtualNetworkPeeringStateConnected {
-		logger.Info("Waiting for peering Connected state",
-			"azureLocalPeeringId", ptr.Deref(state.localPeering.ID, ""),
-			"azurePeeringState", ptr.Deref(state.localPeering.Properties.PeeringState, ""))
+	logger.Info("Waiting for peering Connected state")
 
-		changed := false
-
-		if state.ObjAsVpcPeering().Status.State != cloudcontrolv1beta1.VirtualNetworkPeeringStateInitiated {
-			state.ObjAsVpcPeering().Status.State = cloudcontrolv1beta1.VirtualNetworkPeeringStateInitiated
-			changed = true
-		}
-
-		if meta.RemoveStatusCondition(state.ObjAsVpcPeering().Conditions(), cloudcontrolv1beta1.ConditionTypeError) {
-			changed = true
-		}
-		if meta.RemoveStatusCondition(state.ObjAsVpcPeering().Conditions(), cloudcontrolv1beta1.ConditionTypeReady) {
-			changed = true
-		}
-
-		if changed {
-			return composed.PatchStatus(state.ObjAsVpcPeering()).
-				ErrorLogMessage("Error patching KCP VpcPeering status when state initiated on wait peering connected").
-				SuccessError(composed.StopWithRequeueDelay(util.Timing.T1000ms())).
-				Run(ctx, state)
-		}
-
-		// azure peering connects quickly so we're aggressive and requeue with small delay
-		return composed.StopWithRequeueDelay(util.Timing.T1000ms()), nil
-	}
-
-	return nil, nil
+	return composed.StopWithRequeueDelay(util.Timing.T1000ms()), nil
 }


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:
- skip status update while waiting local peering connected

Related issues: #896 