### PR TITLE
fix: change default auth scope provider for networkconnectivity gcpclient

### DIFF
--- a/pkg/kcp/provider/gcp/client/gcpClients.go
+++ b/pkg/kcp/provider/gcp/client/gcpClients.go
@@ -58,7 +58,7 @@ func NewGcpClients(ctx context.Context, saJsonKeyPath string, logger logr.Logger
 
 	// network connectivity ----------------
 
-	networkConnectivityTokenProvider, err := b.WithScopes(compute.DefaultAuthScopes()).BuildTokenProvider()
+	networkConnectivityTokenProvider, err := b.WithScopes(networkconnectivity.DefaultAuthScopes()).BuildTokenProvider()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build network connectivity token provider: %w", err)
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Before change, no issues were detected, as compute auth scope provider is superset of networkconnectivity auth scope

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
