### PR TITLE
test: fix restore delete scenario in gcp/aws integration tests

### DIFF
--- a/internal/controller/cloud-resources/aws/awsnfsvolumerestore_test.go
+++ b/internal/controller/cloud-resources/aws/awsnfsvolumerestore_test.go
@@ -163,12 +163,9 @@ var _ = Describe("Feature: SKR AwsNfsVolumeRestore", func() {
 				WithArguments(
 					infra.Ctx(), infra.SKR().Client(), awsNfsVolumeRestore,
 					NewObjActions(),
+					HaveDeletionTimestamp(),
 				).
-				Should(Succeed())
-
-			By("Then DeletionTimestamp is set in AwsNfsVolumeRestore", func() {
-				Expect(awsNfsVolumeRestore.DeletionTimestamp.IsZero()).NotTo(BeTrue())
-			})
+				Should(SucceedIgnoreNotFound())
 
 			By("And Then the AwsNfsVolumeRestore in SKR is deleted.", func() {
 				Eventually(IsDeleted).

--- a/internal/controller/cloud-resources/gcpnfsvolumerestore_test.go
+++ b/internal/controller/cloud-resources/gcpnfsvolumerestore_test.go
@@ -180,12 +180,9 @@ var _ = Describe("Feature: SKR GcpNfsVolumeRestore", func() {
 				WithArguments(
 					infra.Ctx(), infra.SKR().Client(), gcpNfsVolumeRestore,
 					NewObjActions(),
+					HaveDeletionTimestamp(),
 				).
-				Should(Succeed())
-
-			By("Then DeletionTimestamp is set in GcpNfsVolumeRestore", func() {
-				Expect(gcpNfsVolumeRestore.DeletionTimestamp.IsZero()).NotTo(BeTrue())
-			})
+				Should(SucceedIgnoreNotFound())
 
 			By("And Then the GcpNfsVolumeRestore in SKR is deleted.", func() {
 				Eventually(IsDeleted, timeout, interval).

--- a/pkg/testinfra/dsl/conditions.go
+++ b/pkg/testinfra/dsl/conditions.go
@@ -169,3 +169,17 @@ func HaveFinalizer(finalizer string) ObjAssertion {
 		return nil
 	}
 }
+
+func HaveDeletionTimestamp() ObjAssertion {
+	return func(obj client.Object) error {
+		if obj.GetDeletionTimestamp() == nil {
+			return fmt.Errorf(
+				"expected object %T %s/%s to have deletion timestamp set, but deletion timestamp is nil",
+				obj,
+				obj.GetNamespace(),
+				obj.GetName(),
+			)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- As restore can get deleted pretty fast, changing the integration tests to be more resilient in delete scenario
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
