### PR TITLE
docs(AzureVpcPeering): remove warning

### DIFF
--- a/docs/user/resources/04-30-30-azure-vpc-peering.md
+++ b/docs/user/resources/04-30-30-azure-vpc-peering.md
@@ -1,8 +1,5 @@
 # AzureVpcPeering Custom Resource
 
-> [!Warning]
-> VPC peering for Microsoft Azure is a feature available only for SAP-internal teams.
-
 The `azurevpcpeering.cloud-resources.kyma-project.io` custom resource (CR) specifies the virtual network peering between Kyma and the remote Azure Virtual Private Cloud (VPC) network. Virtual network peering is only possible within Microsoft Azure networks whose subscriptions are sharing the same tenant determined by the Kyma underlying cloud provider landscape.
 
 Once an `AzureVpcPeering` CR is created and reconciled, the Cloud Manager controller creates a VPC peering connection in the VPC network of the Kyma cluster in the underlying cloud provider landscape, and accepts a VPC peering connection in the remote cloud provider landscape.

--- a/docs/user/tutorials/01-30-30-azure-vpc-peering.md
+++ b/docs/user/tutorials/01-30-30-azure-vpc-peering.md
@@ -1,8 +1,5 @@
 # Creating VPC Peering in Microsoft Azure
 
-> [!Warning]
-> VPC peering for Microsoft Azure is a feature available only for SAP-internal teams.
-
 This tutorial explains how to create a Virtual Private Cloud (VPC) peering connection between a remote VPC network and SAP, BTP Kyma runtime in Microsoft Azure. Learn how to create a new resource group, VPC network and a virtual machine (VM), and assign required roles to the provided Kyma service principal in your Microsoft Azure subscription.
 
 ## Prerequisites


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- remove "VPC peering for Microsoft Azure is a feature available only for SAP-internal teams." warning since Azure VPC peering is available for external customers as well