### PR TITLE
fix(GcpNfsVolume): no longer tries to edit capacity in spec

### DIFF
--- a/pkg/skr/gcpnfsvolume/modifyPersistentVolumeClaim.go
+++ b/pkg/skr/gcpnfsvolume/modifyPersistentVolumeClaim.go
@@ -19,7 +19,6 @@ func modifyPersistentVolumeClaim(ctx context.Context, st composed.State) (error,
 	}
 
 	nfsVolume := state.ObjAsGcpNfsVolume()
-	capacity := gcpNfsVolumeCapacityToResourceQuantity(nfsVolume)
 
 	if !meta.IsStatusConditionTrue(nfsVolume.Status.Conditions, v1beta1.ConditionTypeReady) {
 		return nil, nil
@@ -27,12 +26,6 @@ func modifyPersistentVolumeClaim(ctx context.Context, st composed.State) (error,
 
 	if state.PVC == nil {
 		return nil, nil
-	}
-
-	capacityChanged := !capacity.Equal(state.PVC.Spec.Resources.Requests["storage"])
-	if capacityChanged {
-		state.PVC.Spec.Resources.Requests["storage"] = *capacity
-		logger.Info("Detected modified PVC capacity")
 	}
 
 	expectedLabels := getVolumeClaimLabels(nfsVolume)
@@ -49,7 +42,7 @@ func modifyPersistentVolumeClaim(ctx context.Context, st composed.State) (error,
 		logger.Info("Detected desynced PVC annotations")
 	}
 
-	if !(capacityChanged || labelsChanged || annotationsDesynced) {
+	if !(labelsChanged || annotationsDesynced) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Value in .Spec.Resources.Requests[storage] is no longer edited

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
