### PR TITLE
fix: Update sec-scanners-config.yaml -remove 1.2.4 from scanned images

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -2,7 +2,6 @@ module-name: cloud-manager
 kind: kyma
 bdba:
   - europe-docker.pkg.dev/kyma-project/prod/cloud-manager:main
-  - europe-docker.pkg.dev/kyma-project/prod/cloud-manager:1.2.4
   - europe-docker.pkg.dev/kyma-project/prod/cloud-manager:1.2.5
 mend:
   language: golang-mod


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- remove 1.2.4 from scanned images as 1.2.5 is already in prod. 1.2.4 has outdated x-crypto and x-net


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
