### PR TITLE
feat(AwsRedis): make redisTier machine type configurable

### DIFF
--- a/pkg/kcp/provider/aws/config/config.go
+++ b/pkg/kcp/provider/aws/config/config.go
@@ -3,15 +3,18 @@ package config
 import (
 	"time"
 
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/config"
 )
 
 type AwsConfigStruct struct {
-	ArnPartition             string        `json:"arnPartition" yaml:"arnPartition"`
-	Default                  AwsCreds      `json:"default" yaml:"default"`
-	Peering                  AwsCreds      `json:"peering" yaml:"peering"`
-	BackupRoleName           string        `json:"backupRoleName" yaml:"backupRoleName"`
-	EfsCapacityCheckInterval time.Duration `json:"efsCapacityCheckInterval" yaml:"efsCapacityCheckInterval"`
+	ArnPartition                  string                                               `json:"arnPartition" yaml:"arnPartition"`
+	Default                       AwsCreds                                             `json:"default" yaml:"default"`
+	Peering                       AwsCreds                                             `json:"peering" yaml:"peering"`
+	BackupRoleName                string                                               `json:"backupRoleName" yaml:"backupRoleName"`
+	EfsCapacityCheckInterval      time.Duration                                        `json:"efsCapacityCheckInterval" yaml:"efsCapacityCheckInterval"`
+	RedisInstanceTierMachineTypes map[cloudresourcesv1beta1.AwsRedisTier]string        `json:"redisInstanceTierMachineTypes" yaml:"redisInstanceTierMachineTypes"`
+	RedisClusterTierMachineTypes  map[cloudresourcesv1beta1.AwsRedisClusterTier]string `json:"redisClusterTierMachineTypes" yaml:"redisClusterTierMachineTypes"`
 }
 
 var AwsConfig = &AwsConfigStruct{}
@@ -26,6 +29,7 @@ func InitConfig(cfg config.Config) {
 	cfg.Path(
 		"aws.config",
 		config.Bind(AwsConfig),
+		config.SourceFile("aws.yaml"),
 		config.Path(
 			"arnPartition",
 			config.SourceEnv("AWS_PARTITION"),

--- a/pkg/skr/awsrediscluster/createKcpRedisInstance.go
+++ b/pkg/skr/awsrediscluster/createKcpRedisInstance.go
@@ -7,6 +7,7 @@ import (
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -20,7 +21,7 @@ func createKcpRedisCluster(ctx context.Context, st composed.State) (error, conte
 
 	awsRedisCluster := state.ObjAsAwsRedisCluster()
 
-	cacheNodeType, err := redisTierToCacheNodeTypeConvertor(awsRedisCluster.Spec.RedisTier)
+	cacheNodeType, err := redisTierToCacheNodeTypeConvertor(awsRedisCluster.Spec.RedisTier, awsconfig.AwsConfig.RedisClusterTierMachineTypes)
 
 	if err != nil {
 		errMsg := "failed to map redisTier to cacheNodeType"

--- a/pkg/skr/awsrediscluster/modifyKcpRedisInstance.go
+++ b/pkg/skr/awsrediscluster/modifyKcpRedisInstance.go
@@ -6,6 +6,7 @@ import (
 
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,7 +27,7 @@ func modifyKcpRedisCluster(ctx context.Context, st composed.State) (error, conte
 		return nil, ctx
 	}
 
-	cacheNodeType, err := redisTierToCacheNodeTypeConvertor(awsRedisCluster.Spec.RedisTier)
+	cacheNodeType, err := redisTierToCacheNodeTypeConvertor(awsRedisCluster.Spec.RedisTier, awsconfig.AwsConfig.RedisClusterTierMachineTypes)
 
 	if err != nil {
 		errMsg := "failed to map redisTier to cacheNodeType"

--- a/pkg/skr/awsrediscluster/state.go
+++ b/pkg/skr/awsrediscluster/state.go
@@ -6,6 +6,7 @@ import (
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
 	"github.com/kyma-project/cloud-manager/pkg/skr/common/defaultiprange"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -83,7 +84,7 @@ func (s *State) GetAuthSecretData() map[string][]byte {
 func (s *State) ShouldModifyKcp() bool {
 	awsRedisCluster := s.ObjAsAwsRedisCluster()
 
-	cacheNodeType, err := redisTierToCacheNodeTypeConvertor(awsRedisCluster.Spec.RedisTier)
+	cacheNodeType, err := redisTierToCacheNodeTypeConvertor(awsRedisCluster.Spec.RedisTier, awsconfig.AwsConfig.RedisClusterTierMachineTypes)
 	if err != nil {
 		return true
 	}

--- a/pkg/skr/awsrediscluster/util.go
+++ b/pkg/skr/awsrediscluster/util.go
@@ -88,7 +88,13 @@ var AwsRedisClusterTierToCacheNodeTypeMap = map[cloudresourcesv1beta1.AwsRedisCl
 	cloudresourcesv1beta1.AwsRedisTierC8: "cache.m7g.16xlarge",
 }
 
-func redisTierToCacheNodeTypeConvertor(AwsRedisClusterTier cloudresourcesv1beta1.AwsRedisClusterTier) (string, error) {
+func redisTierToCacheNodeTypeConvertor(AwsRedisClusterTier cloudresourcesv1beta1.AwsRedisClusterTier, fromConfigOverwrite map[cloudresourcesv1beta1.AwsRedisClusterTier]string) (string, error) {
+	if fromConfigOverwrite != nil {
+		if overrideNode, exists := fromConfigOverwrite[AwsRedisClusterTier]; exists {
+			return overrideNode, nil
+		}
+	}
+
 	cacheNode, exists := AwsRedisClusterTierToCacheNodeTypeMap[AwsRedisClusterTier]
 
 	if !exists {

--- a/pkg/skr/awsrediscluster/util_test.go
+++ b/pkg/skr/awsrediscluster/util_test.go
@@ -28,17 +28,34 @@ func TestUtil(t *testing.T) {
 			{cloudresourcesv1beta1.AwsRedisTierC8, "cache.m7g.16xlarge"},
 		}
 
+		overwritesFromConfig := map[cloudresourcesv1beta1.AwsRedisClusterTier]string{
+			cloudresourcesv1beta1.AwsRedisTierC1: "cache.t4g.small",
+			cloudresourcesv1beta1.AwsRedisTierC2: "cache.t4g.medium",
+			cloudresourcesv1beta1.AwsRedisTierC3: "cache.m7g.large",
+			cloudresourcesv1beta1.AwsRedisTierC4: "cache.m7g.xlarge",
+			cloudresourcesv1beta1.AwsRedisTierC5: "cache.m7g.2xlarge",
+			cloudresourcesv1beta1.AwsRedisTierC6: "cache.m7g.4xlarge",
+			cloudresourcesv1beta1.AwsRedisTierC7: "cache.m7g.8xlarge",
+			cloudresourcesv1beta1.AwsRedisTierC8: "cache.m7g.16xlarge",
+		}
+
 		for _, testCase := range testCases {
 			t.Run(fmt.Sprintf("should return expected result for input (%s)", testCase.InputRedisTier), func(t *testing.T) {
-				cacheNodeType, err := redisTierToCacheNodeTypeConvertor(testCase.InputRedisTier)
+				cacheNodeType, err := redisTierToCacheNodeTypeConvertor(testCase.InputRedisTier, nil)
 
 				assert.Equal(t, testCase.ExpectedCacheNodeType, cacheNodeType, "resulting cacheNodeType does not match expected cacheNodeType")
 				assert.Nil(t, err, "expected nil error, got an error")
 			})
 
+			t.Run(fmt.Sprintf("should return expected result for input (%s) (with overwrite config)", testCase.InputRedisTier), func(t *testing.T) {
+				cacheNodeType, err := redisTierToCacheNodeTypeConvertor(testCase.InputRedisTier, overwritesFromConfig)
+
+				assert.Equal(t, overwritesFromConfig[testCase.InputRedisTier], cacheNodeType, "resulting cacheNodeType does not match expected cacheNodeType")
+				assert.Nil(t, err, "expected nil error, got an error")
+			})
 		}
 		t.Run("should return error for unknown input", func(t *testing.T) {
-			cacheNodeType, err := redisTierToCacheNodeTypeConvertor("unknown")
+			cacheNodeType, err := redisTierToCacheNodeTypeConvertor("unknown", nil)
 
 			assert.NotNil(t, err, "expected defined error, got nil")
 			assert.Equal(t, "", cacheNodeType, "expected cacheNodeType to have zero value")

--- a/pkg/skr/awsredisinstance/createKcpRedisInstance.go
+++ b/pkg/skr/awsredisinstance/createKcpRedisInstance.go
@@ -7,6 +7,7 @@ import (
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -20,7 +21,7 @@ func createKcpRedisInstance(ctx context.Context, st composed.State) (error, cont
 
 	awsRedisInstance := state.ObjAsAwsRedisInstance()
 
-	cacheNodeType, err := redisTierToCacheNodeTypeConvertor(awsRedisInstance.Spec.RedisTier)
+	cacheNodeType, err := redisTierToCacheNodeTypeConvertor(awsRedisInstance.Spec.RedisTier, awsconfig.AwsConfig.RedisInstanceTierMachineTypes)
 
 	if err != nil {
 		errMsg := "failed to map redisTier to cacheNodeType"

--- a/pkg/skr/awsredisinstance/modifyKcpRedisInstance.go
+++ b/pkg/skr/awsredisinstance/modifyKcpRedisInstance.go
@@ -6,6 +6,7 @@ import (
 
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,7 +27,7 @@ func modifyKcpRedisInstance(ctx context.Context, st composed.State) (error, cont
 		return nil, ctx
 	}
 
-	cacheNodeType, err := redisTierToCacheNodeTypeConvertor(awsRedisInstance.Spec.RedisTier)
+	cacheNodeType, err := redisTierToCacheNodeTypeConvertor(awsRedisInstance.Spec.RedisTier, awsconfig.AwsConfig.RedisInstanceTierMachineTypes)
 
 	if err != nil {
 		errMsg := "failed to map redisTier to cacheNodeType"

--- a/pkg/skr/awsredisinstance/state.go
+++ b/pkg/skr/awsredisinstance/state.go
@@ -6,6 +6,7 @@ import (
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	awsconfig "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/config"
 	"github.com/kyma-project/cloud-manager/pkg/skr/common/defaultiprange"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -83,7 +84,7 @@ func (s *State) GetAuthSecretData() map[string][]byte {
 func (s *State) ShouldModifyKcp() bool {
 	awsRedisInstance := s.ObjAsAwsRedisInstance()
 
-	cacheNodeType, err := redisTierToCacheNodeTypeConvertor(awsRedisInstance.Spec.RedisTier)
+	cacheNodeType, err := redisTierToCacheNodeTypeConvertor(awsRedisInstance.Spec.RedisTier, awsconfig.AwsConfig.RedisInstanceTierMachineTypes)
 	if err != nil {
 		return true
 	}

--- a/pkg/skr/awsredisinstance/util.go
+++ b/pkg/skr/awsredisinstance/util.go
@@ -6,6 +6,7 @@ import (
 
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+
 	"github.com/kyma-project/cloud-manager/pkg/util"
 )
 
@@ -107,7 +108,13 @@ var awsRedisTierToCacheNodeTypeMap = map[cloudresourcesv1beta1.AwsRedisTier]stri
 	cloudresourcesv1beta1.AwsRedisTierP6: "cache.m7g.16xlarge",
 }
 
-func redisTierToCacheNodeTypeConvertor(awsRedisTier cloudresourcesv1beta1.AwsRedisTier) (string, error) {
+func redisTierToCacheNodeTypeConvertor(awsRedisTier cloudresourcesv1beta1.AwsRedisTier, fromConfigOverwrite map[cloudresourcesv1beta1.AwsRedisTier]string) (string, error) {
+	if fromConfigOverwrite != nil {
+		if overrideNode, exists := fromConfigOverwrite[awsRedisTier]; exists {
+			return overrideNode, nil
+		}
+	}
+
 	cacheNode, exists := awsRedisTierToCacheNodeTypeMap[awsRedisTier]
 
 	if !exists {

--- a/pkg/skr/awsredisinstance/util_test.go
+++ b/pkg/skr/awsredisinstance/util_test.go
@@ -35,21 +35,47 @@ func TestUtil(t *testing.T) {
 			{cloudresourcesv1beta1.AwsRedisTierP6, "cache.m7g.16xlarge"},
 		}
 
+		overwritesFromConfig := map[cloudresourcesv1beta1.AwsRedisTier]string{
+			cloudresourcesv1beta1.AwsRedisTierS1: "custom.99.small",
+			cloudresourcesv1beta1.AwsRedisTierS2: "custom.99.medium",
+			cloudresourcesv1beta1.AwsRedisTierS3: "custom.99.large",
+			cloudresourcesv1beta1.AwsRedisTierS4: "custom.99.xlarge",
+			cloudresourcesv1beta1.AwsRedisTierS5: "custom.99.2xlarge",
+			cloudresourcesv1beta1.AwsRedisTierS6: "custom.99.4xlarge",
+			cloudresourcesv1beta1.AwsRedisTierS7: "custom.99.8xlarge",
+			cloudresourcesv1beta1.AwsRedisTierS8: "custom.99.16xlarge",
+
+			cloudresourcesv1beta1.AwsRedisTierP1: "custom.99.large",
+			cloudresourcesv1beta1.AwsRedisTierP2: "custom.99.xlarge",
+			cloudresourcesv1beta1.AwsRedisTierP3: "custom.99.2xlarge",
+			cloudresourcesv1beta1.AwsRedisTierP4: "custom.99.4xlarge",
+			cloudresourcesv1beta1.AwsRedisTierP5: "custom.99.8xlarge",
+			cloudresourcesv1beta1.AwsRedisTierP6: "custom.99.16xlarge",
+		}
+
 		for _, testCase := range testCases {
 			t.Run(fmt.Sprintf("should return expected result for input (%s)", testCase.InputRedisTier), func(t *testing.T) {
-				cacheNodeType, err := redisTierToCacheNodeTypeConvertor(testCase.InputRedisTier)
+				cacheNodeType, err := redisTierToCacheNodeTypeConvertor(testCase.InputRedisTier, nil)
 
 				assert.Equal(t, testCase.ExpectedCacheNodeType, cacheNodeType, "resulting cacheNodeType does not match expected cacheNodeType")
 				assert.Nil(t, err, "expected nil error, got an error")
 			})
 
+			t.Run(fmt.Sprintf("should return expected result for input (%s) (with overwrite config)", testCase.InputRedisTier), func(t *testing.T) {
+				cacheNodeType, err := redisTierToCacheNodeTypeConvertor(testCase.InputRedisTier, overwritesFromConfig)
+
+				assert.Equal(t, overwritesFromConfig[testCase.InputRedisTier], cacheNodeType, "resulting cacheNodeType does not match expected cacheNodeType")
+				assert.Nil(t, err, "expected nil error, got an error")
+			})
 		}
+
 		t.Run("should return error for unknown input", func(t *testing.T) {
-			cacheNodeType, err := redisTierToCacheNodeTypeConvertor("unknown")
+			cacheNodeType, err := redisTierToCacheNodeTypeConvertor("unknown", nil)
 
 			assert.NotNil(t, err, "expected defined error, got nil")
 			assert.Equal(t, "", cacheNodeType, "expected cacheNodeType to have zero value")
 		})
+
 	})
 
 	type replicaConverterTestCase struct {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

```yaml
# aws.yaml example

redisInstanceTierMachineTypes:
  S1: "custom.s1.medium"
  P1: "custom.p1.large"
redisClusterTierMachineTypes:
  C1: "custom.c1.medium"

```

**Related issue(s)**
https://github.com/kyma-project/cloud-manager/issues/1502
