### PR TITLE
(GCP VPC Peering) Updating documentation

### DIFF
--- a/docs/user/00-31-vpc-peering-authorization.md
+++ b/docs/user/00-31-vpc-peering-authorization.md
@@ -74,13 +74,7 @@ Grant the following permissions to the Kyma service account in your GCP project:
 | `compute.networks.listEffectiveTags` | Required to check if the remote VPC is tagged with the Kyma shoot name tag. |
 
 It is recommended to create an IAM custom role with the permissions listed above.
-For more information on how to create a custom role, see the [official Google Cloud documentation](https://cloud.google.com/iam/docs/creating-custom-roles#creating).
-
-See an example of creating a custom role with the required permissions:
-
-```shell
-gcloud iam roles create peeringWithKyma --permissions="compute.networks.addPeering,compute.networks.get,compute.networks.listEffectiveTags" --project=replacing-with-your-project-id
-```
+For more information on how to create a custom role, see the [official Google Cloud documentation](https://cloud.google.com/iam/docs/creating-custom-roles#creating) or the [GCP VPC Peering tutorial](tutorials/01-30-20-gcp-vpc-peering.md#authorize-cloud-manager-in-the-remote-project).
 
 ### Service Account
 
@@ -93,13 +87,7 @@ Use the following table to identify the correct Cloud Manager service account:
 <!-- The stage landscape is visible only in the Internal DRAFT version of Help Portal docs. The stage landscape is not part of the Cloud Production version of Help Portal docs -->
 
 With the service account, you can authorize the Cloud Manager module in the remote project. 
-For more information, see the official Google Cloud documentation on how to [grant roles to service accounts](https://cloud.google.com/iam/docs/granting-changing-revoking-access#grant-single-role).
-
-See an example of assigning the custom role created in the previous example to the service account:
-
-```shell
-gcloud projects add-iam-policy-binding replacing-with-your-project-id --member=serviceAccount:cloud-manager-peering@sap-ti-dx-kyma-mps-prod.iam.gserviceaccount.com --role=projects/replacing-with-your-project-id/roles/peeringWithKyma
-```
+For more information, see the official Google Cloud documentation on how to [grant roles to service accounts](https://cloud.google.com/iam/docs/granting-changing-revoking-access#grant-single-role) or the [GCP VPC Peering tutorial](tutorials/01-30-20-gcp-vpc-peering.md#authorize-cloud-manager-in-the-remote-project)..
 
 ## Microsoft Azure
 <!-- VPC peering for Microsoft Azure is visible only in the Internal DRAFT version of Help Portal docs and it is not part of the Cloud Production version of Help Portal docs -->

--- a/docs/user/00-31-vpc-peering-authorization.md
+++ b/docs/user/00-31-vpc-peering-authorization.md
@@ -74,7 +74,7 @@ Grant the following permissions to the Kyma service account in your GCP project:
 | `compute.networks.listEffectiveTags` | Required to check if the remote VPC is tagged with the Kyma shoot name tag. |
 
 It is recommended to create an IAM custom role with the permissions listed above.
-For more information on how to create a custom role, see the [official Google Cloud documentation](https://cloud.google.com/iam/docs/creating-custom-roles#creating) or the [GCP VPC Peering tutorial](tutorials/01-30-20-gcp-vpc-peering.md#authorize-cloud-manager-in-the-remote-project).
+For more information, see the official Google Cloud documentation on how to [create a custom role](https://cloud.google.com/iam/docs/creating-custom-roles#creating) or the [Authorize Cloud Manager in the Remote Project section](tutorials/01-30-20-gcp-vpc-peering.md#authorize-cloud-manager-in-the-remote-project) in the Creating VPC Peering in Google Cloud tutorial.
 
 ### Service Account
 
@@ -87,7 +87,7 @@ Use the following table to identify the correct Cloud Manager service account:
 <!-- The stage landscape is visible only in the Internal DRAFT version of Help Portal docs. The stage landscape is not part of the Cloud Production version of Help Portal docs -->
 
 With the service account, you can authorize the Cloud Manager module in the remote project. 
-For more information, see the official Google Cloud documentation on how to [grant roles to service accounts](https://cloud.google.com/iam/docs/granting-changing-revoking-access#grant-single-role) or the [GCP VPC Peering tutorial](tutorials/01-30-20-gcp-vpc-peering.md#authorize-cloud-manager-in-the-remote-project)..
+For more information, see the official Google Cloud documentation on how to [grant a single role](https://cloud.google.com/iam/docs/granting-changing-revoking-access#grant-single-role) to a service account or the [Authorize Cloud Manager in the Remote Project section](tutorials/01-30-20-gcp-vpc-peering.md#authorize-cloud-manager-in-the-remote-project) in the Creating VPC Peering in Google Cloud tutorial.
 
 ## Microsoft Azure
 <!-- VPC peering for Microsoft Azure is visible only in the Internal DRAFT version of Help Portal docs and it is not part of the Cloud Production version of Help Portal docs -->

--- a/docs/user/tutorials/01-30-20-gcp-vpc-peering.md
+++ b/docs/user/tutorials/01-30-20-gcp-vpc-peering.md
@@ -7,7 +7,7 @@ This tutorial explains how to create a Virtual Private Cloud (VPC) peering conne
 * You have the Cloud Manager module added. See [Add and Delete a Kyma Module](https://help.sap.com/docs/btp/sap-business-technology-platform-internal/enable-and-disable-kyma-module?state=DRAFT&version=Internal#loio1b548e9ad4744b978b8b595288b0cb5c).
 * Google Cloud CLI
 
-> [!TIP] Use a POSIX-compliant shell or adjust the commands accordingly. For example, if you use Windows, replace the `export` commands with `set` and use `%` before and after the environment variables names.
+> [!NOTE] Use a POSIX-compliant shell or adjust the commands accordingly. For example, if you use Windows, replace the `export` commands with `set` and use `%` before and after the environment variables names.
 
 ## Steps
 

--- a/docs/user/tutorials/01-30-20-gcp-vpc-peering.md
+++ b/docs/user/tutorials/01-30-20-gcp-vpc-peering.md
@@ -5,12 +5,37 @@ This tutorial explains how to create a Virtual Private Cloud (VPC) peering conne
 ## Prerequisites
 
 * You have the Cloud Manager module added. See [Add and Delete a Kyma Module](https://help.sap.com/docs/btp/sap-business-technology-platform-internal/enable-and-disable-kyma-module?state=DRAFT&version=Internal#loio1b548e9ad4744b978b8b595288b0cb5c).
-* You authorized Cloud Manager in the Google Cloud remote project. See [Authorizing Cloud Manager in the Remote Cloud Provider](../00-31-vpc-peering-authorization.md#google-cloud).
 * Google Cloud CLI
 
 > [!TIP] Use a POSIX-compliant shell or adjust the commands accordingly. For example, if you use Windows, replace the `export` commands with `set` and use `%` before and after the environment variables names.
 
 ## Steps
+
+### Authorize Cloud Manager in the Remote Project
+
+To create a VPC peering connection, certain permissions are required in the remote project.
+The recommended approach is creating a role and assigning it to the Cloud Manager service account.
+
+1. Export your remote project ID and desired role name as an environment variable.
+
+   ```shell
+   export YOUR_REMOTE_PROJECT_ID={YOUR_REMOTE_PROJECT_ID}
+   export ROLE_NAME=peeringWithKyma
+   ```
+
+2. Create a custom role with the required permissions.
+
+   ```shell
+   gcloud iam roles create $ROLE_NAME --permissions="compute.networks.addPeering,compute.networks.get,compute.networks.listEffectiveTags" --project=$YOUR_REMOTE_PROJECT_ID
+   ```
+
+3. Check on [Authorizing Cloud Manager in the Remote Cloud Provider](../00-31-vpc-peering-authorization.md#service-account) and assign the custom role created on the previous step to the correct Cloud Manager service account for your environment.
+
+   ```shell
+    gcloud projects add-iam-policy-binding $YOUR_REMOTE_PROJECT_ID --member=serviceAccount:cloud-manager-peering@sap-ti-dx-kyma-mps-prod.iam.gserviceaccount.com --role=projects/$YOUR_REMOTE_PROJECT_ID/roles/$ROLE_NAME
+   ```
+   
+
 
 ### Allow SAP BTP, Kyma Runtime to Peer with Your Network
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- From internal feedback I learned the documentation is now on SAP Help and it is best to not include gcloud examples there, so I added a link to the tutorial and added the commands there.
