### PR TITLE
fix: AzureRwxVolumeRestore controller integration test to tell AzureR…

### DIFF
--- a/internal/controller/cloud-resources/azure/azurerwxvolumerestore_controller_test.go
+++ b/internal/controller/cloud-resources/azure/azurerwxvolumerestore_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	skrazurerwxvolumebackup "github.com/kyma-project/cloud-manager/pkg/skr/azurerwxvolumebackup"
 	. "github.com/kyma-project/cloud-manager/pkg/testinfra/dsl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -71,7 +72,6 @@ var _ = Describe("Feature: SKR AzureRwxVolumeRestore in place", func() {
 		})
 
 		By("And Given SKR PV exists", func() {
-			//skrazurerwxvol.Ignore.AddName(skrRwxVolumeName)
 			//Create SKR AzureRwxVolume if it doesn't exist.
 			Eventually(GivenPvExists).
 				WithArguments(
@@ -121,6 +121,7 @@ var _ = Describe("Feature: SKR AzureRwxVolumeRestore in place", func() {
 				Should(Succeed())
 		})
 		By("And Given SKR AzureRwxVolumeBackup exists", func() {
+			skrazurerwxvolumebackup.Ignore.AddName(skrRwxVolumeName)
 			//Create SKR AzureRwxVolumeBackup if it doesn't exist.
 			Eventually(CreateAzureRwxVolumeBackup).
 				WithArguments(

--- a/pkg/skr/azurerwxvolumebackup/ignorant.go
+++ b/pkg/skr/azurerwxvolumebackup/ignorant.go
@@ -1,0 +1,5 @@
+package azurerwxvolumebackup
+
+import "github.com/kyma-project/cloud-manager/pkg/common/ignorant"
+
+var Ignore = ignorant.New()

--- a/pkg/skr/azurerwxvolumebackup/reconciler.go
+++ b/pkg/skr/azurerwxvolumebackup/reconciler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/skr/azurerwxvolumebackup/client"
 	skrruntime "github.com/kyma-project/cloud-manager/pkg/skr/runtime/reconcile"
 	"github.com/kyma-project/cloud-manager/pkg/util"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	commonscope "github.com/kyma-project/cloud-manager/pkg/skr/common/scope"
@@ -20,6 +21,10 @@ type reconciler struct {
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+
+	if Ignore != nil && Ignore.ShouldIgnoreKey(request) {
+		return ctrl.Result{}, nil
+	}
 
 	state := r.factory.NewState(request)
 


### PR DESCRIPTION
…wxVolumeBackup reconciler to ignore the object it creates for testing

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- AzureRwxVolumeBackup reconciler to have the ability to ignore specific objects
- AzureRwxVolumeRestore controller test (integration test) to have its AzureRwxVolumeBackup object ignored by AzureRwxVolumeBackup reconciler 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #1211 