### PR TITLE
fix: scope provider for network

### DIFF
--- a/pkg/kcp/scope/providerFromScopeToState.go
+++ b/pkg/kcp/scope/providerFromScopeToState.go
@@ -1,0 +1,18 @@
+package scope
+
+import (
+	"context"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+)
+
+func providerFromScopeToState(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+
+	if !composed.IsObjLoaded(ctx, state) {
+		return nil, ctx
+	}
+
+	state.provider = state.ObjAsScope().Spec.Provider
+
+	return nil, ctx
+}

--- a/pkg/kcp/scope/reconciler.go
+++ b/pkg/kcp/scope/reconciler.go
@@ -70,6 +70,7 @@ func (r *scopeReconciler) newState(req ctrl.Request) *State {
 func (r *scopeReconciler) newAction() composed.Action {
 	return composed.ComposeActionsNoName(
 		composed.LoadObjNoStopIfNotFound, // loads Scope
+		providerFromScopeToState,
 		gardenerClusterLoad,
 		networksLoad,
 		gardenerClusterExtractShootName,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

In a case that Scope is not created, but network is, the state.provider is not set, since it was set only when Scope is created. This PR sets state.provider from the loaded Scope

- set provider from loaded Scope to state

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
