### PR TITLE
docs(VpcPeering): improve tutorial to identify correct principals

### DIFF
--- a/docs/user/resources/04-30-10-aws-vpc-peering.md
+++ b/docs/user/resources/04-30-10-aws-vpc-peering.md
@@ -14,8 +14,8 @@ Cloud Manager uses [`AssumeRole`](https://awscli.amazonaws.com/v2/documentation/
 
 Use the following table to identify Cloud Manager principal based on your Kyma landscape:
 
-| BTP cockpit URL                    | Kyma dashboard URL                     | Cloud Manager principal                                    |
-|------------------------------------|----------------------------------------|------------------------------------------------------------|
+| BTP cockpit URL                    | Kyma dashboard URL                     | Cloud Manager principal ARN                                  |
+|------------------------------------|----------------------------------------|--------------------------------------------------------------|
 | https://canary.cockpit.btp.int.sap | https://dashboard.stage.kyma.cloud.sap | `arn:aws:iam::194230256199:user/cloud-manager-peering-stage` |
 | https://emea.cockpit.btp.cloud.sap | https://dashboard.kyma.cloud.sap       | `arn:aws:iam::194230256199:user/cloud-manager-peering-prod`  |
 
@@ -61,6 +61,11 @@ Use the following table to identify Cloud Manager principal based on your Kyma l
     ```
 
 3. Attach the **CloudManagerPeeringAccess** policy to the **CloudManagerPeeringRole**:
+
+## Required Actions in the Remote Project
+
+Before creating the VPC peering, please tag your AWS account VPC with the Kyma shoot name tag.  
+For more information, check the [Create Virtual Private Cloud Peering in Amazon Web Services](../tutorials/01-30-10-aws-vpc-peering.md) tutorial.
 
 ## Deleting `AwsVpcPeering`
 

--- a/docs/user/resources/04-30-10-aws-vpc-peering.md
+++ b/docs/user/resources/04-30-10-aws-vpc-peering.md
@@ -14,7 +14,7 @@ Cloud Manager uses [`AssumeRole`](https://awscli.amazonaws.com/v2/documentation/
 
 Use the following table to identify Cloud Manager principal based on your Kyma landscape:
 
-| BTP cockpit URL                    | Kyma dashboard URL                     | Cloud Manager principal ARN                                  |
+| BTP cockpit URL                    | Kyma dashboard URL                     | Cloud Manager principal                                      |
 |------------------------------------|----------------------------------------|--------------------------------------------------------------|
 | https://canary.cockpit.btp.int.sap | https://dashboard.stage.kyma.cloud.sap | `arn:aws:iam::194230256199:user/cloud-manager-peering-stage` |
 | https://emea.cockpit.btp.cloud.sap | https://dashboard.kyma.cloud.sap       | `arn:aws:iam::194230256199:user/cloud-manager-peering-prod`  |

--- a/docs/user/resources/04-30-30-azure-vpc-peering.md
+++ b/docs/user/resources/04-30-30-azure-vpc-peering.md
@@ -24,6 +24,13 @@ And assign the following Identity and Access Management (IAM) roles to the Cloud
 * Classic Network Contributor
 * Network Contributor
 
+## Required Actions in the Remote Project
+
+Before creating the VPC peering, please tag your Azure subscription VPC with the Kyma shoot name tag.  
+For more information, check the [Create Virtual Private Cloud Peering in Microsoft Azure](../tutorials/01-30-30-azure-vpc-peering.md) tutorial.
+
+
+
 ## Deleting `AzureVpcPeering`
 
 Kyma's underlying cloud provider VPC peering connection is deleted as a part of the AzureVpcPeering deletion. The remote VPC

--- a/docs/user/tutorials/01-30-10-aws-vpc-peering.md
+++ b/docs/user/tutorials/01-30-10-aws-vpc-peering.md
@@ -19,7 +19,7 @@ This tutorial explains how to create a Virtual Private Cloud (VPC) peering conne
 2. Create a trust policy document. See [AwsVpcPeering Custom Resource](../resources/04-30-10-aws-vpc-peering.md?id=authorization) to identify Cloud Manager principal:
 
     ```shell
-    export CLOUD_MANAGER_PRINCIPAL=`arn:aws:iam::194230256199:user/cloud-manager-peering-stage`
+    export CLOUD_MANAGER_PRINCIPAL={CLOUD_MANAGER_PRINCIPAL}
     cat > trust_policy.json <<- EOF
     {
         "Version": "2012-10-17",

--- a/docs/user/tutorials/01-30-10-aws-vpc-peering.md
+++ b/docs/user/tutorials/01-30-10-aws-vpc-peering.md
@@ -16,7 +16,7 @@ This tutorial explains how to create a Virtual Private Cloud (VPC) peering conne
     export AWS_REGION={REGION}
     ```
 
-2. Create a trust policy document. See [AwsVpcPeering Custom Resource](../resources/04-30-10-aws-vpc-peering.md?id=authorization) to identify Cloud Manager principal:
+2. Create a trust policy document. See [AwsVpcPeering Custom Resource](../resources/04-30-10-aws-vpc-peering.md#authorization) to identify Cloud Manager principal:
 
     ```shell
     export CLOUD_MANAGER_PRINCIPAL={CLOUD_MANAGER_PRINCIPAL}

--- a/docs/user/tutorials/01-30-10-aws-vpc-peering.md
+++ b/docs/user/tutorials/01-30-10-aws-vpc-peering.md
@@ -16,10 +16,10 @@ This tutorial explains how to create a Virtual Private Cloud (VPC) peering conne
     export AWS_REGION={REGION}
     ```
 
-2. Create a trust policy document. See [AwsVpcPeering Custom Resource](../resources/04-30-10-aws-vpc-peering.md?id=authorization) to identify Cloud Manager principal ARN:
+2. Create a trust policy document. See [AwsVpcPeering Custom Resource](../resources/04-30-10-aws-vpc-peering.md?id=authorization) to identify Cloud Manager principal:
 
     ```shell
-    export PRINCIPAL_ARN=`arn:aws:iam::194230256199:user/cloud-manager-peering-stage`
+    export CLOUD_MANAGER_PRINCIPAL=`arn:aws:iam::194230256199:user/cloud-manager-peering-stage`
     cat > trust_policy.json <<- EOF
     {
         "Version": "2012-10-17",
@@ -27,7 +27,7 @@ This tutorial explains how to create a Virtual Private Cloud (VPC) peering conne
             {
                 "Effect": "Allow",
                 "Principal": {
-                    "AWS": "$PRINCIPAL_ARN"
+                    "AWS": "$CLOUD_MANAGER_PRINCIPAL"
                 },
                 "Action": "sts:AssumeRole"
             }

--- a/docs/user/tutorials/01-30-10-aws-vpc-peering.md
+++ b/docs/user/tutorials/01-30-10-aws-vpc-peering.md
@@ -16,11 +16,10 @@ This tutorial explains how to create a Virtual Private Cloud (VPC) peering conne
     export AWS_REGION={REGION}
     ```
 
-2. Create a trust policy document.
+2. Create a trust policy document. See [AwsVpcPeering Custom Resource](../resources/04-30-10-aws-vpc-peering?id=authorization) to identify Cloud Manager principal ARN:
 
     ```shell
-    export PRINCIPAL_PROFILE_AWS_ACCOUNT_ID=194230256199
-    export USER_NAME=cloud-manager-peering-dev
+    export PRINCIPAL_ARN=`arn:aws:iam::194230256199:user/cloud-manager-peering-stage`
     cat > trust_policy.json <<- EOF
     {
         "Version": "2012-10-17",
@@ -28,7 +27,7 @@ This tutorial explains how to create a Virtual Private Cloud (VPC) peering conne
             {
                 "Effect": "Allow",
                 "Principal": {
-                    "AWS": "arn:aws:iam::$PRINCIPAL_PROFILE_AWS_ACCOUNT_ID:user/$USER_NAME"
+                    "AWS": "$PRINCIPAL_ARN"
                 },
                 "Action": "sts:AssumeRole"
             }

--- a/docs/user/tutorials/01-30-10-aws-vpc-peering.md
+++ b/docs/user/tutorials/01-30-10-aws-vpc-peering.md
@@ -16,7 +16,7 @@ This tutorial explains how to create a Virtual Private Cloud (VPC) peering conne
     export AWS_REGION={REGION}
     ```
 
-2. Create a trust policy document. See [AwsVpcPeering Custom Resource](../resources/04-30-10-aws-vpc-peering?id=authorization) to identify Cloud Manager principal ARN:
+2. Create a trust policy document. See [AwsVpcPeering Custom Resource](../resources/04-30-10-aws-vpc-peering.md?id=authorization) to identify Cloud Manager principal ARN:
 
     ```shell
     export PRINCIPAL_ARN=`arn:aws:iam::194230256199:user/cloud-manager-peering-stage`

--- a/docs/user/tutorials/01-30-30-azure-vpc-peering.md
+++ b/docs/user/tutorials/01-30-30-azure-vpc-peering.md
@@ -16,7 +16,7 @@ This tutorial explains how to create a Virtual Private Cloud (VPC) peering conne
     az account set --subscription $SUBSCRIPTION
     ```
 
-2. Assign the required roles to the Cloud Manager peering service principal. See [AzureVpcPeering Custom Resource](../resources/04-30-30-azure-vpc-peering?id=authorization) to identify Cloud Manager service principal: 
+2. Assign the required roles to the Cloud Manager peering service principal. See [AzureVpcPeering Custom Resource](../resources/04-30-30-azure-vpc-peering.md?id=authorization) to identify Cloud Manager service principal: 
     ```shell
     export SUBSCRIPTION_ID=$(az account show --query id -o tsv)
     export PRINCIPAL_NAME={PRINCIPAL_NAME}

--- a/docs/user/tutorials/01-30-30-azure-vpc-peering.md
+++ b/docs/user/tutorials/01-30-30-azure-vpc-peering.md
@@ -16,7 +16,7 @@ This tutorial explains how to create a Virtual Private Cloud (VPC) peering conne
     az account set --subscription $SUBSCRIPTION
     ```
 
-2. Assign the required roles to the Cloud Manager peering service principal. See [AzureVpcPeering Custom Resource](../resources/04-30-30-azure-vpc-peering.md?id=authorization) to identify Cloud Manager service principal: 
+2. Assign the required roles to the Cloud Manager peering service principal. See [AzureVpcPeering Custom Resource](../resources/04-30-30-azure-vpc-peering.md#authorization) to identify Cloud Manager service principal: 
     ```shell
     export SUBSCRIPTION_ID=$(az account show --query id -o tsv)
     export CLOUD_MANAGER_PRINCIPAL={CLOUD_MANAGER_PRINCIPAL}

--- a/docs/user/tutorials/01-30-30-azure-vpc-peering.md
+++ b/docs/user/tutorials/01-30-30-azure-vpc-peering.md
@@ -19,8 +19,8 @@ This tutorial explains how to create a Virtual Private Cloud (VPC) peering conne
 2. Assign the required roles to the Cloud Manager peering service principal. See [AzureVpcPeering Custom Resource](../resources/04-30-30-azure-vpc-peering.md?id=authorization) to identify Cloud Manager service principal: 
     ```shell
     export SUBSCRIPTION_ID=$(az account show --query id -o tsv)
-    export PRINCIPAL_NAME={PRINCIPAL_NAME}
-    export OBJECT_ID=$(az ad sp list --display-name $PRINCIPAL_NAME --query "[].id" -o tsv)
+    export CLOUD_MANAGER_PRINCIPAL={CLOUD_MANAGER_PRINCIPAL}
+    export OBJECT_ID=$(az ad sp list --display-name $CLOUD_MANAGER_PRINCIPAL --query "[].id" -o tsv)
     
     az role assignment create --assignee $OBJECT_ID \
     --role "Network Contributor" \

--- a/docs/user/tutorials/01-30-30-azure-vpc-peering.md
+++ b/docs/user/tutorials/01-30-30-azure-vpc-peering.md
@@ -16,11 +16,10 @@ This tutorial explains how to create a Virtual Private Cloud (VPC) peering conne
     az account set --subscription $SUBSCRIPTION
     ```
 
-2. Assign the required roles to the Cloud Manager peering service principal:
-
+2. Assign the required roles to the Cloud Manager peering service principal. See [AzureVpcPeering Custom Resource](../resources/04-30-30-azure-vpc-peering?id=authorization) to identify Cloud Manager service principal: 
     ```shell
     export SUBSCRIPTION_ID=$(az account show --query id -o tsv)
-    export PRINCIPAL_NAME=kyma-cloud-manager-peering-stage
+    export PRINCIPAL_NAME={PRINCIPAL_NAME}
     export OBJECT_ID=$(az ad sp list --display-name $PRINCIPAL_NAME --query "[].id" -o tsv)
     
     az role assignment create --assignee $OBJECT_ID \


### PR DESCRIPTION
Updates tutorials with links to Cloud Manager principals that should be used depending on the Kyma landscape.