### PR TITLE
refactor(cloud-control): use gcpclient.GcpClientProvider in GcpRedisCluster

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -422,7 +422,7 @@ func main() {
 	}
 	if err = cloudcontrolcontroller.SetupGcpRedisClusterReconciler(
 		mgr,
-		gcpredisclusterclient.NewMemorystoreClientProvider(),
+		gcpredisclusterclient.NewMemorystoreClientProvider(gcpClients),
 		env,
 	); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GcpRedisCluster")

--- a/internal/controller/cloud-control/gcprediscluster_controller.go
+++ b/internal/controller/cloud-control/gcprediscluster_controller.go
@@ -36,7 +36,7 @@ import (
 
 func SetupGcpRedisClusterReconciler(
 	kcpManager manager.Manager,
-	memorystoreClusterClientProvider gcpclient.ClientProvider[client.MemorystoreClusterClient],
+	memorystoreClusterClientProvider gcpclient.GcpClientProvider[client.MemorystoreClusterClient],
 	env abstractions.Environment,
 ) error {
 	if env == nil {

--- a/pkg/kcp/provider/gcp/client/gcpClients.go
+++ b/pkg/kcp/provider/gcp/client/gcpClients.go
@@ -58,7 +58,13 @@ func NewGcpClients(ctx context.Context, saJsonKeyPath string, logger logr.Logger
 
 	// network connectivity ----------------
 
-	ncCrossNetworkAutomation, err := networkconnectivity.NewCrossNetworkAutomationClient(ctx, option.WithTokenSource(computeTokenSource))
+	networkConnectivityTokenProvider, err := b.WithScopes(compute.DefaultAuthScopes()).BuildTokenProvider()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build network connectivity token provider: %w", err)
+	}
+	networkConnectivityTokenSource := oauth2adapt.TokenSourceFromTokenProvider(networkConnectivityTokenProvider)
+
+	ncCrossNetworkAutomation, err := networkconnectivity.NewCrossNetworkAutomationClient(ctx, option.WithTokenSource(networkConnectivityTokenSource))
 	if err != nil {
 		return nil, fmt.Errorf("create network connectivity cross network automation client: %w", err)
 	}

--- a/pkg/kcp/provider/gcp/mock/server.go
+++ b/pkg/kcp/provider/gcp/mock/server.go
@@ -179,9 +179,9 @@ func (s *server) MemoryStoreProviderFake() client.ClientProvider[gcpredisinstanc
 	}
 }
 
-func (s *server) MemoryStoreClusterProviderFake() client.ClientProvider[gcpredisclusterclient.MemorystoreClusterClient] {
-	return func(ctx context.Context, saJsonKeyPath string) (gcpredisclusterclient.MemorystoreClusterClient, error) {
-		return s, nil
+func (s *server) MemoryStoreClusterProviderFake() client.GcpClientProvider[gcpredisclusterclient.MemorystoreClusterClient] {
+	return func() gcpredisclusterclient.MemorystoreClusterClient {
+		return s
 	}
 }
 

--- a/pkg/kcp/provider/gcp/mock/type.go
+++ b/pkg/kcp/provider/gcp/mock/type.go
@@ -42,7 +42,7 @@ type Providers interface {
 	FileBackupClientProvider() client.ClientProvider[gcpnfsbackupclient.FileBackupClient]
 	VpcPeeringProvider() client.ClientProvider[gcpvpcpeeringclient.VpcPeeringClient]
 	MemoryStoreProviderFake() client.ClientProvider[gcpredisinstanceclient.MemorystoreClient]
-	MemoryStoreClusterProviderFake() client.ClientProvider[gcpredisclusterclient.MemorystoreClusterClient]
+	MemoryStoreClusterProviderFake() client.GcpClientProvider[gcpredisclusterclient.MemorystoreClusterClient]
 	ExposedDataProvider() client.GcpClientProvider[gcpexposeddataclient.Client]
 }
 

--- a/pkg/kcp/provider/gcp/rediscluster/client/memorystoreClusterClient.go
+++ b/pkg/kcp/provider/gcp/rediscluster/client/memorystoreClusterClient.go
@@ -10,9 +10,9 @@ import (
 
 	cluster "cloud.google.com/go/redis/cluster/apiv1"
 	"cloud.google.com/go/redis/cluster/apiv1/clusterpb"
-	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	gcpmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/meta"
-	"google.golang.org/api/option"
+
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
@@ -32,29 +32,23 @@ type MemorystoreClusterClient interface {
 	DeleteRedisCluster(ctx context.Context, projectId, locationId, clusterId string) error
 }
 
-func NewMemorystoreClientProvider() client.ClientProvider[MemorystoreClusterClient] {
-	return func(ctx context.Context, saJsonKeyPath string) (MemorystoreClusterClient, error) {
-		return NewMemorystoreClient(saJsonKeyPath), nil
+func NewMemorystoreClientProvider(gcpClients *gcpclient.GcpClients) gcpclient.GcpClientProvider[MemorystoreClusterClient] {
+	return func() MemorystoreClusterClient {
+		return NewMemorystoreClient(gcpClients)
 	}
 }
 
-func NewMemorystoreClient(saJsonKeyPath string) MemorystoreClusterClient {
-	return &memorystoreClient{saJsonKeyPath: saJsonKeyPath}
+func NewMemorystoreClient(gcpClients *gcpclient.GcpClients) MemorystoreClusterClient {
+	return &memorystoreClient{redisClusterClient: gcpClients.RedisCluster}
 }
 
 type memorystoreClient struct {
-	saJsonKeyPath string
+	redisClusterClient *cluster.CloudRedisClusterClient
 }
 
 func (memorystoreClient *memorystoreClient) GetRedisClusterCertificateAuthority(ctx context.Context, projectId, locationId, clusterId string) (string, error) {
-	redisClient, err := cluster.NewCloudRedisClusterClient(ctx, option.WithCredentialsFile(memorystoreClient.saJsonKeyPath))
-	if err != nil {
-		return "", err
-	}
-	defer redisClient.Close() // nolint: errcheck
-
 	name := GetGcpMemoryStoreRedisClusterName(projectId, locationId, clusterId)
-	response, err := redisClient.GetClusterCertificateAuthority(ctx, &clusterpb.GetClusterCertificateAuthorityRequest{
+	response, err := memorystoreClient.redisClusterClient.GetClusterCertificateAuthority(ctx, &clusterpb.GetClusterCertificateAuthorityRequest{
 		Name: name,
 	})
 
@@ -71,11 +65,6 @@ func (memorystoreClient *memorystoreClient) GetRedisClusterCertificateAuthority(
 }
 
 func (memorystoreClient *memorystoreClient) UpdateRedisCluster(ctx context.Context, redisCluster *clusterpb.Cluster, updateMask []string) error {
-	redisClient, err := cluster.NewCloudRedisClusterClient(ctx, option.WithCredentialsFile(memorystoreClient.saJsonKeyPath))
-	if err != nil {
-		return err
-	}
-	defer redisClient.Close() // nolint: errcheck
 	req := &clusterpb.UpdateClusterRequest{
 		UpdateMask: &fieldmaskpb.FieldMask{
 			Paths: updateMask,
@@ -83,7 +72,7 @@ func (memorystoreClient *memorystoreClient) UpdateRedisCluster(ctx context.Conte
 		Cluster: redisCluster,
 	}
 
-	_, err = redisClient.UpdateCluster(ctx, req)
+	_, err := memorystoreClient.redisClusterClient.UpdateCluster(ctx, req)
 	if err != nil {
 		logger := composed.LoggerFromCtx(ctx)
 		logger.Error(err, "Failed to update redis cluster", "redisCluster", redisCluster.Name)
@@ -94,12 +83,6 @@ func (memorystoreClient *memorystoreClient) UpdateRedisCluster(ctx context.Conte
 }
 
 func (memorystoreClient *memorystoreClient) CreateRedisCluster(ctx context.Context, projectId, locationId, clusterId string, options CreateRedisClusterRequest) error {
-	redisClient, err := cluster.NewCloudRedisClusterClient(ctx, option.WithCredentialsFile(memorystoreClient.saJsonKeyPath))
-	if err != nil {
-		return err
-	}
-	defer redisClient.Close() // nolint: errcheck
-
 	parent := fmt.Sprintf("projects/%s/locations/%s", projectId, locationId)
 	req := &clusterpb.CreateClusterRequest{
 		Parent:    parent,
@@ -123,7 +106,7 @@ func (memorystoreClient *memorystoreClient) CreateRedisCluster(ctx context.Conte
 		},
 	}
 
-	_, err = redisClient.CreateCluster(ctx, req)
+	_, err := memorystoreClient.redisClusterClient.CreateCluster(ctx, req)
 
 	if err != nil {
 		logger := composed.LoggerFromCtx(ctx)
@@ -136,18 +119,13 @@ func (memorystoreClient *memorystoreClient) CreateRedisCluster(ctx context.Conte
 
 func (memorystoreClient *memorystoreClient) GetRedisCluster(ctx context.Context, projectId, locationId, clusterId string) (*clusterpb.Cluster, error) {
 	logger := composed.LoggerFromCtx(ctx).WithValues("projectId", projectId, "locationId", locationId, "clusterId", clusterId)
-	redisClient, err := cluster.NewCloudRedisClusterClient(ctx, option.WithCredentialsFile(memorystoreClient.saJsonKeyPath))
-	if err != nil {
-		return nil, err
-	}
-	defer redisClient.Close() // nolint: errcheck
 
 	name := GetGcpMemoryStoreRedisClusterName(projectId, locationId, clusterId)
 	req := &clusterpb.GetClusterRequest{
 		Name: name,
 	}
 
-	instanceResponse, err := redisClient.GetCluster(ctx, req)
+	instanceResponse, err := memorystoreClient.redisClusterClient.GetCluster(ctx, req)
 	if err != nil {
 		if gcpmeta.IsNotFound(err) {
 			logger.Info("target Redis instance not found")
@@ -161,17 +139,11 @@ func (memorystoreClient *memorystoreClient) GetRedisCluster(ctx context.Context,
 }
 
 func (memorystoreClient *memorystoreClient) DeleteRedisCluster(ctx context.Context, projectId string, locationId string, clusterId string) error {
-	redisClient, redisClientErr := cluster.NewCloudRedisClusterClient(ctx, option.WithCredentialsFile(memorystoreClient.saJsonKeyPath))
-	if redisClientErr != nil {
-		return redisClientErr
-	}
-	defer redisClient.Close() // nolint: errcheck
-
 	req := &clusterpb.DeleteClusterRequest{
 		Name: GetGcpMemoryStoreRedisClusterName(projectId, locationId, clusterId),
 	}
 
-	_, err := redisClient.DeleteCluster(ctx, req)
+	_, err := memorystoreClient.redisClusterClient.DeleteCluster(ctx, req)
 
 	if err != nil {
 		logger := composed.LoggerFromCtx(ctx)

--- a/pkg/kcp/provider/gcp/rediscluster/state.go
+++ b/pkg/kcp/provider/gcp/rediscluster/state.go
@@ -32,12 +32,12 @@ type StateFactory interface {
 }
 
 type stateFactory struct {
-	memorystoreClientProvider gcpclient.ClientProvider[client.MemorystoreClusterClient]
+	memorystoreClientProvider gcpclient.GcpClientProvider[client.MemorystoreClusterClient]
 	env                       abstractions.Environment
 }
 
 func NewStateFactory(
-	memorystoreClientProvider gcpclient.ClientProvider[client.MemorystoreClusterClient],
+	memorystoreClientProvider gcpclient.GcpClientProvider[client.MemorystoreClusterClient],
 	env abstractions.Environment,
 ) StateFactory {
 	return &stateFactory{
@@ -48,13 +48,8 @@ func NewStateFactory(
 
 func (statefactory *stateFactory) NewState(ctx context.Context, focalState focal.State) (*State, error) {
 
-	memorystoreClient, err := statefactory.memorystoreClientProvider(
-		ctx,
-		statefactory.env.Get("GCP_SA_JSON_KEY_PATH"),
-	)
-	if err != nil {
-		return nil, err
-	}
+	memorystoreClient := statefactory.memorystoreClientProvider()
+
 	return newState(focalState, memorystoreClient), nil
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- refactor GcpRedisCluster to use gcpclient.GcpClientProvider 
- refactor networkconnectivityclient to use custom token provider

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
