### PR TITLE
fix(BackupSchedule): flaky test

### DIFF
--- a/pkg/skr/backupschedule/evaluateNextRun_test.go
+++ b/pkg/skr/backupschedule/evaluateNextRun_test.go
@@ -130,7 +130,7 @@ func (suite *evaluateNextRunSuite) TestWhenNextRunTimeIsNotDueYet() {
 	delay := result.RequeueAfter
 	suite.Nil(err)
 	suite.NotNil(delay)
-	suite.Greater(delay, time.Duration(0))
+	suite.Greater(delay, time.Duration(int64(0.95 * float64(offset))))
 	suite.LessOrEqual(delay, offset)
 }
 

--- a/pkg/skr/backupschedule/evaluateNextRun_test.go
+++ b/pkg/skr/backupschedule/evaluateNextRun_test.go
@@ -126,7 +126,12 @@ func (suite *evaluateNextRunSuite) TestWhenNextRunTimeIsNotDueYet() {
 	err, _ = evaluateNextRun(ctx, state)
 
 	//validate expected return values
-	suite.Equal(composed.StopWithRequeueDelay(offset), err)
+	result, err := composed.HandleWithoutLogging(err, ctx)
+	delay := result.RequeueAfter
+	suite.Nil(err)
+	suite.NotNil(delay)
+	suite.Greater(delay, time.Duration(0))
+	suite.LessOrEqual(delay, offset)
 }
 
 func (suite *evaluateNextRunSuite) TestWhenScheduleJustRun() {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Fix for occasional failure of test evaluateNextRun.TestWhenNextRunTimeIsNotDueYet()


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #988