### PR TITLE
fix: AzureRwxVolumeRestore updateStatus error messages

### DIFF
--- a/pkg/skr/azurerwxvolumerestore/checkRestoreJob.go
+++ b/pkg/skr/azurerwxvolumerestore/checkRestoreJob.go
@@ -30,7 +30,6 @@ func checkRestoreJob(ctx context.Context, st composed.State) (error, context.Con
 				Reason:  cloudresourcesv1beta1.ConditionReasonInvalidRecoveryPointId,
 				Message: fmt.Sprintf("Source AzureRwxVolumeBackup has an invalid recoveryPointId: '%v'", state.azureRwxVolumeBackup.Status.RecoveryPointId),
 			}).
-			ErrorLogMessage("Error patching AzureRwxVolumeRestore status").
 			SuccessError(composed.StopAndForget).
 			Run(ctx, state)
 	}

--- a/pkg/skr/azurerwxvolumerestore/findAzureRestoreJob.go
+++ b/pkg/skr/azurerwxvolumerestore/findAzureRestoreJob.go
@@ -33,7 +33,6 @@ func findAzureRestoreJob(ctx context.Context, st composed.State) (error, context
 				Reason:  cloudresourcesv1beta1.ConditionReasonInvalidRecoveryPointId,
 				Message: fmt.Sprintf("Source AzureRwxVolumeBackup has an invalid recoveryPointId: '%v'", state.azureRwxVolumeBackup.Status.RecoveryPointId),
 			}).
-			ErrorLogMessage("Error patching AzureRwxVolumeRestore status").
 			SuccessError(composed.StopAndForget).
 			Run(ctx, state)
 	}

--- a/pkg/skr/azurerwxvolumerestore/loadAzureRwxVolumeBackup.go
+++ b/pkg/skr/azurerwxvolumerestore/loadAzureRwxVolumeBackup.go
@@ -61,7 +61,6 @@ func loadAzureRwxVolumeBackup(ctx context.Context, st composed.State) (error, co
 				Message: "AzureRwxVolumeBackup is not ready",
 			}).
 			SuccessError(composed.StopWithRequeueDelay(util.Timing.T10000ms())).
-			SuccessLogMsg("Error loading AzureRwxVolumeBackup").
 			Run(ctx, state)
 	}
 

--- a/pkg/skr/azurerwxvolumerestore/loadPersistentVolume.go
+++ b/pkg/skr/azurerwxvolumerestore/loadPersistentVolume.go
@@ -36,7 +36,6 @@ func loadPersistentVolume(ctx context.Context, st composed.State) (error, contex
 				Reason:  cloudresourcesv1beta1.ConditionReasonPvNotFound,
 				Message: "Persistent volume was not found",
 			}).
-			ErrorLogMessage("Error patching AzureRwxVolumeRestore status").
 			SuccessError(composed.StopAndForget).
 			Run(ctx, state)
 	}
@@ -51,7 +50,6 @@ func loadPersistentVolume(ctx context.Context, st composed.State) (error, contex
 				Reason:  cloudresourcesv1beta1.ConditionReasonPvNotBound,
 				Message: fmt.Sprintf("PV for specified destination PVC is in invalid state %v", pv.Status.Phase),
 			}).
-			ErrorLogMessage("Error patching AzureRwxVolumeRestore status").
 			SuccessError(composed.StopAndForget).
 			Run(ctx, state)
 	}
@@ -65,7 +63,6 @@ func loadPersistentVolume(ctx context.Context, st composed.State) (error, contex
 				Reason:  cloudresourcesv1beta1.ConditionReasonInvalidVolumeHandle,
 				Message: fmt.Sprintf("Persistant Volume has an unexpected volume handle: %v", pv.Spec.CSI.VolumeHandle),
 			}).
-			ErrorLogMessage("Error patching AzureRwxVolumeRestore status").
 			SuccessError(composed.StopAndForget).
 			Run(ctx, state)
 	}

--- a/pkg/skr/azurerwxvolumerestore/loadPersistentVolumeClaim.go
+++ b/pkg/skr/azurerwxvolumerestore/loadPersistentVolumeClaim.go
@@ -35,7 +35,6 @@ func loadPersistentVolumeClaim(ctx context.Context, st composed.State) (error, c
 				Reason:  cloudresourcesv1beta1.ConditionReasonPvcNotFound,
 				Message: "Specified destination was not found",
 			}).
-			ErrorLogMessage("Error patching AzureRwxVolumeRestore status").
 			SuccessError(composed.StopAndForget).
 			Run(ctx, state)
 	}
@@ -50,7 +49,6 @@ func loadPersistentVolumeClaim(ctx context.Context, st composed.State) (error, c
 				Reason:  cloudresourcesv1beta1.ConditionReasonPvcNotBound,
 				Message: fmt.Sprintf("Specified destination PVC is in invalid state %v", pvc.Status.Phase),
 			}).
-			ErrorLogMessage("Error patching AzureRwxVolumeRestore status").
 			SuccessError(composed.StopAndForget).
 			Run(ctx, state)
 	}
@@ -64,7 +62,6 @@ func loadPersistentVolumeClaim(ctx context.Context, st composed.State) (error, c
 				Reason:  cloudresourcesv1beta1.ConditionReasonInvalidProvisioner,
 				Message: "Specified destination PVC is not provisioned by Azure CSI driver (file.csi.azure.com)",
 			}).
-			ErrorLogMessage("Error patching AzureRwxVolumeRestore status").
 			SuccessError(composed.StopAndForget).
 			Run(ctx, state)
 	}

--- a/pkg/skr/azurerwxvolumerestore/startAzureRestore.go
+++ b/pkg/skr/azurerwxvolumerestore/startAzureRestore.go
@@ -32,7 +32,6 @@ func startAzureRestore(ctx context.Context, st composed.State) (error, context.C
 				Reason:  cloudresourcesv1beta1.ConditionReasonInvalidRecoveryPointId,
 				Message: errorMessage,
 			}).
-			ErrorLogMessage("Error patching AzureRwxVolumeRestore status").
 			SuccessError(composed.StopAndForget).
 			Run(ctx, state)
 	}
@@ -48,7 +47,6 @@ func startAzureRestore(ctx context.Context, st composed.State) (error, context.C
 				Reason:  cloudresourcesv1beta1.ConditionReasonInvalidStorageAccountPath,
 				Message: errorMessage,
 			}).
-			ErrorLogMessage("Error patching AzureRwxVolumeRestore status").
 			SuccessError(composed.StopAndForget).
 			Run(ctx, state)
 	}
@@ -80,7 +78,6 @@ func startAzureRestore(ctx context.Context, st composed.State) (error, context.C
 				Message: "Error starting Azure Restore",
 			}).
 			SuccessError(composed.StopWithRequeueDelay(util.Timing.T1000ms())).
-			SuccessLogMsg("Error patching AzureRwxVolumeRestore status").
 			Run(ctx, state)
 	}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- removing unnecessary ErrorLogMsg calls during update status. Default behavior is sufficient.
- removing incorrect SuccessLogMsg calls during update status.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #964 