### PR TITLE
fix: Scope finalizer do not add finalizer to Kyma being deleted

### DIFF
--- a/pkg/composed/bridge.go
+++ b/pkg/composed/bridge.go
@@ -3,8 +3,15 @@ package composed
 import (
 	"context"
 	"errors"
+	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
+
+func HandleWithoutLogging(err error, ctx context.Context) (ctrl.Result, error) {
+	logger := logr.Discard()
+	ctx = LoggerIntoCtx(ctx, logger)
+	return Handle(err, ctx)
+}
 
 func Handle(err error, ctx context.Context) (ctrl.Result, error) {
 	logger := LoggerFromCtx(ctx)

--- a/pkg/kcp/scope/addKymaFinalizer.go
+++ b/pkg/kcp/scope/addKymaFinalizer.go
@@ -12,7 +12,12 @@ func addKymaFinalizer(ctx context.Context, st composed.State) (error, context.Co
 
 	if !state.ObjAsScope().DeletionTimestamp.IsZero() {
 		// Scope is being deleted
-		return nil, nil
+		return nil, ctx
+	}
+
+	if !state.kyma.GetDeletionTimestamp().IsZero() {
+		// kyma is being deleted - it has deletionTimestamp and finalizer can not be added in that state
+		return nil, ctx
 	}
 
 	added, err := composed.PatchObjAddFinalizer(ctx, cloudcontrolv1beta1.FinalizerName, state.kyma, state.Cluster().K8sClient())

--- a/pkg/kcp/scope/reconciler.go
+++ b/pkg/kcp/scope/reconciler.go
@@ -48,7 +48,13 @@ func (r *scopeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	state := r.newState(req)
 	action := r.newAction()
 
-	return composed.Handle(action(ctx, state))
+	// Scope reconciler is triggered very often due to KLM constant changes on watched Kyma
+	// HandleWithoutLogging should be used, so no reconciliation outcome is logged since it most cases
+	// the reconciler will do nothing since no change regarding CloudManager was done on Kyma
+	// so it will just produce an unnecessary log entry "Reconciliation finished without control error - doing stop and forget"
+	// To accommodate this non-functional requirement to keep logs tidy and prevent excessive and not so usable log entries
+	// in cases when Scope actually did something we have to accept the discomfort of not having this log entry
+	return composed.HandleWithoutLogging(action(ctx, state))
 }
 
 func (r *scopeReconciler) newState(req ctrl.Request) *State {


### PR DESCRIPTION
+ prevent overwhelming reconciler outcome log entries when Scope did nothing

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Scope reconciler do not add finalizer when Kyma has deletionTimestamp to prevent error message `Kyma.operator.kyma-project.io "xxxx" is invalid: metadata.finalizers: Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers []string{"cloud-control.kyma-project.io/deletion-hook"}`
- do not log Scope reconciler outcome to avoid majority of produced logs when Scope did nothing due to frequent KLM changes to Kyma

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
