### PR TITLE
fix: nuke does not requeue when no scope

### DIFF
--- a/pkg/kcp/nuke/reconciler.go
+++ b/pkg/kcp/nuke/reconciler.go
@@ -51,7 +51,7 @@ func (r *nukeReconciler) newAction() composed.Action {
 	return composed.ComposeActions(
 		"nukeMain",
 		feature.LoadFeatureContextFromObj(&cloudcontrolv1beta1.Nuke{}),
-		focal.New(),
+		focal.NewWithOptionalScope(),
 		composed.If(
 			// if Nuke not marked for deletion
 			composed.Not(composed.MarkedForDeletionPredicate),


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- use `focal.NewWithOptionalScope()` so that case when there's no Scope is gracefully handled

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
