### PR TITLE
fix: Azure vnetLoad use resourceGroupName instead of resourceName

### DIFF
--- a/pkg/kcp/provider/azure/exposedData/vnetLoad.go
+++ b/pkg/kcp/provider/azure/exposedData/vnetLoad.go
@@ -2,6 +2,7 @@ package exposedData
 
 import (
 	"context"
+
 	"github.com/kyma-project/cloud-manager/pkg/common"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	azuremeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/meta"
@@ -14,7 +15,7 @@ func vnetLoad(ctx context.Context, st composed.State) (error, context.Context) {
 		return composed.LogErrorAndReturn(common.ErrLogical, "KCP Kyma Network has invalid network id", composed.StopAndForget, ctx)
 	}
 
-	vnet, err := state.azureClient.GetNetwork(ctx, state.networkId.ResourceName, state.networkId.NetworkName())
+	vnet, err := state.azureClient.GetNetwork(ctx, state.networkId.ResourceGroup, state.networkId.NetworkName())
 	if err != nil {
 		return azuremeta.LogErrorAndReturn(err, "Error loading Azure vnet", ctx)
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- pass `ResourceGroup` instead of `ResourceName` to `GetNetwork(ctx context.Context, resourceGroupName, virtualNetworkName string) (*armnetwork.VirtualNetwork, error)` method.
  - in practice, resourceName and resourceGroupName are same, and that's why there were no issues. But that is just an implementation detail, and we should not rely on it.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
