### PR TITLE
Rename security scanners config fields

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,8 +1,8 @@
 module-name: cloud-manager
 kind: kyma
-protecode:
+bdba:
   - europe-docker.pkg.dev/kyma-project/prod/cloud-manager:main
-whitesource:
+mend:
   language: golang-mod
   exclude:
     - "**/*_test.go"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

With recent tool naming change, we want to keep the same names in security-scanner-config

Changes proposed in this pull request:

- Rename `protecode` to `bdba`
- Rename `whitesource` to `mend`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
kyma/test-infra#491