### PR TITLE
chore: lower docker build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.4 as builder
+FROM --platform=$BUILDPLATFORM golang:1.24.4 as builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

According to https://github.com/kyma-project/test-infra/tree/main/cmd/image-builder#cross-compiling-and-caching-for-non-native-architecture-builds to use benefit of cross-compilation it's required to ensure builder stage will run on native build platform.

Changes proposed in this pull request:

- Add `--platform=$BUILDPLATFORM` to ensure builder stage runs on native build platform to cross-compile binary for arm64.
