### PR TITLE
fix: gcpConfig 

### DIFF
--- a/pkg/config/config_bind_test.go
+++ b/pkg/config/config_bind_test.go
@@ -1,11 +1,13 @@
 package config
 
 import (
-	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
+	"github.com/stretchr/testify/assert"
 )
 
 type fileStruct struct {
@@ -13,8 +15,9 @@ type fileStruct struct {
 }
 
 type fileStructDefaults struct {
-	IpRanges      int `mapstructure:"ipranges"`
-	AwsNfsVolumes int `mapstructure:"awsnfsvolumes"`
+	IpRanges      int           `mapstructure:"ipranges"`
+	AwsNfsVolumes int           `mapstructure:"awsnfsvolumes"`
+	Duration      time.Duration `mapstructure:"duration"`
 }
 
 func TestConfigBind(t *testing.T) {
@@ -39,6 +42,7 @@ func TestConfigBind(t *testing.T) {
 	assert.NotNilf(t, obj.Defaults, "expected obj.defaults not to be nil")
 	assert.Equal(t, 1, obj.Defaults.IpRanges)
 	assert.Equal(t, 3, obj.Defaults.AwsNfsVolumes)
+	assert.Equal(t, 30*time.Second, obj.Defaults.Duration)
 
 	// When file content changes
 	err = copyFile("testdata/file-v2.yaml", filepath.Join(dir, "file.yaml"))

--- a/pkg/config/testdata/file-v1.yaml
+++ b/pkg/config/testdata/file-v1.yaml
@@ -1,3 +1,4 @@
 defaults:
   ipranges: 1
   awsnfsvolumes: 3
+  duration: 30s

--- a/pkg/kcp/provider/gcp/client/gcpConfig_test.go
+++ b/pkg/kcp/provider/gcp/client/gcpConfig_test.go
@@ -15,9 +15,9 @@ func Test_GcpConfig(t *testing.T) {
 		GcpConfig = &GcpConfigStruct{}
 
 		env := abstractions.NewMockedEnvironment(map[string]string{
-			"GCP_RETRY_WAIT_DURATION": "123s",
+			"GCP_RETRY_WAIT_DURATION":     "123s",
 			"GCP_OPERATION_WAIT_DURATION": "124s",
-			"GCP_API_TIMEOUT_DURATION": "125s",
+			"GCP_API_TIMEOUT_DURATION":    "125s",
 			"GCP_CAPACITY_CHECK_INTERVAL": "126s",
 		})
 
@@ -26,16 +26,16 @@ func Test_GcpConfig(t *testing.T) {
 		cfg.Read()
 
 		assert.Equal(t, "123s", GcpConfig.RetryWaitTime)
-		assert.Equal(t, 123 *time.Second, GcpConfig.GcpRetryWaitTime)
+		assert.Equal(t, 123*time.Second, GcpConfig.GcpRetryWaitTime)
 
 		assert.Equal(t, "124s", GcpConfig.OperationWaitTime)
-		assert.Equal(t, 124 *time.Second, GcpConfig.GcpOperationWaitTime)
+		assert.Equal(t, 124*time.Second, GcpConfig.GcpOperationWaitTime)
 
 		assert.Equal(t, "125s", GcpConfig.ApiTimeout)
-		assert.Equal(t, 125 *time.Second, GcpConfig.GcpApiTimeout)
+		assert.Equal(t, 125*time.Second, GcpConfig.GcpApiTimeout)
 
 		assert.Equal(t, "126s", GcpConfig.CapacityCheckInterval)
-		assert.Equal(t, 126 *time.Second, GcpConfig.GcpCapacityCheckInterval)
+		assert.Equal(t, 126*time.Second, GcpConfig.GcpCapacityCheckInterval)
 	})
 
 	t.Run("empty", func(t *testing.T) {
@@ -49,13 +49,13 @@ func Test_GcpConfig(t *testing.T) {
 		cfg.Read()
 
 		assert.Equal(t, "5s", GcpConfig.RetryWaitTime)
-		assert.Equal(t, 5 *time.Second, GcpConfig.GcpRetryWaitTime)
+		assert.Equal(t, 5*time.Second, GcpConfig.GcpRetryWaitTime)
 
 		assert.Equal(t, "5s", GcpConfig.OperationWaitTime)
-		assert.Equal(t, 5 *time.Second, GcpConfig.GcpOperationWaitTime)
+		assert.Equal(t, 5*time.Second, GcpConfig.GcpOperationWaitTime)
 
 		assert.Equal(t, "8s", GcpConfig.ApiTimeout)
-		assert.Equal(t, 8 *time.Second, GcpConfig.GcpApiTimeout)
+		assert.Equal(t, 8*time.Second, GcpConfig.GcpApiTimeout)
 
 		assert.Equal(t, "1h", GcpConfig.CapacityCheckInterval)
 		assert.Equal(t, time.Hour, GcpConfig.GcpCapacityCheckInterval)

--- a/pkg/kcp/provider/gcp/client/gcpConfig_test.go
+++ b/pkg/kcp/provider/gcp/client/gcpConfig_test.go
@@ -1,0 +1,63 @@
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
+	"github.com/kyma-project/cloud-manager/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GcpConfig(t *testing.T) {
+
+	t.Run("with env set", func(t *testing.T) {
+		GcpConfig = &GcpConfigStruct{}
+
+		env := abstractions.NewMockedEnvironment(map[string]string{
+			"GCP_RETRY_WAIT_DURATION": "123s",
+			"GCP_OPERATION_WAIT_DURATION": "124s",
+			"GCP_API_TIMEOUT_DURATION": "125s",
+			"GCP_CAPACITY_CHECK_INTERVAL": "126s",
+		})
+
+		cfg := config.NewConfig(env)
+		InitConfig(cfg)
+		cfg.Read()
+
+		assert.Equal(t, "123s", GcpConfig.RetryWaitTime)
+		assert.Equal(t, 123 *time.Second, GcpConfig.GcpRetryWaitTime)
+
+		assert.Equal(t, "124s", GcpConfig.OperationWaitTime)
+		assert.Equal(t, 124 *time.Second, GcpConfig.GcpOperationWaitTime)
+
+		assert.Equal(t, "125s", GcpConfig.ApiTimeout)
+		assert.Equal(t, 125 *time.Second, GcpConfig.GcpApiTimeout)
+
+		assert.Equal(t, "126s", GcpConfig.CapacityCheckInterval)
+		assert.Equal(t, 126 *time.Second, GcpConfig.GcpCapacityCheckInterval)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		// must instantiate a new one to isolate from previous tests
+		GcpConfig = &GcpConfigStruct{}
+
+		env := abstractions.NewMockedEnvironment(map[string]string{})
+
+		cfg := config.NewConfig(env)
+		InitConfig(cfg)
+		cfg.Read()
+
+		assert.Equal(t, "5s", GcpConfig.RetryWaitTime)
+		assert.Equal(t, 5 *time.Second, GcpConfig.GcpRetryWaitTime)
+
+		assert.Equal(t, "5s", GcpConfig.OperationWaitTime)
+		assert.Equal(t, 5 *time.Second, GcpConfig.GcpOperationWaitTime)
+
+		assert.Equal(t, "8s", GcpConfig.ApiTimeout)
+		assert.Equal(t, 8 *time.Second, GcpConfig.GcpApiTimeout)
+
+		assert.Equal(t, "1h", GcpConfig.CapacityCheckInterval)
+		assert.Equal(t, time.Hour, GcpConfig.GcpCapacityCheckInterval)
+	})
+}

--- a/pkg/kcp/provider/gcp/client/gcpConstants.go
+++ b/pkg/kcp/provider/gcp/client/gcpConstants.go
@@ -90,6 +90,9 @@ func GetDuration(value string, defaultValue time.Duration) time.Duration {
 	if err != nil {
 		return defaultValue
 	}
+	if duration <= 0 {
+		return GcpApiTimeout
+	}
 	return duration
 }
 

--- a/pkg/kcp/provider/gcp/client/gcpConstants.go
+++ b/pkg/kcp/provider/gcp/client/gcpConstants.go
@@ -75,7 +75,7 @@ func InitConfig(cfg config.Config) {
 		),
 		config.Path(
 			"capacityCheckInterval",
-			config.DefaultScalar(1*time.Hour),
+			config.DefaultScalar("1h"),
 			config.SourceEnv("GCP_CAPACITY_CHECK_INTERVAL"),
 		),
 		config.SourceFile("gcpclient.GcpConfig.yaml"),


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- fixed default value for `capacityCheckInterval`
- changed `gcp.client.GetDuration()` to return `GcpApiTimeout` in case given duration is zero or less
- added test for GcpConfig
- changed config so it parse non-strings like ints, floats, duration, slice... 
- changed `composed.Handle()` not to allow zero requeue delay, but to switch it to 1h instead

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
