### PR TITLE
fix(GcpNfsVolume): Status not changing to Ready from Updating

### DIFF
--- a/pkg/skr/gcpnfsvolume/updateStatus.go
+++ b/pkg/skr/gcpnfsvolume/updateStatus.go
@@ -87,6 +87,7 @@ func updateStatus(ctx context.Context, st composed.State) (error, context.Contex
 
 	}
 	return composed.PatchStatus(state.ObjAsGcpNfsVolume()).
+		RemoveConditions(cloudresourcesv1beta1.ConditionTypeReady).
 		SuccessError(composed.StopWithRequeueDelay(2*util.Timing.T100ms())).
 		Run(ctx, state)
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Fix for updating the State to `Ready` after resizing the nfs volume size.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #1277