### PR TITLE
docs: Move the authorization content out of the resources docs

### DIFF
--- a/docs/user/00-50-vpc-peering-authorization.md
+++ b/docs/user/00-50-vpc-peering-authorization.md
@@ -1,0 +1,95 @@
+# Authorizing Cloud Manager in the Remote Cloud Provider
+
+To create VPC peering in the Kyma environment, you must authorize the Cloud Manager module in the remote cloud provider to accept the connection.
+
+## Amazon Web Services
+
+For cross-account access in Amazon Web Services, Cloud Manager uses `AssumeRole`. `AssumeRole` requires specifying the trusted principle. For more information, see the [official Amazon Web Services documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sts/assume-role.html).
+
+Use the following table to identify the Cloud Manager principal based on your Kyma landscape:
+
+| BTP Cockpit URL                    | Kyma Dashboard URL                     | Cloud Manager Principal                                      |
+|------------------------------------|----------------------------------------|--------------------------------------------------------------|
+| https://canary.cockpit.btp.int.sap | https://dashboard.stage.kyma.cloud.sap | `arn:aws:iam::194230256199:user/cloud-manager-peering-stage` |
+| https://emea.cockpit.btp.cloud.sap | https://dashboard.kyma.cloud.sap       | `arn:aws:iam::194230256199:user/cloud-manager-peering-prod`  |
+
+1. Create a new role named **CloudManagerPeeringRole** with a trust policy that allows the Cloud Manager principal to assume the role:
+
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "{CLOUD_MANAGER_PRINCIPAL}"
+                },
+                "Action": "sts:AssumeRole"
+            }
+        ]
+    }
+
+    ```
+
+2. Create a new **CloudManagerPeeringAccess** managed policy with the following permissions:
+
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "Statement1",
+                "Effect": "Allow",
+                "Action": [
+                    "ec2:AcceptVpcPeeringConnection",
+                    "ec2:DescribeVpcs",
+                    "ec2:DescribeVpcPeeringConnections",
+                    "ec2:DescribeRouteTables",
+                    "ec2:CreateRoute",
+                    "ec2:CreateTags"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }
+    ```
+
+3. Attach the **CloudManagerPeeringAccess** policy to the **CloudManagerPeeringRole**.
+
+## Google Cloud
+
+Grant the following permissions to the Kyma service account in your GCP Project:
+
+| Permission                           | Description                                                                 |
+|--------------------------------------|-----------------------------------------------------------------------------|
+| `compute.networks.addPeering`        | Required to create the peering request in the remote project and VPC.       |
+| `compute.networks.get`               | Required to fetch the list of existing VPC peerings from the remote VPC.    |
+| `compute.networks.ListEffectiveTags` | Required to check if the remote VPC is tagged with the Kyma shoot name tag. |
+
+For more information on how to manage access to service accounts, see the [official Google Cloud documentation](https://cloud.google.com/iam/docs/manage-access-service-accounts).
+
+### Service Account
+
+For security reasons, each Kyma landscape has its own service account.
+Use the following table to identify the correct Cloud Manager service account for your Kyma landscape:
+
+| BTP Cockpit URL                    | Kyma Dashboard URL                     | Cloud Manager Service Account                                          |
+|------------------------------------|----------------------------------------|------------------------------------------------------------------------|
+| https://canary.cockpit.btp.int.sap | https://dashboard.stage.kyma.cloud.sap | `cloud-manager-peering@sap-ti-dx-kyma-mps-stage.iam.gserviceaccount.com` |
+| https://emea.cockpit.btp.cloud.sap | https://dashboard.kyma.cloud.sap       | `cloud-manager-peering@sap-ti-dx-kyma-mps-prod.iam.gserviceaccount.com`  |
+
+## Microsoft Azure
+
+Use the following table to identify the Cloud Manager service principal based on your Kyma landscape:
+
+| BTP Cockpit URL                    | Kyma Dashboard URL                     | Cloud Manager Service Principal  |
+|------------------------------------|----------------------------------------|----------------------------------|
+| https://canary.cockpit.btp.int.sap | https://dashboard.stage.kyma.cloud.sap | kyma-cloud-manager-peering-stage |
+| https://emea.cockpit.btp.cloud.sap | https://dashboard.kyma.cloud.sap       | kyma-cloud-manager-peering-prod  |
+
+Assign the following Identity and Access Management (IAM) roles to the Cloud Manager service principal:
+
+* Classic Network Contributor
+* Network Contributor
+
+For more information, see the [official Microsoft Azure documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal).

--- a/docs/user/resources/04-30-10-aws-vpc-peering.md
+++ b/docs/user/resources/04-30-10-aws-vpc-peering.md
@@ -7,61 +7,6 @@ of the same cloud provider.
 Once an `AwsVpcPeering` CR is created and reconciled, the Cloud Manager controller creates a VPC peering connection in 
 the Kyma cluster underlying cloud provider account and accepts VPC peering connection in the remote cloud provider account.
 
-## Authorization
-
-Cloud Manager must be authorized in the remote cloud provider account to accept VPC peering connection. For cross-account access,
-Cloud Manager uses [`AssumeRole`](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sts/assume-role.html).
-
-Use the following table to identify Cloud Manager principal based on your Kyma landscape:
-
-| BTP cockpit URL                    | Kyma dashboard URL                     | Cloud Manager principal                                      |
-|------------------------------------|----------------------------------------|--------------------------------------------------------------|
-| https://canary.cockpit.btp.int.sap | https://dashboard.stage.kyma.cloud.sap | `arn:aws:iam::194230256199:user/cloud-manager-peering-stage` |
-| https://emea.cockpit.btp.cloud.sap | https://dashboard.kyma.cloud.sap       | `arn:aws:iam::194230256199:user/cloud-manager-peering-prod`  |
-
-1. Create a new role named **CloudManagerPeeringRole** with a trust policy that allows Cloud Manager principal to assume the role:
-
-    ```json
-    {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": "{CLOUD_MANAGER_PRINCIPAL}"
-                },
-                "Action": "sts:AssumeRole"
-            }
-        ]
-    }
-
-    ```
-
-2. Create a new managed policy **CloudManagerPeeringAccess** with the following permissions:
-
-    ```json
-    {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Sid": "Statement1",
-                "Effect": "Allow",
-                "Action": [
-                    "ec2:AcceptVpcPeeringConnection",
-                    "ec2:DescribeVpcs",
-                    "ec2:DescribeVpcPeeringConnections",
-                    "ec2:DescribeRouteTables",
-                    "ec2:CreateRoute",
-                    "ec2:CreateTags"
-                ],
-                "Resource": "*"
-            }
-        ]
-    }
-    ```
-
-3. Attach the **CloudManagerPeeringAccess** policy to the **CloudManagerPeeringRole**:
-
 ## Required Actions in the Remote Project
 
 Before creating the VPC peering, please tag your AWS account VPC with the Kyma shoot name tag.  

--- a/docs/user/resources/04-30-20-gcp-vpc-peering.md
+++ b/docs/user/resources/04-30-20-gcp-vpc-peering.md
@@ -4,34 +4,10 @@ The `gcpvpcpeering.cloud-resources.kyma-project.io` custom resource (CR) describ
  that you can create to allow communication between Kyma and a remote VPC in Google Cloud Platform (GCP).
 It enables you to consume services available in the remote VPC from the Kyma cluster.
 
-## Required Permissions in the Remote Project
-
-To create VPC peering, the following permissions must be granted to the Kyma service account in your GCP project:
-
-| Permission                           | Description                                                                 |
-|--------------------------------------|-----------------------------------------------------------------------------|
-| `compute.networks.addPeering`        | Required to create the peering request in the remote project and VPC.       |
-| `compute.networks.get`               | Required to fetch the list of existing VPC peerings from the remote VPC.    |
-| `compute.networks.ListEffectiveTags` | Required to check if the remote VPC is tagged with the Kyma shoot name tag. |
-
-For more information on how to manage access to service accounts, see the [Google Cloud documentation](https://cloud.google.com/iam/docs/manage-access-service-accounts).
-
-### Service Account
-
-For security reasons, each Kyma landscape has its own service account.
-Use the following table to identify the correct Cloud Manager service account for your Kyma landscape:
-
-| BTP cockpit URL                    | Kyma Dashboard URL                     | Cloud Manager service account                                          |
-|------------------------------------|----------------------------------------|------------------------------------------------------------------------|
-| https://canary.cockpit.btp.int.sap | https://dashboard.stage.kyma.cloud.sap | `cloud-manager-peering@sap-ti-dx-kyma-mps-stage.iam.gserviceaccount.com` |
-| https://emea.cockpit.btp.cloud.sap | https://dashboard.kyma.cloud.sap       | `cloud-manager-peering@sap-ti-dx-kyma-mps-prod.iam.gserviceaccount.com`  |
-
-
 ## Required Actions in the Remote Project
 
 Before creating the VPC peering, please tag your GCP project's VPC with the Kyma shoot name tag.  
 For more information, check the [Create Virtual Private Cloud Peering in Google Cloud](../tutorials/01-30-20-gcp-vpc-peering.md) tutorial.
-
 
 ## Specification <!-- {docsify-ignore} -->
 

--- a/docs/user/resources/04-30-30-azure-vpc-peering.md
+++ b/docs/user/resources/04-30-30-azure-vpc-peering.md
@@ -8,28 +8,10 @@ Once an `AzureVpcPeering` CR is created and reconciled, the Cloud Manager contro
 the VPC network of the Kyma cluster in the underlying cloud provider subscription, and accepts a VPC peering connection in
 the remote cloud provider subscription.
 
-## Authorization
-
-Cloud Manager must be authorized in the remote cloud provider subscription to accept a VPC peering connection.
-
-Use the following table to identify Cloud Manager service principal based on your Kyma landscape:
-
-| BTP cockpit URL                    | Kyma dashboard URL                     | Cloud Manager service principal  |
-|------------------------------------|----------------------------------------|----------------------------------|
-| https://canary.cockpit.btp.int.sap | https://dashboard.stage.kyma.cloud.sap | kyma-cloud-manager-peering-stage |
-| https://emea.cockpit.btp.cloud.sap | https://dashboard.kyma.cloud.sap       | kyma-cloud-manager-peering-prod  |
-
-And assign the following Identity and Access Management (IAM) roles to the Cloud Manager service principal:
-
-* Classic Network Contributor
-* Network Contributor
-
 ## Required Actions in the Remote Project
 
 Before creating the VPC peering, please tag your Azure subscription VPC with the Kyma shoot name tag.  
 For more information, check the [Create Virtual Private Cloud Peering in Microsoft Azure](../tutorials/01-30-30-azure-vpc-peering.md) tutorial.
-
-
 
 ## Deleting `AzureVpcPeering`
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Move the authorization content for each cloud provider out of the resources docs.
-
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
