### PR TITLE
fix: AzureRwxVolumeRestore startAzureRestore logic

### DIFF
--- a/api/cloud-resources/v1beta1/azurerwxvolumerestore_types.go
+++ b/api/cloud-resources/v1beta1/azurerwxvolumerestore_types.go
@@ -103,7 +103,7 @@ type AzureRwxVolumeRestore struct {
 }
 
 func (in *AzureRwxVolumeRestore) State() string {
-	return string(in.Status.State)
+	return in.Status.State
 }
 
 func (in *AzureRwxVolumeRestore) SetState(v string) {
@@ -169,5 +169,5 @@ const (
 	ConditionReasonRestoreJobCancelled             = "RestoreJobCancelled"
 	ConditionReasonRestoreJobInvalidStatus         = "RestoreJobInvalidStatus"
 	ConditionReasonRestoreJobCompletedWithWarnings = "RestoreJobCompletedWithWarnings"
-	ConditionReasonRestoreJobNotFound              = "RestoreJobNotFound"
+	ConditionReasonErrorStartingRestore            = "ErrorStartingRestore"
 )


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Fixing RecoveryPointId value passed to azure api
- Better error handling in startAzureRestore

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #964 