### PR TITLE
fix(NukeAwsBackups) - Load vault before listing the backups

### DIFF
--- a/pkg/kcp/provider/aws/nuke/loadNfsBackups.go
+++ b/pkg/kcp/provider/aws/nuke/loadNfsBackups.go
@@ -13,6 +13,11 @@ func loadNfsBackups(ctx context.Context, st composed.State) (error, context.Cont
 	state := st.(*State)
 	logger := composed.LoggerFromCtx(ctx)
 
+	if state.vault == nil {
+		logger.Info("No vault exists.")
+		return nil, ctx
+	}
+
 	backups, err := state.awsClient.ListRecoveryPointsForVault(ctx, state.GetAccountId(), state.GetVaultName())
 	if err != nil {
 		logger.Error(err, "Error listing Aws Recovery Points")

--- a/pkg/kcp/provider/aws/nuke/loadVault.go
+++ b/pkg/kcp/provider/aws/nuke/loadVault.go
@@ -1,0 +1,27 @@
+package nuke
+
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"k8s.io/utils/ptr"
+	"time"
+)
+
+func loadVault(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+
+	//Get the vaultName and load it.
+	vaultName := state.GetVaultName()
+	vaults, err := state.awsClient.ListBackupVaults(ctx)
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error listing AWS Backup Vaults", composed.StopWithRequeueDelay(time.Second), ctx)
+	}
+
+	//Match the vault by name. If found, continue...
+	for _, vault := range vaults {
+		if ptr.Deref(vault.BackupVaultName, "") == vaultName {
+			state.vault = &vault
+		}
+	}
+	return nil, nil
+}

--- a/pkg/kcp/provider/aws/nuke/new.go
+++ b/pkg/kcp/provider/aws/nuke/new.go
@@ -30,6 +30,7 @@ func New(stateFactory StateFactory) composed.Action {
 		return composed.ComposeActions(
 			"awsNuke",
 			createAwsClient,
+			loadVault,
 			loadNfsBackups,
 			providerResourceStatusDiscovered,
 			deleteNfsBackup,

--- a/pkg/kcp/provider/aws/nuke/state.go
+++ b/pkg/kcp/provider/aws/nuke/state.go
@@ -43,6 +43,7 @@ type State struct {
 	nuketypes.State
 	ProviderResources []*nuketypes.ProviderResourceKindState
 
+	vault             *types.BackupVaultListMember
 	awsClientProvider awsClient.SkrClientProvider[awsnukeclient.NukeNfsBackupClient]
 	env               abstractions.Environment
 	awsClient         awsnukeclient.NukeNfsBackupClient


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Fix for preventing Nuke status going to error when no AwsNfsBackup exists


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #https://github.tools.sap/kyma/cloud-manager-infra/issues/13