### PR TITLE
feat: adding client methods for finding azure backup job ids

### DIFF
--- a/pkg/kcp/provider/azure/mock/storageStore.go
+++ b/pkg/kcp/provider/azure/mock/storageStore.go
@@ -34,6 +34,16 @@ type storageStore struct {
 	protectedItems map[string][]*armrecoveryservicesbackup.ProtectedItemResource
 }
 
+func (s *storageStore) GetLastBackupJobStartTime(ctx context.Context, vaultName string, resourceGroupName string, fileShareName string, startTime time.Time) (*time.Time, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s *storageStore) FindNextBackupJobId(ctx context.Context, vaultName string, resourceGroupName string, fileShareName string, startTime time.Time) (*string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (s *storageStore) FindRestoreJobId(ctx context.Context, vaultName string, resourceGroupName string, fileShareName string, startFilter string, restoreFolderPath string) (*string, bool, error) {
 	if isContextCanceled(ctx) {
 		return nil, false, errors.New("context canceled")
@@ -260,6 +270,7 @@ func (s *storageStore) TriggerRestore(ctx context.Context, request client.Restor
 					},
 				}),
 				StartTime: to.Ptr(time.Now()),
+				Operation: to.Ptr(string(armrecoveryservicesbackup.JobOperationTypeRestore)),
 			}),
 		},
 	}

--- a/pkg/skr/azurerwxvolumebackup/client/constants.go
+++ b/pkg/skr/azurerwxvolumebackup/client/constants.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4"
 )
@@ -168,4 +169,8 @@ func ParseContainerId(containerId string) (subscription string, resourceGroup st
 		}
 	}
 	return result["subscription"], result["resourceGroup"], result["vault"], result["container"], nil
+}
+
+func ToStorageJobTimeFilter(time time.Time) string {
+	return time.UTC().Format("2006-01-02 03:04:05 PM")
 }

--- a/pkg/skr/azurerwxvolumebackup/client/jobsMock.go
+++ b/pkg/skr/azurerwxvolumebackup/client/jobsMock.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4"
 	"net/http"
+	"time"
 )
 
 var (
@@ -20,6 +21,13 @@ type restoreJob struct {
 	finalStatus       string
 }
 
+type backupJob struct {
+	jobId       string
+	status      string
+	finalStatus string
+	startTime   string
+}
+
 func newJobsMockClient() *jobsClient {
 	return &jobsClient{}
 }
@@ -27,6 +35,7 @@ func newJobsMockClient() *jobsClient {
 type jobsMockClient struct {
 	jobsClient
 	restoreJobs []*restoreJob
+	backupJobs  []*backupJob
 }
 
 func (m *jobsMockClient) FindRestoreJobId(_ context.Context, _ string, _ string, _ string, _ string, restoreFolderPath string) (*string, bool, error) {
@@ -51,6 +60,40 @@ func (m *jobsMockClient) FindRestoreJobId(_ context.Context, _ string, _ string,
 	return nil, false, nil
 }
 
+func (m *jobsMockClient) FindNextBackupJobId(_ context.Context, _ string, _ string, _ string, startTime time.Time) (*string, error) {
+	var results []string
+	for _, job := range m.backupJobs {
+		jobStartTime, err := time.Parse(time.RFC3339, job.startTime)
+		if err != nil {
+			return nil, err
+		}
+		if jobStartTime.After(startTime) {
+			results = append(results, job.jobId)
+		}
+	}
+	if len(results) > 1 {
+		return nil, errors.New("multiple backup jobs found")
+	}
+	if len(results) == 1 {
+		return &results[0], nil
+	}
+	return nil, nil
+}
+
+func (m *jobsMockClient) GetLastBackupJobStartTime(_ context.Context, _ string, _ string, _ string, _ time.Time) (*time.Time, error) {
+	var lastStartTime *time.Time
+	for _, job := range m.backupJobs {
+		startTime, err := time.Parse(time.RFC3339, job.startTime)
+		if err != nil {
+			return nil, err
+		}
+		if lastStartTime == nil || startTime.After(*lastStartTime) {
+			lastStartTime = &startTime
+		}
+	}
+	return lastStartTime, nil
+}
+
 func (m *jobsMockClient) GetStorageJob(_ context.Context, _ string,
 	_ string, jobId string) (*armrecoveryservicesbackup.AzureStorageJob, error) {
 	for _, job := range jobsMock.restoreJobs {
@@ -64,17 +107,36 @@ func (m *jobsMockClient) GetStorageJob(_ context.Context, _ string,
 			}), nil
 		}
 	}
+	for _, job := range jobsMock.backupJobs {
+		if job.jobId == jobId {
+			if job.status == string(armrecoveryservicesbackup.JobStatusInProgress) {
+				job.status = job.finalStatus
+			}
+			return to.Ptr(armrecoveryservicesbackup.AzureStorageJob{
+				Status: to.Ptr(job.status),
+			}), nil
+		}
+	}
 	err := runtime.NewResponseError(&http.Response{
 		StatusCode: http.StatusNotFound,
 	})
 	return nil, err
 }
 
-func (m *jobsMockClient) AddStorageJob(jobId, restoreFolderPath string, status, finalStatus armrecoveryservicesbackup.JobStatus) {
+func (m *jobsMockClient) AddRestoreJob(jobId, restoreFolderPath string, status, finalStatus armrecoveryservicesbackup.JobStatus) {
 	m.restoreJobs = append(m.restoreJobs, &restoreJob{
 		jobId:             jobId,
 		restoreFolderPath: restoreFolderPath,
 		status:            string(status),
 		finalStatus:       string(finalStatus),
+	})
+}
+
+func (m *jobsMockClient) AddBackupJob(jobId string, status, finalStatus armrecoveryservicesbackup.JobStatus, startTime string) {
+	m.backupJobs = append(m.backupJobs, &backupJob{
+		jobId:       jobId,
+		status:      string(status),
+		finalStatus: string(finalStatus),
+		startTime:   startTime,
 	})
 }

--- a/pkg/skr/azurerwxvolumebackup/client/restoreMock.go
+++ b/pkg/skr/azurerwxvolumebackup/client/restoreMock.go
@@ -28,6 +28,6 @@ func (c restoreMockClient) TriggerRestore(_ context.Context,
 	if request.ResourceGroupName != "" {
 		nextJobStatus = armrecoveryservicesbackup.JobStatus(request.ResourceGroupName)
 	}
-	jobsMock.AddStorageJob(request.VaultName, request.TargetFolderName, armrecoveryservicesbackup.JobStatusInProgress, nextJobStatus)
+	jobsMock.AddRestoreJob(request.VaultName, request.TargetFolderName, armrecoveryservicesbackup.JobStatusInProgress, nextJobStatus)
 	return &request.VaultName, nil
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Adding a method to find the backup job with the latest timestamp
- Adding a method to find the single backup job after the last backup
Utilizing both these methods provides a way to get the backup jobId after a successful trigger.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #963 