### PR TITLE
chore: trigger generate release notes on non-patch version only

### DIFF
--- a/.github/workflows/create-release-notes.yaml
+++ b/.github/workflows/create-release-notes.yaml
@@ -3,7 +3,7 @@ name: Generate Release Notes
 on:
   push:
     tags:
-      - "*"  # Triggers on any tag creation
+      - "*.*.0"  # Triggers on non-patch tag creation
 
 jobs:
   generate-release-notes:


### PR DESCRIPTION
Changes proposed in this pull request:

Trigger "generate release notes" on non-patch tag name only, eg 1.2.0 will trigger it, but 1.2.1 will not.

