### PR TITLE
fix: aws arn partition

### DIFF
--- a/pkg/kcp/provider/aws/config/config.go
+++ b/pkg/kcp/provider/aws/config/config.go
@@ -1,11 +1,13 @@
 package config
 
 import (
-	"github.com/kyma-project/cloud-manager/pkg/config"
 	"time"
+
+	"github.com/kyma-project/cloud-manager/pkg/config"
 )
 
 type AwsConfigStruct struct {
+	ArnPartition             string        `json:"arnPartition" yaml:"arnPartition"`
 	Default                  AwsCreds      `json:"default" yaml:"default"`
 	Peering                  AwsCreds      `json:"peering" yaml:"peering"`
 	BackupRoleName           string        `json:"backupRoleName" yaml:"backupRoleName"`
@@ -24,6 +26,12 @@ func InitConfig(cfg config.Config) {
 	cfg.Path(
 		"aws.config",
 		config.Bind(AwsConfig),
+		config.Path(
+			"arnPartition",
+			config.SourceEnv("AWS_PARTITION"),
+			config.SourceFile("AWS_PARTITION"),
+			config.DefaultScalar("aws"),
+		),
 		config.Path(
 			"default.accessKeyId",
 			config.SourceEnv("AWS_ACCESS_KEY_ID"),

--- a/pkg/kcp/provider/aws/config/config_test.go
+++ b/pkg/kcp/provider/aws/config/config_test.go
@@ -1,13 +1,26 @@
 package config
 
 import (
-	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
-	"github.com/kyma-project/cloud-manager/pkg/config"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
+	"github.com/kyma-project/cloud-manager/pkg/config"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestConfigDefaultValues(t *testing.T) {
+	env := abstractions.NewMockedEnvironment(map[string]string{})
+	cfg := config.NewConfig(env)
+	InitConfig(cfg)
+	cfg.Read()
+
+	assert.Equal(t, "aws", AwsConfig.ArnPartition)
+	assert.Equal(t, "CloudManagerBackupServiceRole", AwsConfig.BackupRoleName)
+	assert.Equal(t, time.Hour, AwsConfig.EfsCapacityCheckInterval)
+}
 
 func TestConfigAllFromEnv(t *testing.T) {
 	env := abstractions.NewMockedEnvironment(map[string]string{

--- a/pkg/kcp/provider/aws/exposedData/state.go
+++ b/pkg/kcp/provider/aws/exposedData/state.go
@@ -2,12 +2,13 @@ package exposedData
 
 import (
 	"context"
-	"fmt"
+
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	awsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/client"
 	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
 	awsexposeddataclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/exposedData/client"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
 	scopetypes "github.com/kyma-project/cloud-manager/pkg/kcp/scope/types"
 )
 
@@ -28,7 +29,7 @@ type stateFactory struct {
 }
 
 func (f *stateFactory) NewState(ctx context.Context, baseState scopetypes.State) (context.Context, composed.State, error) {
-	roleName := fmt.Sprintf("arn:aws:iam::%s:role/%s", baseState.ObjAsScope().Spec.Scope.Aws.AccountId, awsconfig.AwsConfig.Default.AssumeRoleName)
+	roleName := awsutil.RoleArnDefault(baseState.ObjAsScope().Spec.Scope.Aws.AccountId)
 
 	logger := composed.LoggerFromCtx(ctx)
 	logger = logger.WithValues("awsAssumeRoleName", roleName)

--- a/pkg/kcp/provider/aws/iprange/v2/state.go
+++ b/pkg/kcp/provider/aws/iprange/v2/state.go
@@ -2,13 +2,14 @@ package v2
 
 import (
 	"context"
-	"fmt"
+
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/go-logr/logr"
 	iprangetypes "github.com/kyma-project/cloud-manager/pkg/kcp/iprange/types"
 	awsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/client"
 	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
 	awsiprangeclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/iprange/client"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
 )
 
 type State struct {
@@ -37,7 +38,7 @@ type stateFactory struct {
 }
 
 func (f *stateFactory) NewState(ctx context.Context, ipRangeState iprangetypes.State, logger logr.Logger) (*State, error) {
-	roleName := fmt.Sprintf("arn:aws:iam::%s:role/%s", ipRangeState.Scope().Spec.Scope.Aws.AccountId, awsconfig.AwsConfig.Default.AssumeRoleName)
+	roleName := awsutil.RoleArnDefault(ipRangeState.Scope().Spec.Scope.Aws.AccountId)
 
 	logger.
 		WithValues(

--- a/pkg/kcp/provider/aws/nfsinstance/state.go
+++ b/pkg/kcp/provider/aws/nfsinstance/state.go
@@ -2,7 +2,7 @@ package nfsinstance
 
 import (
 	"context"
-	"fmt"
+
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	efstypes "github.com/aws/aws-sdk-go-v2/service/efs/types"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
@@ -10,6 +10,7 @@ import (
 	awsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/client"
 	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
 	awsnfsinstanceclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/nfsinstance/client"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
 )
 
 type State struct {
@@ -39,7 +40,7 @@ type stateFactory struct {
 }
 
 func (f *stateFactory) NewState(ctx context.Context, nfsInstanceState nfsinstancetypes.State) (*State, error) {
-	roleName := fmt.Sprintf("arn:aws:iam::%s:role/%s", nfsInstanceState.Scope().Spec.Scope.Aws.AccountId, awsconfig.AwsConfig.Default.AssumeRoleName)
+	roleName := awsutil.RoleArnDefault(nfsInstanceState.Scope().Spec.Scope.Aws.AccountId)
 
 	c, err := f.skrProvider(
 		ctx,

--- a/pkg/kcp/provider/aws/nuke/createAwsClient.go
+++ b/pkg/kcp/provider/aws/nuke/createAwsClient.go
@@ -2,21 +2,17 @@ package nuke
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
 )
 
 func createAwsClient(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
 	logger := composed.LoggerFromCtx(ctx)
 
-	roleName := fmt.Sprintf(
-		"arn:aws:iam::%s:role/%s",
-		state.Scope().Spec.Scope.Aws.AccountId,
-		awsconfig.AwsConfig.Default.AssumeRoleName,
-	)
+	roleName := awsutil.RoleArnDefault(state.Scope().Spec.Scope.Aws.AccountId)
 
 	logger.
 		WithValues(

--- a/pkg/kcp/provider/aws/rediscluster/state.go
+++ b/pkg/kcp/provider/aws/rediscluster/state.go
@@ -2,7 +2,6 @@ package rediscluster
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -12,6 +11,7 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	awsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/client"
 	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
 	"github.com/kyma-project/cloud-manager/pkg/kcp/rediscluster/types"
 	"k8s.io/utils/ptr"
 )
@@ -54,7 +54,7 @@ type stateFactory struct {
 }
 
 func (f *stateFactory) NewState(ctx context.Context, redisInstace types.State) (*State, error) {
-	roleName := fmt.Sprintf("arn:aws:iam::%s:role/%s", redisInstace.Scope().Spec.Scope.Aws.AccountId, awsconfig.AwsConfig.Default.AssumeRoleName)
+	roleName := awsutil.RoleArnDefault(redisInstace.Scope().Spec.Scope.Aws.AccountId)
 
 	logger := composed.LoggerFromCtx(ctx)
 	logger.

--- a/pkg/kcp/provider/aws/redisinstance/state.go
+++ b/pkg/kcp/provider/aws/redisinstance/state.go
@@ -2,7 +2,6 @@ package redisinstance
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -11,6 +10,7 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	awsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/client"
 	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
 	"github.com/kyma-project/cloud-manager/pkg/kcp/redisinstance/types"
 	"k8s.io/utils/ptr"
 )
@@ -53,7 +53,7 @@ type stateFactory struct {
 }
 
 func (f *stateFactory) NewState(ctx context.Context, redisInstace types.State) (*State, error) {
-	roleName := fmt.Sprintf("arn:aws:iam::%s:role/%s", redisInstace.Scope().Spec.Scope.Aws.AccountId, awsconfig.AwsConfig.Default.AssumeRoleName)
+	roleName := awsutil.RoleArnDefault(redisInstace.Scope().Spec.Scope.Aws.AccountId)
 
 	logger := composed.LoggerFromCtx(ctx)
 	logger.

--- a/pkg/kcp/provider/aws/util/arn.go
+++ b/pkg/kcp/provider/aws/util/arn.go
@@ -1,0 +1,92 @@
+package util
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
+)
+
+var arnResourceTypeRegex = regexp.MustCompile("[:/]")
+
+func StripArnResourceType(resource string) string {
+	arr := arnResourceTypeRegex.Split(resource, -1)
+	if len(arr) == 1 {
+		return arr[0]
+	}
+	return arr[1]
+}
+
+func ParseArnResourceId(arnStr string) string {
+	a, err := arn.Parse(arnStr)
+	if err != nil {
+		return ""
+	}
+	return StripArnResourceType(a.Resource)
+}
+
+// IAM Role =====================================================================
+
+// RoleArn returns string arn in form "arn:<partition>:iam::<accountId>:role/<roleName>"
+func RoleArn(accountId, roleName string) string {
+	a := &arn.ARN{
+		Partition: awsconfig.AwsConfig.ArnPartition,
+		Service:   "iam",
+		AccountID: accountId,
+		Resource:  fmt.Sprintf("role/%s", roleName),
+	}
+	return a.String()
+}
+
+func RoleArnDefault(accountId string) string {
+	return RoleArn(accountId, awsconfig.AwsConfig.Default.AssumeRoleName)
+}
+
+func RoleArnPeering(accountId string) string {
+	return RoleArn(accountId, awsconfig.AwsConfig.Peering.AssumeRoleName)
+}
+
+func RoleArnBackup(accountId string) string {
+	return RoleArn(accountId, awsconfig.AwsConfig.BackupRoleName)
+}
+
+// EFS ============================================================================
+
+// EfsArn returns string arn in form "arn:<partition>:elasticfilesystem:<region>:<accountId>:file-system/<fileSystemId>"
+func EfsArn(region, accountId, fileSystemId string) string {
+	a := &arn.ARN{
+		Partition: awsconfig.AwsConfig.ArnPartition,
+		Service:   "elasticfilesystem",
+		Region:    region,
+		AccountID: accountId,
+		Resource:  fmt.Sprintf("file-system/%s", fileSystemId),
+	}
+	return a.String()
+}
+
+// Backup =====================================================================
+
+// BackupVaultArn returns string arn in form "arn:<partition>:backup:<region>:<accountId>:backup-vault:<vaultName>"
+func BackupVaultArn(region, accountId, vaultName string) string {
+	a := &arn.ARN{
+		Partition: awsconfig.AwsConfig.ArnPartition,
+		Service:   "backup",
+		Region:    region,
+		AccountID: accountId,
+		Resource:  fmt.Sprintf("backup-vault:%s", vaultName),
+	}
+	return a.String()
+}
+
+// BackupRecoveryPointArn returns string arn in form "arn:<partition>:backup:<region>:<accountId>:recovery-point:<recoveryPointId>"
+func BackupRecoveryPointArn(region, accountId, recoveryPointId string) string {
+	a := &arn.ARN{
+		Partition: awsconfig.AwsConfig.ArnPartition,
+		Service:   "backup",
+		Region:    region,
+		AccountID: accountId,
+		Resource:  fmt.Sprintf("recovery-point:%s", recoveryPointId),
+	}
+	return a.String()
+}

--- a/pkg/kcp/provider/aws/util/arn_test.go
+++ b/pkg/kcp/provider/aws/util/arn_test.go
@@ -1,0 +1,118 @@
+package util
+
+import (
+	"testing"
+
+	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArn(t *testing.T) {
+
+	t.Run("StripArnResourceType", func(t *testing.T) {
+		for in, expected := range map[string]string{
+			"role/roleName": "roleName",
+			"role:roleName": "roleName",
+			"roleName":      "roleName",
+		} {
+			res := StripArnResourceType(in)
+			assert.Equal(t, expected, res)
+		}
+	})
+
+	t.Run("ParseArnResourceId", func(t *testing.T) {
+		for in, expected := range map[string]string{
+			"invalid-arn":                       "",
+			"arn:aws:iam::123123:role":          "role",
+			"arn:aws:iam::123123:role/":         "",
+			"arn:aws:iam::123123:role/roleName": "roleName",
+		} {
+			res := ParseArnResourceId(in)
+			assert.Equal(t, expected, res)
+		}
+	})
+
+	awsconfig.AwsConfig.Default.AssumeRoleName = "DefaultRole"
+	awsconfig.AwsConfig.Peering.AssumeRoleName = "PeeringRole"
+	awsconfig.AwsConfig.BackupRoleName = "BackupRole"
+
+	t.Run("partition custom", func(t *testing.T) {
+		awsconfig.AwsConfig.ArnPartition = "aws-cn"
+
+		t.Run("RoleArn", func(t *testing.T) {
+			x := RoleArn("123123", "roleName")
+			assert.Equal(t, "arn:aws-cn:iam::123123:role/roleName", x)
+		})
+
+		t.Run("AssumeRoleArnDefault", func(t *testing.T) {
+			x := RoleArnDefault("123123")
+			assert.Equal(t, "arn:aws-cn:iam::123123:role/DefaultRole", x)
+		})
+
+		t.Run("AssumeRoleArnPeering", func(t *testing.T) {
+			x := RoleArnPeering("123123")
+			assert.Equal(t, "arn:aws-cn:iam::123123:role/PeeringRole", x)
+		})
+
+		t.Run("AssumeRoleArnBackup", func(t *testing.T) {
+			x := RoleArnBackup("123123")
+			assert.Equal(t, "arn:aws-cn:iam::123123:role/BackupRole", x)
+		})
+
+		t.Run("EfsArn", func(t *testing.T) {
+			x := EfsArn("us-east-1", "123123", "fs-123456")
+			assert.Equal(t, "arn:aws-cn:elasticfilesystem:us-east-1:123123:file-system/fs-123456", x)
+		})
+
+		t.Run("BackupVaultArn", func(t *testing.T) {
+			x := BackupVaultArn("us-east-1", "123123", "my-vault")
+			assert.Equal(t, "arn:aws-cn:backup:us-east-1:123123:backup-vault:my-vault", x)
+		})
+
+		t.Run("BackupRecoveryPointArn", func(t *testing.T) {
+			x := BackupRecoveryPointArn("us-east-1", "123123", "my-point")
+			assert.Equal(t, "arn:aws-cn:backup:us-east-1:123123:recovery-point:my-point", x)
+		})
+
+	})
+
+	t.Run("partition default", func(t *testing.T) {
+		awsconfig.AwsConfig.ArnPartition = "aws"
+
+		t.Run("RoleArn", func(t *testing.T) {
+			x := RoleArn("123123", "roleName")
+			assert.Equal(t, "arn:aws:iam::123123:role/roleName", x)
+		})
+
+		t.Run("AssumeRoleArnDefault", func(t *testing.T) {
+			x := RoleArnDefault("123123")
+			assert.Equal(t, "arn:aws:iam::123123:role/DefaultRole", x)
+		})
+
+		t.Run("AssumeRoleArnPeering", func(t *testing.T) {
+			x := RoleArnPeering("123123")
+			assert.Equal(t, "arn:aws:iam::123123:role/PeeringRole", x)
+		})
+
+		t.Run("AssumeRoleArnBackup", func(t *testing.T) {
+			x := RoleArnBackup("123123")
+			assert.Equal(t, "arn:aws:iam::123123:role/BackupRole", x)
+		})
+
+		t.Run("EfsArn", func(t *testing.T) {
+			x := EfsArn("us-east-1", "123123", "fs-123456")
+			assert.Equal(t, "arn:aws:elasticfilesystem:us-east-1:123123:file-system/fs-123456", x)
+		})
+
+		t.Run("BackupVaultArn", func(t *testing.T) {
+			x := BackupVaultArn("us-east-1", "123123", "my-vault")
+			assert.Equal(t, "arn:aws:backup:us-east-1:123123:backup-vault:my-vault", x)
+		})
+
+		t.Run("BackupRecoveryPointArn", func(t *testing.T) {
+			x := BackupRecoveryPointArn("us-east-1", "123123", "my-point")
+			assert.Equal(t, "arn:aws:backup:us-east-1:123123:recovery-point:my-point", x)
+		})
+	})
+
+}

--- a/pkg/kcp/provider/aws/vpcpeering/createRemoteClient.go
+++ b/pkg/kcp/provider/aws/vpcpeering/createRemoteClient.go
@@ -6,6 +6,7 @@ import (
 
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +24,7 @@ func createRemoteClient(ctx context.Context, st composed.State) (error, context.
 	remoteAccountId := state.remoteNetwork.Status.Network.Aws.AwsAccountId
 	remoteRegion := state.remoteNetwork.Status.Network.Aws.Region
 
-	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", remoteAccountId, state.roleName)
+	roleArn := awsutil.RoleArnPeering(remoteAccountId)
 
 	composed.LoggerIntoCtx(ctx, logger.WithValues(
 		"remoteAwsRegion", remoteRegion,

--- a/pkg/skr/awsnfsvolumebackup/createAwsClient.go
+++ b/pkg/skr/awsnfsvolumebackup/createAwsClient.go
@@ -8,6 +8,7 @@ import (
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -16,11 +17,7 @@ func createAwsClient(ctx context.Context, st composed.State) (error, context.Con
 	logger := composed.LoggerFromCtx(ctx)
 	backup := state.ObjAsAwsNfsVolumeBackup()
 
-	roleName := fmt.Sprintf(
-		"arn:aws:iam::%s:role/%s",
-		state.Scope().Spec.Scope.Aws.AccountId,
-		awsconfig.AwsConfig.Default.AssumeRoleName,
-	)
+	roleName := awsutil.RoleArnDefault(state.Scope().Spec.Scope.Aws.AccountId)
 
 	logger.
 		WithValues(

--- a/pkg/skr/awsnfsvolumebackup/createAwsDestBackup.go
+++ b/pkg/skr/awsnfsvolumebackup/createAwsDestBackup.go
@@ -6,6 +6,7 @@ import (
 
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
 	"github.com/kyma-project/cloud-manager/pkg/skr/awsnfsvolumebackup/client"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,7 @@ func createAwsDestBackup(ctx context.Context, st composed.State) (error, context
 		SourceBackupVaultName:     state.GetVaultName(),
 		DestinationBackupVaultArn: state.GetDestinationBackupVaultArn(),
 		RecoveryPointArn:          state.GetRecoveryPointArn(),
-		IamRoleArn:                state.GetBackupRoleArn(),
+		IamRoleArn:                awsutil.RoleArnBackup(state.Scope().Spec.Scope.Aws.AccountId),
 		IdempotencyToken:          ptr.To(backup.Status.IdempotencyToken),
 	})
 	if err != nil {

--- a/pkg/skr/awsnfsvolumebackup/deleteAwsBackup_test.go
+++ b/pkg/skr/awsnfsvolumebackup/deleteAwsBackup_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-logr/logr"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
 	"github.com/kyma-project/cloud-manager/pkg/skr/awsnfsvolumebackup/client"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/apimachinery/pkg/types"
@@ -93,7 +94,7 @@ func (s *deleteAwsBackupSuite) TestDeleteAwsBackupAfterCreatingBackup() {
 
 	//update jobId and Id fields with empty values
 	obj.Status.State = cloudresourcesv1beta1.StateReady
-	obj.Status.Id = state.awsClient.ParseRecoveryPointId(ptr.Deref(res.RecoveryPointArn, ""))
+	obj.Status.Id = awsutil.ParseArnResourceId(ptr.Deref(res.RecoveryPointArn, ""))
 	obj.Status.JobId = ptr.Deref(res.BackupJobId, "")
 	err = factory.skrCluster.K8sClient().Status().Update(ctx, obj)
 	s.Nil(err)

--- a/pkg/skr/awsnfsvolumebackup/loadAwsBackup_test.go
+++ b/pkg/skr/awsnfsvolumebackup/loadAwsBackup_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
 	"github.com/kyma-project/cloud-manager/pkg/skr/awsnfsvolumebackup/client"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/utils/ptr"
@@ -111,7 +112,7 @@ func (s *loadAwsBackupSuite) TestLoadAwsBackupAfterCreatingBackup() {
 
 	//update jobId and Id fields with empty values
 	obj.Status.State = cloudresourcesv1beta1.StateReady
-	obj.Status.Id = state.awsClient.ParseRecoveryPointId(ptr.Deref(res.RecoveryPointArn, ""))
+	obj.Status.Id = awsutil.ParseArnResourceId(ptr.Deref(res.RecoveryPointArn, ""))
 	obj.Status.JobId = ptr.Deref(res.BackupJobId, "")
 	err = factory.skrCluster.K8sClient().Status().Update(ctx, obj)
 	s.Nil(err)

--- a/pkg/skr/awsnfsvolumebackup/loadAwsCopyJob.go
+++ b/pkg/skr/awsnfsvolumebackup/loadAwsCopyJob.go
@@ -7,8 +7,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/backup/types"
 	"github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func loadAwsCopyJob(ctx context.Context, st composed.State) (error, context.Context) {
@@ -68,7 +70,7 @@ func loadAwsCopyJob(ctx context.Context, st composed.State) (error, context.Cont
 
 	//Update the remoteId with the value from CopyJob.
 	logger.Info("Updating the Status with remote RestorePoint details")
-	remoteId := state.awsClient.ParseRecoveryPointId(*copyJob.CopyJob.DestinationRecoveryPointArn)
+	remoteId := awsutil.ParseArnResourceId(ptr.Deref(copyJob.CopyJob.DestinationRecoveryPointArn, ""))
 	backup.Status.RemoteId = remoteId
 	backup.Status.Locations = append(backup.Status.Locations, backup.Spec.Location)
 	return composed.PatchStatus(backup).

--- a/pkg/skr/awsnfsvolumebackup/state.go
+++ b/pkg/skr/awsnfsvolumebackup/state.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	awsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/client"
 	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
 	awsnfsvolumebackupclient "github.com/kyma-project/cloud-manager/pkg/skr/awsnfsvolumebackup/client"
 	commonscope "github.com/kyma-project/cloud-manager/pkg/skr/common/scope"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -83,8 +84,7 @@ func (s *State) GetFileSystemArn() string {
 	if s.kcpAwsNfsInstance == nil || s.Scope() == nil {
 		return ""
 	}
-	arn := fmt.Sprintf("arn:aws:elasticfilesystem:%s:%s:file-system/%s",
-		s.Scope().Spec.Region, s.Scope().Spec.Scope.Aws.AccountId, s.kcpAwsNfsInstance.Status.Id)
+	arn := awsutil.EfsArn(s.Scope().Spec.Region, s.Scope().Spec.Scope.Aws.AccountId, s.kcpAwsNfsInstance.Status.Id)
 	return arn
 }
 
@@ -93,17 +93,7 @@ func (s *State) GetRecoveryPointArn() string {
 	if len(id) == 0 || s.Scope() == nil {
 		return ""
 	}
-	arn := fmt.Sprintf("arn:aws:backup:%s:%s:recovery-point:%s",
-		s.Scope().Spec.Region, s.Scope().Spec.Scope.Aws.AccountId, id)
-	return arn
-}
-
-func (s *State) GetBackupRoleArn() string {
-	if s.Scope() == nil {
-		return ""
-	}
-	arn := fmt.Sprintf("arn:aws:iam::%s:role/%s",
-		s.Scope().Spec.Scope.Aws.AccountId, awsconfig.AwsConfig.BackupRoleName)
+	arn := awsutil.BackupRecoveryPointArn(s.Scope().Spec.Region, s.Scope().Spec.Scope.Aws.AccountId, id)
 	return arn
 }
 
@@ -137,8 +127,7 @@ func (s *State) GetDestinationBackupVaultArn() string {
 	if len(s.ObjAsAwsNfsVolumeBackup().Spec.Location) == 0 || s.Scope() == nil {
 		return ""
 	}
-	arn := fmt.Sprintf("arn:aws:backup:%s:%s:backup-vault:%s",
-		s.ObjAsAwsNfsVolumeBackup().Spec.Location, s.Scope().Spec.Scope.Aws.AccountId, s.GetVaultName())
+	arn := awsutil.BackupVaultArn(s.ObjAsAwsNfsVolumeBackup().Spec.Location, s.Scope().Spec.Scope.Aws.AccountId, s.GetVaultName())
 	return arn
 }
 
@@ -148,8 +137,7 @@ func (s *State) GetDestinationRecoveryPointArn() string {
 		return ""
 	}
 
-	arn := fmt.Sprintf("arn:aws:backup:%s:%s:recovery-point:%s",
-		s.ObjAsAwsNfsVolumeBackup().Spec.Location, s.Scope().Spec.Scope.Aws.AccountId, id)
+	arn := awsutil.BackupRecoveryPointArn(s.ObjAsAwsNfsVolumeBackup().Spec.Location, s.Scope().Spec.Scope.Aws.AccountId, id)
 	return arn
 }
 

--- a/pkg/skr/awsnfsvolumerestore/createAwsClient.go
+++ b/pkg/skr/awsnfsvolumerestore/createAwsClient.go
@@ -2,9 +2,11 @@ package awsnfsvolumerestore
 
 import (
 	"context"
-	"fmt"
+
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
+
 	"time"
 )
 
@@ -12,11 +14,7 @@ func createAwsClient(ctx context.Context, st composed.State) (error, context.Con
 	state := st.(*State)
 	logger := composed.LoggerFromCtx(ctx)
 
-	roleName := fmt.Sprintf(
-		"arn:aws:iam::%s:role/%s",
-		state.Scope().Spec.Scope.Aws.AccountId,
-		awsconfig.AwsConfig.Default.AssumeRoleName,
-	)
+	roleName := awsutil.RoleArnDefault(state.Scope().Spec.Scope.Aws.AccountId)
 
 	logger.
 		WithValues(

--- a/pkg/skr/awsnfsvolumerestore/state.go
+++ b/pkg/skr/awsnfsvolumerestore/state.go
@@ -2,11 +2,12 @@ package awsnfsvolumerestore
 
 import (
 	"fmt"
+
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	awsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/client"
-	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
+	awsutil "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/util"
 	restoreclient "github.com/kyma-project/cloud-manager/pkg/skr/awsnfsvolumerestore/client"
 	commonscope "github.com/kyma-project/cloud-manager/pkg/skr/common/scope"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -63,15 +64,13 @@ func (s *State) GetRecoveryPointArn() string {
 	if id == "" {
 		return ""
 	}
-	arn := fmt.Sprintf("arn:aws:backup:%s:%s:recovery-point:%s",
-		s.Scope().Spec.Region, s.Scope().Spec.Scope.Aws.AccountId, id)
-	return arn
+	arnTxt := awsutil.BackupRecoveryPointArn(s.Scope().Spec.Region, s.Scope().Spec.Scope.Aws.AccountId, id)
+	return arnTxt
 }
 
 func (s *State) GetBackupRoleArn() string {
-	arn := fmt.Sprintf("arn:aws:iam::%s:role/%s",
-		s.Scope().Spec.Scope.Aws.AccountId, awsconfig.AwsConfig.BackupRoleName)
-	return arn
+	arnTxt := awsutil.RoleArnBackup(s.Scope().Spec.Scope.Aws.AccountId)
+	return arnTxt
 }
 
 func (s *State) GetVaultName() string {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- added field `ArnPartition` to `AwsConfig` that defaults to `aws`
- added in `awsutil` package ARN building funcs for resources we use
- replaced our own parsing with regex with AWS SDK arn package

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
