### PR TITLE
docs(AzureVpcPeering): service principal needs to be identified in earlier steps

### DIFF
--- a/docs/user/tutorials/01-30-30-azure-vpc-peering.md
+++ b/docs/user/tutorials/01-30-30-azure-vpc-peering.md
@@ -22,7 +22,7 @@ This tutorial explains how to create a Virtual Private Cloud (VPC) peering conne
    az account set --subscription $SUBSCRIPTION
    ```
 
-2. Verify if the Cloud Manager service principal exists in your tenant.
+2. Verify if the Cloud Manager service principal exists in your tenant. See [Authorizing Cloud Manager in the Remote Cloud Provider](../00-31-vpc-peering-authorization.md#microsoft-azure) to identify the Cloud Manager principal.
    ```shell
    export APPLICATION_ID={APPLICATION_ID}
    az ad sp show --id $APPLICATION_ID
@@ -31,7 +31,7 @@ This tutorial explains how to create a Virtual Private Cloud (VPC) peering conne
    ```shell
    az ad sp create --id $APPLICATION_ID
    ```
-4. Assign the required `Classic Network Contributor` and `Network Contributor` Identity and Access Management (IAM) roles to the Cloud Manager service principal. See [Authorizing Cloud Manager in the Remote Cloud Provider](../00-31-vpc-peering-authorization.md#microsoft-azure) to identify the Cloud Manager principal.
+4. Assign the required `Classic Network Contributor` and `Network Contributor` Identity and Access Management (IAM) roles to the Cloud Manager service principal.
     ```shell
     export SUBSCRIPTION_ID=$(az account show --query id -o tsv)
     export OBJECT_ID=$(az ad sp show --id $APPLICATION_ID --query "id" -o tsv)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Identification of service principal moved from step 4 to step 2
