### PR TITLE
fix: enhance the log messages of Gcp Nfs Volume/Backup/Restore

### DIFF
--- a/pkg/kcp/provider/gcp/client/serviceUsageClient.go
+++ b/pkg/kcp/provider/gcp/client/serviceUsageClient.go
@@ -45,7 +45,7 @@ func (s serviceUsageClient) GetServiceUsageOperation(ctx context.Context, operat
 	operation, err := s.svcServiceUsage.Operations.Get(operationName).Do()
 	IncrementCallCounter("ServiceUsage", "Operations.Get", "", err)
 	if err != nil {
-		logger.V(4).Info("GetOperation", "err", err)
+		logger.Info("GetOperation", "err", err)
 		return nil, err
 	}
 	return operation, err
@@ -58,7 +58,7 @@ func (s serviceUsageClient) EnableService(ctx context.Context, projectId string,
 	operation, err := s.svcServiceUsage.Services.Enable(completeServiceName, enableServiceRequest).Do()
 	IncrementCallCounter("ServiceUsage", "Services.Enable", "", err)
 	if err != nil {
-		logger.V(4).Info("EnableService", "err", err)
+		logger.Info("EnableService", "err", err)
 	}
 	return operation, err
 }
@@ -70,7 +70,7 @@ func (s serviceUsageClient) DisableService(ctx context.Context, projectId string
 	operation, err := s.svcServiceUsage.Services.Disable(completeServiceName, disableServiceRequest).Do()
 	IncrementCallCounter("ServiceUsage", "Services.Disable", "", err)
 	if err != nil {
-		logger.V(4).Info("DisableService", "err", err)
+		logger.Info("DisableService", "err", err)
 	}
 	return operation, err
 }
@@ -81,7 +81,7 @@ func (s serviceUsageClient) IsServiceEnabled(ctx context.Context, projectId stri
 	service, err := s.svcServiceUsage.Services.Get(completeServiceName).Do()
 	IncrementCallCounter("ServiceUsage", "Services.Get", "", err)
 	if err != nil {
-		logger.V(4).Info("isServiceEnabled", "err", err)
+		logger.Info("isServiceEnabled", "err", err)
 		return false, err
 	}
 	return service.State == "ENABLED", nil

--- a/pkg/kcp/provider/gcp/iprange/client/computeClient.go
+++ b/pkg/kcp/provider/gcp/iprange/client/computeClient.go
@@ -47,7 +47,7 @@ func (c *computeClient) GetIpRange(ctx context.Context, projectId, name string) 
 	out, err := c.svcCompute.GlobalAddresses.Get(projectId, name).Do()
 	client.IncrementCallCounter("Compute", "GlobalAddresses.Get", "", err)
 	if err != nil {
-		logger.V(4).Info("GetIpRange", "err", err)
+		logger.Info("GetIpRange", "err", err)
 	}
 	return out, err
 }
@@ -56,7 +56,7 @@ func (c *computeClient) DeleteIpRange(ctx context.Context, projectId, name strin
 	logger := composed.LoggerFromCtx(ctx)
 	operation, err := c.svcCompute.GlobalAddresses.Delete(projectId, name).Do()
 	client.IncrementCallCounter("Compute", "GlobalAddresses.Delete", "", err)
-	logger.V(4).Info("DeleteIpRange", "operation", operation, "err", err)
+	logger.Info("DeleteIpRange", "operation", operation, "err", err)
 	return operation, err
 }
 
@@ -72,7 +72,7 @@ func (c *computeClient) CreatePscIpRange(ctx context.Context, projectId, vpcName
 		Purpose:      string(client.IpRangePurposeVPCPeering),
 	}).Do()
 	client.IncrementCallCounter("Compute", "GlobalAddresses.Insert", "", err)
-	logger.V(4).Info("CreatePscIpRange", "operation", operation, "err", err)
+	logger.Info("CreatePscIpRange", "operation", operation, "err", err)
 	return operation, err
 }
 

--- a/pkg/kcp/provider/gcp/iprange/client/serviceNetworkingClient.go
+++ b/pkg/kcp/provider/gcp/iprange/client/serviceNetworkingClient.go
@@ -60,7 +60,7 @@ func (c *serviceNetworkingClient) PatchServiceConnection(ctx context.Context, pr
 		ReservedPeeringRanges: reservedIpRanges,
 	}).Force(true).Do()
 	client.IncrementCallCounter("ServiceNetworking", "Services.Connections.Patch", "", err)
-	logger.V(4).Info("PatchServiceConnection", "operation", operation, "err", err)
+	logger.Info("PatchServiceConnection", "operation", operation, "err", err)
 	return operation, err
 }
 
@@ -75,7 +75,7 @@ func (c *serviceNetworkingClient) DeleteServiceConnection(ctx context.Context, p
 		ConsumerNetwork: network,
 	}).Do()
 	client.IncrementCallCounter("ServiceNetworking", "Services.Connections.DeleteConnection", "", err)
-	logger.V(4).Info("DeleteServiceConnection", "operation", operation, "err", err)
+	logger.Info("DeleteServiceConnection", "operation", operation, "err", err)
 	return operation, err
 }
 
@@ -99,7 +99,7 @@ func (c *serviceNetworkingClient) CreateServiceConnection(ctx context.Context, p
 		ReservedPeeringRanges: reservedIpRanges,
 	}).Do()
 	client.IncrementCallCounter("ServiceNetworking", "Services.Connections.Create", "", err)
-	logger.V(4).Info("CreateServiceConnection", "operation", operation, "err", err)
+	logger.Info("CreateServiceConnection", "operation", operation, "err", err)
 	return operation, err
 }
 

--- a/pkg/kcp/provider/gcp/iprange/v2/checkGcpOperation.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/checkGcpOperation.go
@@ -39,7 +39,7 @@ func checkGcpOperation(ctx context.Context, st composed.State) (error, context.C
 					ipRange.Status.OpIdentifier = ""
 				}
 			}
-
+			logger.Error(err, "Error getting Service Networking Operation from GCP")
 			return composed.PatchStatus(ipRange).
 				SetExclusiveConditions(metav1.Condition{
 					Type:    v1beta1.ConditionTypeError,
@@ -48,7 +48,6 @@ func checkGcpOperation(ctx context.Context, st composed.State) (error, context.C
 					Message: err.Error(),
 				}).
 				SuccessError(composed.StopWithRequeue).
-				SuccessLogMsg("Error getting Service Networking Operation from GCP.").
 				Run(ctx, state)
 		}
 
@@ -80,6 +79,7 @@ func checkGcpOperation(ctx context.Context, st composed.State) (error, context.C
 		project := state.Scope().Spec.Scope.Gcp.Project
 		op, err := state.computeClient.GetGlobalOperation(ctx, project, opName)
 		if err != nil {
+			logger.Error(err, "Error getting Compute Operation from GCP.")
 			return composed.PatchStatus(ipRange).
 				SetExclusiveConditions(metav1.Condition{
 					Type:    v1beta1.ConditionTypeError,
@@ -88,7 +88,6 @@ func checkGcpOperation(ctx context.Context, st composed.State) (error, context.C
 					Message: err.Error(),
 				}).
 				SuccessError(composed.StopWithRequeue).
-				SuccessLogMsg("Error getting Compute Operation from GCP.").
 				Run(ctx, state)
 		}
 

--- a/pkg/kcp/provider/gcp/iprange/v2/identifyPeeringIpRanges.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/identifyPeeringIpRanges.go
@@ -2,7 +2,6 @@ package v2
 
 import (
 	"context"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
@@ -40,6 +39,7 @@ func identifyPeeringIpRanges(ctx context.Context, st composed.State) (error, con
 
 	list, err := state.computeClient.ListGlobalAddresses(ctx, project, vpc)
 	if err != nil {
+		logger.Error(err, "Error listing Global Addresses from GCP.")
 		return composed.PatchStatus(ipRange).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    v1beta1.ConditionTypeError,
@@ -48,7 +48,6 @@ func identifyPeeringIpRanges(ctx context.Context, st composed.State) (error, con
 				Message: "Error listing Global Addresses from GCP",
 			}).
 			SuccessError(composed.StopWithRequeue).
-			SuccessLogMsg("Error listing Global Addresses from GCP").
 			Run(ctx, state)
 	}
 

--- a/pkg/kcp/provider/gcp/iprange/v2/loadPsaConnection.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/loadPsaConnection.go
@@ -2,7 +2,6 @@ package v2
 
 import (
 	"context"
-
 	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -30,6 +29,7 @@ func loadPsaConnection(ctx context.Context, st composed.State) (error, context.C
 	vpc := gcpScope.VpcNetwork
 	list, err := state.serviceNetworkingClient.ListServiceConnections(ctx, project, vpc)
 	if err != nil {
+		logger.Error(err, "Error listing Service Connections from GCP.")
 		return composed.PatchStatus(ipRange).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    v1beta1.ConditionTypeError,
@@ -38,7 +38,6 @@ func loadPsaConnection(ctx context.Context, st composed.State) (error, context.C
 				Message: "Error listing Service Connections from GCP",
 			}).
 			SuccessError(composed.StopWithRequeue).
-			SuccessLogMsg("Error listing Service Connections from GCP").
 			Run(ctx, state)
 	}
 

--- a/pkg/kcp/provider/gcp/iprange/v2/syncPsaConnection.go
+++ b/pkg/kcp/provider/gcp/iprange/v2/syncPsaConnection.go
@@ -2,8 +2,6 @@ package v2
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,6 +39,7 @@ func syncPsaConnection(ctx context.Context, st composed.State) (error, context.C
 	}
 
 	if err != nil {
+		logger.Error(err, "Error creating/deleting/patching Service Connection object in GCP")
 		return composed.PatchStatus(ipRange).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    v1beta1.ConditionTypeError,
@@ -49,7 +48,6 @@ func syncPsaConnection(ctx context.Context, st composed.State) (error, context.C
 				Message: err.Error(),
 			}).
 			SuccessError(composed.StopWithRequeueDelay(gcpclient.GcpConfig.GcpRetryWaitTime)).
-			SuccessLogMsg(fmt.Sprintf("Error creating/deleting Service Connection object in GCP :%s", err)).
 			Run(ctx, state)
 	}
 	if operation != nil {

--- a/pkg/kcp/provider/gcp/nfsbackup/client/fileBackupClient.go
+++ b/pkg/kcp/provider/gcp/nfsbackup/client/fileBackupClient.go
@@ -59,7 +59,8 @@ func (c *fileBackupClient) GetFileBackup(ctx context.Context, projectId, locatio
 	out, err := c.svcFile.Projects.Locations.Backups.Get(client.GetFileBackupPath(projectId, location, name)).Do()
 	client.IncrementCallCounter("File", "Backups.Get", location, err)
 	if err != nil {
-		logger.V(4).Info("GetFileBackup", "err", err)
+		logger.Info("GetFileBackup", "err", err)
+		return nil, err
 	}
 	return out, err
 }
@@ -69,7 +70,7 @@ func (c *fileBackupClient) ListFilesBackups(ctx context.Context, projectId, filt
 	out, err := c.svcFile.Projects.Locations.Backups.List(client.GetFilestoreParentPath(projectId, "-")).Filter(filter).Do()
 	client.IncrementCallCounter("File", "Backups.List", "-", err)
 	if err != nil {
-		logger.V(4).Info("ListFilesBackups", "err", err)
+		logger.Info("ListFilesBackups", "err", err)
 		return nil, err
 	}
 	return out.Backups, nil

--- a/pkg/kcp/provider/gcp/nfsinstance/checkGcpOperation.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/checkGcpOperation.go
@@ -38,6 +38,7 @@ func checkGcpOperation(ctx context.Context, st composed.State) (error, context.C
 			}
 		}
 
+		logger.Error(err, "Error getting File Operation from GCP.")
 		return composed.UpdateStatus(nfsInstance).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    v1beta1.ConditionTypeError,
@@ -46,7 +47,6 @@ func checkGcpOperation(ctx context.Context, st composed.State) (error, context.C
 				Message: err.Error(),
 			}).
 			SuccessError(composed.StopWithRequeue).
-			SuccessLogMsg("Error getting File Operation from GCP.").
 			Run(ctx, state)
 	}
 

--- a/pkg/kcp/provider/gcp/nfsinstance/client/filestoreClient.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/client/filestoreClient.go
@@ -48,7 +48,8 @@ func (c *filestoreClient) GetFilestoreInstance(ctx context.Context, projectId, l
 	out, err := c.svcFilestore.Projects.Locations.Instances.Get(client.GetFilestoreInstancePath(projectId, location, instanceId)).Do()
 	client.IncrementCallCounter("File", "Instances.Get", location, err)
 	if err != nil {
-		logger.V(4).Info("GetFilestoreInstance", "err", err)
+		logger.Info("GetFilestoreInstance", "err", err)
+		return nil, err
 	}
 	return out, err
 }

--- a/pkg/kcp/provider/gcp/nfsinstance/loadNfsInstance.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/loadNfsInstance.go
@@ -36,6 +36,7 @@ func loadNfsInstance(ctx context.Context, st composed.State) (error, context.Con
 				return nil, nil
 			}
 		}
+		logger.Error(err, "Error getting Filestore Instance from GCP.")
 		return composed.UpdateStatus(nfsInstance).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    v1beta1.ConditionTypeError,
@@ -44,7 +45,6 @@ func loadNfsInstance(ctx context.Context, st composed.State) (error, context.Con
 				Message: "Error getting Filestore Instance from GCP",
 			}).
 			SuccessError(composed.StopWithRequeueDelay(gcpclient.GcpConfig.GcpRetryWaitTime)).
-			SuccessLogMsg("Error getting Filestore Instance from GCP").
 			Run(ctx, state)
 	}
 

--- a/pkg/skr/backupschedule/loadBackups.go
+++ b/pkg/skr/backupschedule/loadBackups.go
@@ -29,6 +29,7 @@ func loadBackups(ctx context.Context, st composed.State) (error, context.Context
 	)
 
 	if err != nil {
+		logger.Error(err, "Error listing backups.")
 		return composed.PatchStatus(schedule).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    cloudresourcesv1beta1.ConditionTypeError,

--- a/pkg/skr/backupschedule/loadSource.go
+++ b/pkg/skr/backupschedule/loadSource.go
@@ -26,6 +26,7 @@ func loadSource(ctx context.Context, st composed.State) (error, context.Context)
 	sourceRef, err := getSourceRef(ctx, state)
 	if err != nil {
 		schedule.SetState(cloudresourcesv1beta1.StateError)
+		logger.Error(err, "Error getting SourceRef")
 		return composed.PatchStatus(schedule).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    cloudresourcesv1beta1.ConditionTypeError,
@@ -34,7 +35,6 @@ func loadSource(ctx context.Context, st composed.State) (error, context.Context)
 				Message: "Error loading SourceRef",
 			}).
 			SuccessError(composed.StopWithRequeueDelay(util.Timing.T10000ms())).
-			SuccessLogMsg("Error getting SourceRef").
 			Run(ctx, state)
 	}
 

--- a/pkg/skr/backupschedule/validateSchedule.go
+++ b/pkg/skr/backupschedule/validateSchedule.go
@@ -30,7 +30,7 @@ func validateSchedule(ctx context.Context, st composed.State) (error, context.Co
 	expr, err := cronexpr.Parse(sch)
 
 	if err != nil {
-		logger.Info("Invalid cron expression")
+		logger.Error(err, "Invalid cron expression")
 
 		schedule.SetState(cloudresourcesv1beta1.JobStateError)
 		return composed.PatchStatus(schedule).

--- a/pkg/skr/gcpnfsvolumebackup/checkBackupOperation.go
+++ b/pkg/skr/gcpnfsvolumebackup/checkBackupOperation.go
@@ -39,6 +39,7 @@ func checkBackupOperation(ctx context.Context, st composed.State) (error, contex
 			}
 		}
 		backup.Status.State = v1beta1.GcpNfsBackupError
+		logger.Error(err, "Error getting Filestore backup Operation from GCP.")
 		return composed.PatchStatus(backup).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    v1beta1.ConditionTypeError,
@@ -47,7 +48,6 @@ func checkBackupOperation(ctx context.Context, st composed.State) (error, contex
 				Message: err.Error(),
 			}).
 			SuccessError(composed.StopWithRequeue).
-			SuccessLogMsg("Error getting Filestore backup Operation from GCP.").
 			Run(ctx, state)
 	}
 

--- a/pkg/skr/gcpnfsvolumebackup/createNfsBackup.go
+++ b/pkg/skr/gcpnfsvolumebackup/createNfsBackup.go
@@ -47,6 +47,7 @@ func createNfsBackup(ctx context.Context, st composed.State) (error, context.Con
 	if backup.Status.Id == "" {
 		location, err := getLocation(state, logger)
 		if err != nil {
+			logger.Error(err, "Error in automatically populating the location for the backup.")
 			return composed.PatchStatus(backup).
 				SetExclusiveConditions(metav1.Condition{
 					Type:    cloudresourcesv1beta1.ConditionTypeError,

--- a/pkg/skr/gcpnfsvolumebackup/loadGcpNfsVolume.go
+++ b/pkg/skr/gcpnfsvolumebackup/loadGcpNfsVolume.go
@@ -34,6 +34,7 @@ func loadGcpNfsVolume(ctx context.Context, st composed.State) (error, context.Co
 	err := state.SkrCluster.K8sClient().Get(ctx, nfsVolumeKey, nfsVolume)
 	if err != nil {
 		backup.Status.State = cloudresourcesv1beta1.GcpNfsBackupError
+		logger.Error(err, "Error getting GcpNfsVolume.")
 		return composed.PatchStatus(backup).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    cloudresourcesv1beta1.ConditionTypeError,
@@ -42,7 +43,6 @@ func loadGcpNfsVolume(ctx context.Context, st composed.State) (error, context.Co
 				Message: "Error loading GcpNfsVolume",
 			}).
 			SuccessError(composed.StopWithRequeueDelay(gcpclient.GcpConfig.GcpRetryWaitTime)).
-			SuccessLogMsg("Error getting GcpNfsVolume").
 			Run(ctx, state)
 	}
 

--- a/pkg/skr/gcpnfsvolumerestore/checkRestoreOperation.go
+++ b/pkg/skr/gcpnfsvolumerestore/checkRestoreOperation.go
@@ -40,6 +40,7 @@ func checkRestoreOperation(ctx context.Context, st composed.State) (error, conte
 			}
 		}
 		restore.Status.State = v1beta1.JobStateError
+		logger.Error(err, "Error getting Filestore restore Operation from GCP.")
 		return composed.PatchStatus(restore).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    v1beta1.ConditionTypeError,
@@ -48,7 +49,6 @@ func checkRestoreOperation(ctx context.Context, st composed.State) (error, conte
 				Message: err.Error(),
 			}).
 			SuccessError(composed.StopWithRequeue).
-			SuccessLogMsg("Error getting Filestore restore Operation from GCP.").
 			Run(ctx, state)
 	}
 

--- a/pkg/skr/gcpnfsvolumerestore/findRestoreOperation.go
+++ b/pkg/skr/gcpnfsvolumerestore/findRestoreOperation.go
@@ -40,6 +40,7 @@ func findRestoreOperation(ctx context.Context, st composed.State) (error, contex
 			return nil, nil
 		}
 		restore.Status.State = v1beta1.JobStateError
+		logger.Error(err, "Error listing operations from GCP.")
 		return composed.PatchStatus(restore).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    v1beta1.ConditionTypeError,
@@ -48,7 +49,6 @@ func findRestoreOperation(ctx context.Context, st composed.State) (error, contex
 				Message: err.Error(),
 			}).
 			SuccessError(composed.StopWithRequeueDelay(util.Timing.T100ms())).
-			SuccessLogMsg("Error listing operations from GCP.").
 			Run(ctx, state)
 	}
 

--- a/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolume.go
+++ b/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolume.go
@@ -28,6 +28,7 @@ func loadGcpNfsVolume(ctx context.Context, st composed.State) (error, context.Co
 	}
 	if err != nil {
 		restore.Status.State = cloudresourcesv1beta1.JobStateError
+		logger.Error(err, "Error getting GcpNfsVolume")
 		return composed.PatchStatus(restore).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    cloudresourcesv1beta1.ConditionTypeError,
@@ -36,7 +37,6 @@ func loadGcpNfsVolume(ctx context.Context, st composed.State) (error, context.Co
 				Message: "Error loading GcpNfsVolume",
 			}).
 			SuccessError(composed.StopWithRequeueDelay(gcpclient.GcpConfig.GcpRetryWaitTime)).
-			SuccessLogMsg("Error getting GcpNfsVolume").
 			Run(ctx, state)
 	}
 	//If deleting, we still need the gcpNfsVolume object for finding the restore operation if it exists.

--- a/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolumeBackup.go
+++ b/pkg/skr/gcpnfsvolumerestore/loadGcpNfsVolumeBackup.go
@@ -38,6 +38,7 @@ func loadGcpNfsVolumeBackup(ctx context.Context, st composed.State) (error, cont
 	}
 	if err != nil {
 		restore.Status.State = cloudresourcesv1beta1.JobStateError
+		logger.Error(err, "Error getting GcpNfsVolumeBackup")
 		return composed.PatchStatus(restore).
 			SetExclusiveConditions(metav1.Condition{
 				Type:    cloudresourcesv1beta1.ConditionTypeError,
@@ -46,7 +47,6 @@ func loadGcpNfsVolumeBackup(ctx context.Context, st composed.State) (error, cont
 				Message: "Error loading GcpNfsVolumeBackup",
 			}).
 			SuccessError(composed.StopWithRequeueDelay(gcpclient.GcpConfig.GcpRetryWaitTime)).
-			SuccessLogMsg("Error getting GcpNfsVolumeBackup").
 			Run(ctx, state)
 	}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Removing .V(x) in log messages to be consistent
- Adding/Enhancing log messages for Gcp Nfs volume/backup/restore

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes https://github.tools.sap/kyma/cloud-manager-infra/issues/21