### PR TITLE
feat: add restore permission check for GcpNfsVolume and GcpNfsVolumeR…

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	commonscheme "github.com/kyma-project/cloud-manager/pkg/common/scheme"
 	sapexposeddataclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/sap/exposedData/client"
 	sapiprangeclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/sap/iprange/client"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -221,7 +222,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "AwsNfsVolume")
 		os.Exit(1)
 	}
-	if err = cloudresourcescontroller.SetupGcpNfsVolumeReconciler(skrRegistry); err != nil {
+	if err = cloudresourcescontroller.SetupGcpNfsVolumeReconciler(skrRegistry, gcpnfsbackupclient.NewFileBackupClientProvider(), env); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GcpNfsVolume")
 		os.Exit(1)
 	}
@@ -236,7 +237,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = cloudresourcescontroller.SetupGcpNfsVolumeRestoreReconciler(skrRegistry, gcpnfsrestoreclient.NewFileRestoreClientProvider(), env, setupLog); err != nil {
+	if err = cloudresourcescontroller.SetupGcpNfsVolumeRestoreReconciler(
+		skrRegistry,
+		gcpnfsrestoreclient.NewFileRestoreClientProvider(),
+		gcpnfsbackupclient.NewFileBackupClientProvider(),
+		env,
+		setupLog); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GcpNfsVolumeRestore")
 		os.Exit(1)
 	}

--- a/internal/controller/cloud-resources/gcpnfsvolumerestore_controller.go
+++ b/internal/controller/cloud-resources/gcpnfsvolumerestore_controller.go
@@ -18,10 +18,12 @@ package cloudresources
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
 	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	gcpnfsbackupclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsbackup/client"
 	gcpnfsrestoreclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsrestore/client"
 	"github.com/kyma-project/cloud-manager/pkg/skr/gcpnfsvolumerestore"
 	skrruntime "github.com/kyma-project/cloud-manager/pkg/skr/runtime"
@@ -57,6 +59,7 @@ func (r *GcpNfsVolumeRestoreReconciler) Reconcile(ctx context.Context, req ctrl.
 
 type GcpNfsVolumeRestoreReconcilerFactory struct {
 	fileRestoreClientProvider gcpclient.ClientProvider[gcpnfsrestoreclient.FileRestoreClient]
+	fileBackupClientProvider  gcpclient.ClientProvider[gcpnfsbackupclient.FileBackupClient]
 	env                       abstractions.Environment
 }
 
@@ -66,14 +69,21 @@ func (f *GcpNfsVolumeRestoreReconcilerFactory) New(args reconcile2.ReconcilerArg
 			args.KymaRef,
 			args.KcpCluster,
 			args.SkrCluster,
-			f.fileRestoreClientProvider, f.env),
+			f.fileRestoreClientProvider,
+			f.fileBackupClientProvider,
+			f.env),
 	}
 }
 
-func SetupGcpNfsVolumeRestoreReconciler(reg skrruntime.SkrRegistry, fileRestoreClientProvider gcpclient.ClientProvider[gcpnfsrestoreclient.FileRestoreClient],
+func SetupGcpNfsVolumeRestoreReconciler(reg skrruntime.SkrRegistry,
+	fileRestoreClientProvider gcpclient.ClientProvider[gcpnfsrestoreclient.FileRestoreClient],
+	fileBackupClientProvider gcpclient.ClientProvider[gcpnfsbackupclient.FileBackupClient],
 	env abstractions.Environment, logger logr.Logger) error {
 	return reg.Register().
-		WithFactory(&GcpNfsVolumeRestoreReconcilerFactory{fileRestoreClientProvider: fileRestoreClientProvider, env: env}).
+		WithFactory(&GcpNfsVolumeRestoreReconcilerFactory{
+			fileRestoreClientProvider: fileRestoreClientProvider,
+			fileBackupClientProvider:  fileBackupClientProvider,
+			env:                       env}).
 		For(&cloudresourcesv1beta1.GcpNfsVolumeRestore{}).
 		Complete()
 }

--- a/internal/controller/cloud-resources/suite_test.go
+++ b/internal/controller/cloud-resources/suite_test.go
@@ -103,10 +103,10 @@ var _ = BeforeSuite(func() {
 	Expect(SetupSapNfsVolumeReconciler(infra.Registry())).
 		NotTo(HaveOccurred())
 	// GcpNfsVolume
-	Expect(SetupGcpNfsVolumeReconciler(infra.Registry())).
+	Expect(SetupGcpNfsVolumeReconciler(infra.Registry(), infra.GcpMock().FileBackupClientProvider(), env)).
 		NotTo(HaveOccurred())
 	// GcpNfsVolumeRestore
-	Expect(SetupGcpNfsVolumeRestoreReconciler(infra.Registry(), infra.GcpMock().FilerestoreClientProvider(), env, testSetupLog)).
+	Expect(SetupGcpNfsVolumeRestoreReconciler(infra.Registry(), infra.GcpMock().FilerestoreClientProvider(), infra.GcpMock().FileBackupClientProvider(), env, testSetupLog)).
 		NotTo(HaveOccurred())
 	// GcpNfsVolumeBackup
 	Expect(SetupGcpNfsVolumeBackupReconciler(infra.Registry(), infra.GcpMock().FileBackupClientProvider(), env, testSetupLog)).

--- a/pkg/skr/gcpnfsvolume/checkRestorePermissions.go
+++ b/pkg/skr/gcpnfsvolume/checkRestorePermissions.go
@@ -1,0 +1,39 @@
+package gcpnfsvolume
+
+import (
+	"context"
+
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func checkRestorePermissions(ctx context.Context, st composed.State) (error, context.Context) {
+	logger := composed.LoggerFromCtx(ctx)
+	state := st.(*State)
+	restore := state.ObjAsGcpNfsVolume()
+
+	if composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
+
+	if restore.Spec.SourceBackupUrl == "" {
+		logger.Info("Skipping backup load as no BackupUrl is provided")
+		return nil, nil
+	}
+
+	if !state.IsAllowedToRestoreBackup() {
+		restore.Status.State = cloudresourcesv1beta1.JobStateFailed
+		return composed.PatchStatus(restore).
+			SetExclusiveConditions(metav1.Condition{
+				Type:    cloudresourcesv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  cloudresourcesv1beta1.JobStateError,
+				Message: "Not allowed to restore from the specified backup",
+			}).
+			SuccessError(composed.StopAndForget).
+			Run(ctx, state)
+	}
+
+	return nil, nil
+}

--- a/pkg/skr/gcpnfsvolume/createPersistenceVolume_test.go
+++ b/pkg/skr/gcpnfsvolume/createPersistenceVolume_test.go
@@ -3,6 +3,8 @@ package gcpnfsvolume
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -30,14 +32,19 @@ func (s *createPersistenceVolumeSuite) SetupTest() {
 }
 
 func (s *createPersistenceVolumeSuite) TestWhenNfsVolumeReady() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	//Get state object with GcpNfsVolume
-	state := factory.newState()
+	state, err := factory.newState()
+	assert.Nil(s.T(), err)
 
 	err, _ctx := createPersistenceVolume(ctx, state)
 
@@ -65,7 +72,11 @@ func (s *createPersistenceVolumeSuite) TestWhenNfsVolumeReady() {
 }
 
 func (s *createPersistenceVolumeSuite) TestWhenNfsVolumeReady41() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -74,7 +85,8 @@ func (s *createPersistenceVolumeSuite) TestWhenNfsVolumeReady41() {
 	//Get state object with GcpNfsVolume
 	volume := gcpNfsVolume.DeepCopy()
 	volume.Status.Protocol = string(client.FilestoreProtocolNFSv41)
-	state := factory.newStateWith(volume)
+	state, err := factory.newStateWith(volume)
+	s.Nil(err)
 
 	err, _ctx := createPersistenceVolume(ctx, state)
 
@@ -103,14 +115,19 @@ func (s *createPersistenceVolumeSuite) TestWhenNfsVolumeReady41() {
 }
 
 func (s *createPersistenceVolumeSuite) TestWhenNfsVolumeDeleting() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	//Get state object with GcpNfsVolume
-	state := factory.newStateWith(&deletedGcpNfsVolume)
+	state, err := factory.newStateWith(&deletedGcpNfsVolume)
+	s.Nil(err)
 
 	err, _ctx := createPersistenceVolume(ctx, state)
 
@@ -131,7 +148,11 @@ func (s *createPersistenceVolumeSuite) TestWhenNfsVolumeDeleting() {
 }
 
 func (s *createPersistenceVolumeSuite) TestWhenGcpNfsVolumeNotReady() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -144,7 +165,8 @@ func (s *createPersistenceVolumeSuite) TestWhenGcpNfsVolumeNotReady() {
 			Namespace: "test",
 		},
 	}
-	state := factory.newStateWith(&nfsVolume)
+	state, err := factory.newStateWith(&nfsVolume)
+	s.Nil(err)
 
 	err, _ctx := createPersistenceVolume(ctx, state)
 
@@ -165,14 +187,19 @@ func (s *createPersistenceVolumeSuite) TestWhenGcpNfsVolumeNotReady() {
 }
 
 func (s *createPersistenceVolumeSuite) TestWhenPVAlreadyPresent() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	//Get state object with GcpNfsVolume
-	state := factory.newState()
+	state, err := factory.newState()
+	assert.Nil(s.T(), err)
 	state.PV = &corev1.PersistentVolume{}
 
 	err, _ctx := createPersistenceVolume(ctx, state)

--- a/pkg/skr/gcpnfsvolume/deletePersistenceVolume_test.go
+++ b/pkg/skr/gcpnfsvolume/deletePersistenceVolume_test.go
@@ -2,6 +2,8 @@ package gcpnfsvolume
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -26,7 +28,11 @@ func (s *deletePersistenceVolumeSuite) SetupTest() {
 }
 
 func (s *deletePersistenceVolumeSuite) TestWhenNfsVolumeNotDeleting() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -38,7 +44,8 @@ func (s *deletePersistenceVolumeSuite) TestWhenNfsVolumeNotDeleting() {
 	assert.Nil(s.T(), err)
 
 	//Get state object with GcpNfsVolume
-	state := factory.newState()
+	state, err := factory.newState()
+	assert.Nil(s.T(), err)
 	state.PV = pv
 
 	//Call deletePersistenceVolume.
@@ -57,7 +64,11 @@ func (s *deletePersistenceVolumeSuite) TestWhenNfsVolumeNotDeleting() {
 }
 
 func (s *deletePersistenceVolumeSuite) TestWhenNfsVolumeIsDeleting() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -69,7 +80,8 @@ func (s *deletePersistenceVolumeSuite) TestWhenNfsVolumeIsDeleting() {
 	assert.Nil(s.T(), err)
 
 	//Get state object with GcpNfsVolume
-	state := factory.newStateWith(&deletedGcpNfsVolume)
+	state, err := factory.newStateWith(&deletedGcpNfsVolume)
+	s.Nil(err)
 	state.PV = &pvDeletingGcpNfsVolume
 
 	//Call deletePersistenceVolume method.
@@ -88,14 +100,19 @@ func (s *deletePersistenceVolumeSuite) TestWhenNfsVolumeIsDeleting() {
 }
 
 func (s *deletePersistenceVolumeSuite) TestWhenPVDoNotExist() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	//Get state object with GcpNfsVolume
-	state := factory.newState()
+	state, err := factory.newState()
+	assert.Nil(s.T(), err)
 
 	//Call deletePersistenceVolume method.
 	err, _ctx := deletePersistenceVolume(ctx, state)
@@ -106,7 +123,11 @@ func (s *deletePersistenceVolumeSuite) TestWhenPVDoNotExist() {
 }
 
 func (s *deletePersistenceVolumeSuite) TestWhenPVHasWrongPhase() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -119,7 +140,8 @@ func (s *deletePersistenceVolumeSuite) TestWhenPVHasWrongPhase() {
 	assert.Nil(s.T(), err)
 
 	//Get state object with GcpNfsVolume
-	state := factory.newStateWith(&deletedGcpNfsVolume)
+	state, err := factory.newStateWith(&deletedGcpNfsVolume)
+	s.Nil(err)
 	state.PV = pv
 
 	//Call deletePersistenceVolume method.
@@ -139,7 +161,11 @@ func (s *deletePersistenceVolumeSuite) TestWhenPVHasWrongPhase() {
 }
 
 func (s *deletePersistenceVolumeSuite) TestWhenPVBecomesReadyToDelete() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -170,7 +196,8 @@ func (s *deletePersistenceVolumeSuite) TestWhenPVBecomesReadyToDelete() {
 	assert.Nil(s.T(), err)
 
 	//Get state object with GcpNfsVolume
-	state := factory.newStateWith(&nfsVolume)
+	state, err := factory.newStateWith(&nfsVolume)
+	s.Nil(err)
 	state.PV = pv
 
 	//Call deletePersistenceVolume method.

--- a/pkg/skr/gcpnfsvolume/loadBackup.go
+++ b/pkg/skr/gcpnfsvolume/loadBackup.go
@@ -1,0 +1,48 @@
+package gcpnfsvolume
+
+import (
+	"context"
+
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func loadBackup(ctx context.Context, st composed.State) (error, context.Context) {
+	logger := composed.LoggerFromCtx(ctx)
+	state := st.(*State)
+	restore := state.ObjAsGcpNfsVolume()
+
+	if composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
+
+	if restore.Spec.SourceBackupUrl == "" {
+		logger.Info("Skipping backup load as no BackupUrl is provided")
+		return nil, nil
+	}
+
+	location := extractBackupLocation(restore.Spec.SourceBackupUrl)
+	gcpScope := state.Scope.Spec.Scope.Gcp
+	project := gcpScope.Project
+	name := extractBackupName(restore.Spec.SourceBackupUrl)
+
+	backup, err := state.fileBackupClient.GetFileBackup(ctx, project, location, name)
+
+	if err != nil {
+		restore.Status.State = cloudresourcesv1beta1.JobStateFailed
+		return composed.PatchStatus(restore).
+			SetExclusiveConditions(metav1.Condition{
+				Type:    cloudresourcesv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  cloudresourcesv1beta1.JobStateError,
+				Message: "Failed to get backup details for permission check",
+			}).
+			SuccessError(composed.StopAndForget).
+			Run(ctx, state)
+	}
+
+	state.fileBackup = backup
+
+	return nil, nil
+}

--- a/pkg/skr/gcpnfsvolume/loadKcpNfsInstance_test.go
+++ b/pkg/skr/gcpnfsvolume/loadKcpNfsInstance_test.go
@@ -2,6 +2,8 @@ package gcpnfsvolume
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -23,14 +25,19 @@ func (s *loadKcpNfsInstanceSuite) SetupTest() {
 }
 
 func (s *loadKcpNfsInstanceSuite) TestWithMatchingNfsInstance() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	//Get state object with GcpNfsVolume
-	state := factory.newState()
+	state, err := factory.newState()
+	assert.Nil(s.T(), err)
 
 	err, _ctx := loadKcpNfsInstance(ctx, state)
 
@@ -44,7 +51,11 @@ func (s *loadKcpNfsInstanceSuite) TestWithMatchingNfsInstance() {
 }
 
 func (s *loadKcpNfsInstanceSuite) TestWithNotMatchingNfsInstance() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -57,7 +68,8 @@ func (s *loadKcpNfsInstanceSuite) TestWithNotMatchingNfsInstance() {
 			Namespace: "test",
 		},
 	}
-	state := factory.newStateWith(&nfsVol)
+	state, err := factory.newStateWith(&nfsVol)
+	s.Nil(err)
 
 	err, _ctx := loadKcpNfsInstance(ctx, state)
 
@@ -70,7 +82,11 @@ func (s *loadKcpNfsInstanceSuite) TestWithNotMatchingNfsInstance() {
 }
 
 func (s *loadKcpNfsInstanceSuite) TestWithMultipleMatchingNfsInstances() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -92,7 +108,8 @@ func (s *loadKcpNfsInstanceSuite) TestWithMultipleMatchingNfsInstances() {
 	assert.Nil(s.T(), err)
 
 	//Get state object with GcpNfsVolume
-	state := factory.newState()
+	state, err := factory.newState()
+	assert.Nil(s.T(), err)
 
 	err, _ctx := loadKcpNfsInstance(ctx, state)
 

--- a/pkg/skr/gcpnfsvolume/modifyPersistenceVolume_test.go
+++ b/pkg/skr/gcpnfsvolume/modifyPersistenceVolume_test.go
@@ -3,6 +3,8 @@ package gcpnfsvolume
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -28,7 +30,11 @@ func (s *modifyPersistenceVolumeSuite) SetupTest() {
 }
 
 func (s *modifyPersistenceVolumeSuite) TestWhenNfsVolumeReady() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -39,7 +45,8 @@ func (s *modifyPersistenceVolumeSuite) TestWhenNfsVolumeReady() {
 	err = factory.skrCluster.K8sClient().Get(ctx,
 		types.NamespacedName{Name: gcpNfsVolume.Name, Namespace: gcpNfsVolume.Namespace}, &nfsVol)
 	assert.Nil(s.T(), err)
-	state := factory.newStateWith(&nfsVol)
+	state, err := factory.newStateWith(&nfsVol)
+	s.Nil(err)
 
 	//Create a PV.
 	pv := pvGcpNfsVolume.DeepCopy()
@@ -83,14 +90,19 @@ func (s *modifyPersistenceVolumeSuite) TestWhenNfsVolumeReady() {
 }
 
 func (s *modifyPersistenceVolumeSuite) TestWhenNfsVolumeDeleting() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	//Get state object with GcpNfsVolume
-	state := factory.newStateWith(&deletedGcpNfsVolume)
+	state, err := factory.newStateWith(&deletedGcpNfsVolume)
+	s.Nil(err)
 
 	err, _ctx := modifyPersistenceVolume(ctx, state)
 
@@ -100,7 +112,11 @@ func (s *modifyPersistenceVolumeSuite) TestWhenNfsVolumeDeleting() {
 }
 
 func (s *modifyPersistenceVolumeSuite) TestWhenNfsVolumeNotReady() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -113,7 +129,8 @@ func (s *modifyPersistenceVolumeSuite) TestWhenNfsVolumeNotReady() {
 			Namespace: "test",
 		},
 	}
-	state := factory.newStateWith(&nfsVolume)
+	state, err := factory.newStateWith(&nfsVolume)
+	s.Nil(err)
 
 	err, _ctx := modifyPersistenceVolume(ctx, state)
 
@@ -123,14 +140,19 @@ func (s *modifyPersistenceVolumeSuite) TestWhenNfsVolumeNotReady() {
 }
 
 func (s *modifyPersistenceVolumeSuite) TestWhenPVNotPresent() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	//Get state object with GcpNfsVolume
-	state := factory.newState()
+	state, err := factory.newState()
+	assert.Nil(s.T(), err)
 
 	err, _ctx := modifyPersistenceVolume(ctx, state)
 
@@ -140,14 +162,19 @@ func (s *modifyPersistenceVolumeSuite) TestWhenPVNotPresent() {
 }
 
 func (s *modifyPersistenceVolumeSuite) TestWhenNfsVolumeNotChanged() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	//Get state object with GcpNfsVolume
-	state := factory.newState()
+	state, err := factory.newState()
+	assert.Nil(s.T(), err)
 
 	err, _ctx := modifyPersistenceVolume(ctx, state)
 

--- a/pkg/skr/gcpnfsvolume/reconciler.go
+++ b/pkg/skr/gcpnfsvolume/reconciler.go
@@ -3,6 +3,9 @@ package gcpnfsvolume
 import (
 	"context"
 
+	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
+	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	gcpnfsbackupclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsbackup/client"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 
 	"github.com/kyma-project/cloud-manager/pkg/skr/common/defaultiprange"
@@ -22,10 +25,14 @@ type Reconciler struct {
 }
 
 func (r *Reconciler) Run(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := composed.LoggerFromCtx(ctx)
 	if Ignore.ShouldIgnoreKey(req) {
 		return ctrl.Result{}, nil
 	}
-	state := r.newState(req.NamespacedName)
+	state, err := r.newState(ctx, req.NamespacedName)
+	if err != nil {
+		logger.Error(err, "Error getting the GcpNfsVolumeRestore state object")
+	}
 	action := r.newAction()
 
 	return composed.Handling().
@@ -34,8 +41,9 @@ func (r *Reconciler) Run(ctx context.Context, req ctrl.Request) (ctrl.Result, er
 		Handle(action(ctx, state))
 }
 
-func (r *Reconciler) newState(name types.NamespacedName) *State {
+func (r *Reconciler) newState(ctx context.Context, name types.NamespacedName) (*State, error) {
 	return r.stateFactory.NewState(
+		ctx,
 		r.composedStateFactory.NewState(name, &cloudresourcesv1beta1.GcpNfsVolume{}),
 	)
 }
@@ -60,6 +68,8 @@ func (r *Reconciler) newAction() composed.Action {
 			composed.ComposeActions(
 				"restoreFromSourceBackup",
 				loadScope,
+				loadBackup,
+				checkRestorePermissions,
 				populateBackupUrl),
 			nil,
 		),
@@ -83,11 +93,17 @@ func (r *Reconciler) newAction() composed.Action {
 	)
 }
 
-func NewReconciler(kymaRef klog.ObjectRef, kcpCluster cluster.Cluster, skrCluster cluster.Cluster) Reconciler {
+func NewReconciler(
+	kymaRef klog.ObjectRef,
+	kcpCluster cluster.Cluster,
+	skrCluster cluster.Cluster,
+	fileBackupClientProvider gcpclient.ClientProvider[gcpnfsbackupclient.FileBackupClient],
+	env abstractions.Environment,
+) Reconciler {
 	compSkrCluster := composed.NewStateCluster(skrCluster.GetClient(), skrCluster.GetAPIReader(), skrCluster.GetEventRecorderFor("cloud-resources"), skrCluster.GetScheme())
 	compKcpCluster := composed.NewStateCluster(kcpCluster.GetClient(), kcpCluster.GetAPIReader(), kcpCluster.GetEventRecorderFor("cloud-control"), kcpCluster.GetScheme())
 	composedStateFactory := composed.NewStateFactory(compSkrCluster)
-	stateFactory := NewStateFactory(kymaRef, compKcpCluster, compSkrCluster)
+	stateFactory := NewStateFactory(kymaRef, compKcpCluster, compSkrCluster, fileBackupClientProvider, env)
 	return Reconciler{
 		composedStateFactory: composedStateFactory,
 		stateFactory:         stateFactory,

--- a/pkg/skr/gcpnfsvolume/setProcessing_test.go
+++ b/pkg/skr/gcpnfsvolume/setProcessing_test.go
@@ -2,12 +2,15 @@ package gcpnfsvolume
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/go-logr/logr"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,14 +30,20 @@ func (s *setProcessingSuite) SetupTest() {
 func (s *setProcessingSuite) TestSetProcessingWhenDeleting() {
 
 	obj := deletedGcpNfsVolume.DeepCopy()
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	s.Nil(err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	//Get state object with GcpNfsVolume
-	state := factory.newStateWith(obj)
+	state, err := factory.newStateWith(obj)
+	assert.Nil(s.T(), err)
+
 	s.Nil(err)
 
 	err, ctx = setProcessing(ctx, state)
@@ -45,7 +54,11 @@ func (s *setProcessingSuite) TestSetProcessingWhenDeleting() {
 func (s *setProcessingSuite) TestSetProcessingWhenStateDone() {
 
 	obj := gcpNfsVolume.DeepCopy()
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	s.Nil(err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -59,7 +72,8 @@ func (s *setProcessingSuite) TestSetProcessingWhenStateDone() {
 		Reason:  "test",
 		Message: "test",
 	})
-	state := factory.newStateWith(obj)
+	state, err := factory.newStateWith(obj)
+	assert.Nil(s.T(), err)
 	s.Nil(err)
 
 	err, ctx = setProcessing(ctx, state)
@@ -70,7 +84,11 @@ func (s *setProcessingSuite) TestSetProcessingWhenStateDone() {
 func (s *setProcessingSuite) TestSetProcessingWhenStateError() {
 
 	obj := gcpNfsVolume.DeepCopy()
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	s.Nil(err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -84,7 +102,8 @@ func (s *setProcessingSuite) TestSetProcessingWhenStateError() {
 		Reason:  "test",
 		Message: "test",
 	})
-	state := factory.newStateWith(obj)
+	state, err := factory.newStateWith(obj)
+	assert.Nil(s.T(), err)
 	s.Nil(err)
 
 	err, ctx = setProcessing(ctx, state)
@@ -95,7 +114,11 @@ func (s *setProcessingSuite) TestSetProcessingWhenStateError() {
 func (s *setProcessingSuite) TestSetProcessingWhenStateEmpty() {
 
 	obj := gcpNfsVolume.DeepCopy()
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	s.Nil(err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -105,7 +128,8 @@ func (s *setProcessingSuite) TestSetProcessingWhenStateEmpty() {
 	obj.Status.State = ""
 
 	//Get state object with GcpNfsVolume
-	state := factory.newStateWith(obj)
+	state, err := factory.newStateWith(obj)
+	assert.Nil(s.T(), err)
 	s.Nil(err)
 
 	err, ctx = setProcessing(ctx, state)

--- a/pkg/skr/gcpnfsvolume/state.go
+++ b/pkg/skr/gcpnfsvolume/state.go
@@ -1,10 +1,18 @@
 package gcpnfsvolume
 
 import (
+	"context"
+	"fmt"
+
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	gcpnfsbackupclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsbackup/client"
 	"github.com/kyma-project/cloud-manager/pkg/skr/common/defaultiprange"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"google.golang.org/api/file/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
@@ -21,33 +29,55 @@ type State struct {
 	PVC               *corev1.PersistentVolumeClaim
 	Scope             *cloudcontrolv1beta1.Scope
 	SrcBackupFullPath string
+
+	fileBackup *file.Backup
+
+	fileBackupClient gcpnfsbackupclient.FileBackupClient
 }
 
 type StateFactory interface {
-	NewState(baseState composed.State) *State
+	NewState(ctx context.Context, baseState composed.State) (*State, error)
 }
 
-func NewStateFactory(kymaRef klog.ObjectRef, kcpCluster composed.StateCluster, skrCluster composed.StateCluster) StateFactory {
+func NewStateFactory(
+	kymaRef klog.ObjectRef,
+	kcpCluster composed.StateCluster,
+	skrCluster composed.StateCluster,
+	fileBackupClientProvider gcpclient.ClientProvider[gcpnfsbackupclient.FileBackupClient],
+	env abstractions.Environment,
+) StateFactory {
 	return &stateFactory{
-		kymaRef:    kymaRef,
-		kcpCluster: kcpCluster,
-		skrCluster: skrCluster,
+		kymaRef:                  kymaRef,
+		kcpCluster:               kcpCluster,
+		skrCluster:               skrCluster,
+		fileBackupClientProvider: fileBackupClientProvider,
+		env:                      env,
 	}
 }
 
 type stateFactory struct {
-	kymaRef    klog.ObjectRef
-	kcpCluster composed.StateCluster
-	skrCluster composed.StateCluster
+	kymaRef                  klog.ObjectRef
+	kcpCluster               composed.StateCluster
+	skrCluster               composed.StateCluster
+	fileBackupClientProvider gcpclient.ClientProvider[gcpnfsbackupclient.FileBackupClient]
+	env                      abstractions.Environment
 }
 
-func (f *stateFactory) NewState(baseState composed.State) *State {
-	return &State{
-		State:      baseState,
-		KymaRef:    f.kymaRef,
-		KcpCluster: f.kcpCluster,
-		SkrCluster: f.skrCluster,
+func (f *stateFactory) NewState(ctx context.Context, baseState composed.State) (*State, error) {
+	saPath := f.env.Get("GCP_SA_JSON_KEY_PATH")
+
+	fbc, err := f.fileBackupClientProvider(ctx, saPath)
+	if err != nil {
+		return nil, err
 	}
+
+	return &State{
+		State:            baseState,
+		KymaRef:          f.kymaRef,
+		KcpCluster:       f.kcpCluster,
+		SkrCluster:       f.skrCluster,
+		fileBackupClient: fbc,
+	}, nil
 }
 
 func (s *State) ObjAsGcpNfsVolume() *cloudresourcesv1beta1.GcpNfsVolume {
@@ -68,4 +98,38 @@ func (s *State) SetSkrIpRange(skrIpRange *cloudresourcesv1beta1.IpRange) {
 
 func (s *State) ObjAsObjWithIpRangeRef() defaultiprange.ObjWithIpRangeRef {
 	return s.ObjAsGcpNfsVolume()
+}
+
+func (s *State) IsAllowedToRestoreBackup() bool {
+	if s.fileBackup == nil {
+		return false
+	}
+
+	labels := s.fileBackup.Labels
+	if labels == nil {
+		return false
+	}
+
+	shootName := s.Scope.Spec.ShootName
+
+	managed, exists := s.fileBackup.Labels[gcpclient.ManagedByKey]
+	if !exists || managed != gcpclient.ManagedByValue {
+		return false
+	}
+
+	allowed, exists := labels[ConvertToAccessibleFromKey(shootName)]
+	if exists && allowed == util.GcpLabelBackupAccessibleFrom {
+		return true
+	}
+
+	owner, exists := s.fileBackup.Labels[util.GcpLabelShootName]
+	if exists && owner == shootName {
+		return true
+	}
+
+	return false
+}
+
+func ConvertToAccessibleFromKey(name string) string {
+	return fmt.Sprintf("cm-allow-%s", name)
 }

--- a/pkg/skr/gcpnfsvolume/state_test.go
+++ b/pkg/skr/gcpnfsvolume/state_test.go
@@ -3,13 +3,20 @@ package gcpnfsvolume
 import (
 	"context"
 	"fmt"
+	"net/http/httptest"
 	"time"
+
+	gcpnfsbackupclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsbackup/client"
 
 	"github.com/kyma-project/cloud-manager/api"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
 	commonscheme "github.com/kyma-project/cloud-manager/pkg/common/scheme"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	"google.golang.org/api/file/v1"
+	"google.golang.org/api/option"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -312,7 +319,8 @@ type testStateFactory struct {
 	deletedGcpNfsVolume *cloudresourcesv1beta1.GcpNfsVolume
 }
 
-func newTestStateFactoryWithObject(backup *cloudresourcesv1beta1.GcpNfsVolumeBackup, volumes ...*cloudresourcesv1beta1.GcpNfsVolume) (*testStateFactory, error) {
+func newTestStateFactoryWithObject(fakeHttpServer *httptest.Server, backup *cloudresourcesv1beta1.GcpNfsVolumeBackup, volumes ...*cloudresourcesv1beta1.GcpNfsVolume) (*testStateFactory, error) {
+
 	kcpClient := fake.NewClientBuilder().
 		WithScheme(commonscheme.KcpScheme).
 		WithObjects(&gcpNfsInstance).
@@ -339,7 +347,10 @@ func newTestStateFactoryWithObject(backup *cloudresourcesv1beta1.GcpNfsVolumeBac
 
 	skrCluster := composed.NewStateCluster(skrClient, skrClient, nil, commonscheme.SkrScheme)
 
-	factory := NewStateFactory(kymaRef, kcpCluster, skrCluster)
+	nfsRestoreClientBackup := NewFakeFileBackupClientProvider(fakeHttpServer)
+	env := abstractions.NewMockedEnvironment(map[string]string{"GCP_SA_JSON_KEY_PATH": "test"})
+
+	factory := NewStateFactory(kymaRef, kcpCluster, skrCluster, nfsRestoreClientBackup, env)
 
 	return &testStateFactory{
 		factory:             factory,
@@ -351,17 +362,17 @@ func newTestStateFactoryWithObject(backup *cloudresourcesv1beta1.GcpNfsVolumeBac
 
 }
 
-func newTestStateFactory() (*testStateFactory, error) {
+func newTestStateFactory(fakeHttpServer *httptest.Server) (*testStateFactory, error) {
 	var backup cloudresourcesv1beta1.GcpNfsVolumeBackup
-	return newTestStateFactoryWithObject(&backup, &gcpNfsVolume, &deletedGcpNfsVolume)
+	return newTestStateFactoryWithObject(fakeHttpServer, &backup, &gcpNfsVolume, &deletedGcpNfsVolume)
 }
 
-func (f *testStateFactory) newState() *State {
+func (f *testStateFactory) newState() (*State, error) {
 	return f.newStateWith(&gcpNfsVolume)
 }
 
-func (f *testStateFactory) newStateWith(nfsVolume *cloudresourcesv1beta1.GcpNfsVolume) *State {
-	return f.factory.NewState(composed.NewStateFactory(f.skrCluster).NewState(
+func (f *testStateFactory) newStateWith(nfsVolume *cloudresourcesv1beta1.GcpNfsVolume) (*State, error) {
+	return f.factory.NewState(context.Background(), composed.NewStateFactory(f.skrCluster).NewState(
 		types.NamespacedName{
 			Name:      nfsVolume.Name,
 			Namespace: nfsVolume.Namespace,
@@ -371,4 +382,16 @@ func (f *testStateFactory) newStateWith(nfsVolume *cloudresourcesv1beta1.GcpNfsV
 // Fake client doesn't support type "apply" for patching so falling back on update for unit tests.
 func (s *State) PatchObjStatus(ctx context.Context) error {
 	return s.Cluster().K8sClient().Status().Update(ctx, s.Obj())
+}
+
+func NewFakeFileBackupClientProvider(fakeHttpServer *httptest.Server) client.ClientProvider[gcpnfsbackupclient.FileBackupClient] {
+	return client.NewCachedClientProvider(
+		func(ctx context.Context, saJsonKeyPath string) (gcpnfsbackupclient.FileBackupClient, error) {
+			fsClient, err := file.NewService(ctx, option.WithoutAuthentication(), option.WithEndpoint(fakeHttpServer.URL))
+			if err != nil {
+				return nil, err
+			}
+			return gcpnfsbackupclient.NewFileBackupClient(fsClient), nil
+		},
+	)
 }

--- a/pkg/skr/gcpnfsvolume/updateStatus_test.go
+++ b/pkg/skr/gcpnfsvolume/updateStatus_test.go
@@ -2,6 +2,8 @@ package gcpnfsvolume
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -26,7 +28,11 @@ func (s *updateStatusSuite) SetupTest() {
 }
 
 func (s *updateStatusSuite) TestWhenKcpStatusIsReady() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -39,7 +45,9 @@ func (s *updateStatusSuite) TestWhenKcpStatusIsReady() {
 	err = factory.skrCluster.K8sClient().Status().Update(ctx, nfsVol)
 	assert.Nil(s.T(), err)
 
-	state := factory.newStateWith(nfsVol)
+	state, err := factory.newStateWith(nfsVol)
+	assert.Nil(s.T(), err)
+
 	state.KcpNfsInstance = gcpNfsInstance.DeepCopy()
 	state.KcpNfsInstance.SetStateData(client.GcpNfsStateDataProtocol, nfsProtocol)
 	//Invoke updateStatus
@@ -66,13 +74,18 @@ func (s *updateStatusSuite) TestWhenKcpStatusIsReady() {
 }
 
 func (s *updateStatusSuite) TestWhenKcpNSkrStatusAreReady() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	state := factory.newState()
+	state, err := factory.newState()
+	assert.Nil(s.T(), err)
 	state.KcpNfsInstance = &gcpNfsInstance
 
 	//Invoke updateStatus
@@ -99,7 +112,11 @@ func (s *updateStatusSuite) TestWhenKcpNSkrStatusAreReady() {
 }
 
 func (s *updateStatusSuite) TestWhenKcpStatusIsError() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -124,7 +141,9 @@ func (s *updateStatusSuite) TestWhenKcpStatusIsError() {
 	err = factory.skrCluster.K8sClient().Status().Update(ctx, nfsVol)
 	assert.Nil(s.T(), err)
 
-	state := factory.newStateWith(nfsVol)
+	state, err := factory.newStateWith(nfsVol)
+	assert.Nil(s.T(), err)
+
 	state.KcpNfsInstance = nfsInstance
 
 	//Invoke updateStatus
@@ -151,7 +170,11 @@ func (s *updateStatusSuite) TestWhenKcpStatusIsError() {
 }
 
 func (s *updateStatusSuite) TestWhenKcpNSkrStatusAreError() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -183,7 +206,9 @@ func (s *updateStatusSuite) TestWhenKcpNSkrStatusAreError() {
 	err = factory.skrCluster.K8sClient().Status().Update(ctx, nfsVol)
 	assert.Nil(s.T(), err)
 
-	state := factory.newStateWith(nfsVol)
+	state, err := factory.newStateWith(nfsVol)
+	assert.Nil(s.T(), err)
+
 	state.KcpNfsInstance = nfsInstance
 
 	//Invoke updateStatus
@@ -210,7 +235,11 @@ func (s *updateStatusSuite) TestWhenKcpNSkrStatusAreError() {
 }
 
 func (s *updateStatusSuite) TestWhenKcpNSkrConditionsEmpty() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -228,7 +257,9 @@ func (s *updateStatusSuite) TestWhenKcpNSkrConditionsEmpty() {
 	err = factory.skrCluster.K8sClient().Status().Update(ctx, nfsVol)
 	assert.Nil(s.T(), err)
 
-	state := factory.newStateWith(nfsVol)
+	state, err := factory.newStateWith(nfsVol)
+	assert.Nil(s.T(), err)
+
 	state.KcpNfsInstance = nfsInstance
 
 	//Invoke updateStatus

--- a/pkg/skr/gcpnfsvolume/util.go
+++ b/pkg/skr/gcpnfsvolume/util.go
@@ -132,3 +132,27 @@ func convertBackupUrlToFullPath(project, backupUrl string) (string, error) {
 
 	return fmt.Sprintf("projects/%s/locations/%s/backups/%s", project, locationId, backupId), nil
 }
+
+// extractBackupLocation extracts just the location_id from the full backup name
+// in format: projects/{project_number}/locations/{location_id}/backups/{backup_id}
+// Returns the location_id or empty string if format is invalid
+func extractBackupLocation(backupUrl string) string {
+	parts := strings.Split(backupUrl, "/")
+	if len(parts) != 2 {
+		return ""
+	}
+
+	return parts[0]
+}
+
+// extractBackupLocation extracts just the location_id from the full backup name
+// in format: projects/{project_number}/locations/{location_id}/backups/{backup_id}
+// Returns the location_id or empty string if format is invalid
+func extractBackupName(backupUrl string) string {
+	parts := strings.Split(backupUrl, "/")
+	if len(parts) != 2 {
+		return ""
+	}
+
+	return parts[1]
+}

--- a/pkg/skr/gcpnfsvolume/validateSpec_test.go
+++ b/pkg/skr/gcpnfsvolume/validateSpec_test.go
@@ -2,6 +2,8 @@ package gcpnfsvolume
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -25,13 +27,18 @@ func (s *validateSpecSuite) SetupTest() {
 }
 
 func (s *validateSpecSuite) TestIpRangeWhenNotExist() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	state := factory.newState()
+	state, err := factory.newState()
+	assert.Nil(s.T(), err)
 
 	//Invoke validateIpRange
 	err, _ = validateIpRange(ctx, state)
@@ -53,7 +60,11 @@ func (s *validateSpecSuite) TestIpRangeWhenNotExist() {
 }
 
 func (s *validateSpecSuite) TestIpRangeWhenNotReady() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -71,7 +82,8 @@ func (s *validateSpecSuite) TestIpRangeWhenNotReady() {
 	err = factory.skrCluster.K8sClient().Create(ctx, &ipRange)
 	assert.Nil(s.T(), err)
 
-	state := factory.newState()
+	state, err := factory.newState()
+	assert.Nil(s.T(), err)
 
 	//Invoke validateIpRange
 	err, _ctx := validateIpRange(ctx, state)
@@ -95,7 +107,11 @@ func (s *validateSpecSuite) TestIpRangeWhenNotReady() {
 }
 
 func (s *validateSpecSuite) TestIpRangeWhenReady() {
-	factory, err := newTestStateFactory()
+	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(s.T(), "unexpected request: "+r.URL.String())
+	}))
+	defer fakeHttpServer.Close()
+	factory, err := newTestStateFactory(fakeHttpServer)
 	assert.Nil(s.T(), err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -126,7 +142,8 @@ func (s *validateSpecSuite) TestIpRangeWhenReady() {
 	err = factory.skrCluster.K8sClient().Create(ctx, &ipRange)
 	assert.Nil(s.T(), err)
 
-	state := factory.newState()
+	state, err := factory.newState()
+	assert.Nil(s.T(), err)
 
 	//Invoke validateIpRange
 	err, _ctx := validateIpRange(ctx, state)

--- a/pkg/skr/gcpnfsvolumerestore/checkRestorePermissions.go
+++ b/pkg/skr/gcpnfsvolumerestore/checkRestorePermissions.go
@@ -1,0 +1,39 @@
+package gcpnfsvolumerestore
+
+import (
+	"context"
+
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func checkRestorePermissions(ctx context.Context, st composed.State) (error, context.Context) {
+	logger := composed.LoggerFromCtx(ctx)
+	state := st.(*State)
+	restore := state.ObjAsGcpNfsVolumeRestore()
+
+	if composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
+
+	if restore.Spec.Source.BackupUrl == "" {
+		logger.Info("Skipping backup load as no BackupUrl is provided")
+		return nil, nil
+	}
+
+	if !state.IsAllowedToRestoreBackup() {
+		restore.Status.State = cloudresourcesv1beta1.JobStateFailed
+		return composed.PatchStatus(restore).
+			SetExclusiveConditions(metav1.Condition{
+				Type:    cloudresourcesv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  cloudresourcesv1beta1.JobStateError,
+				Message: "Not allowed to restore from the specified backup",
+			}).
+			SuccessError(composed.StopAndForget).
+			Run(ctx, state)
+	}
+
+	return nil, nil
+}

--- a/pkg/skr/gcpnfsvolumerestore/loadBackup.go
+++ b/pkg/skr/gcpnfsvolumerestore/loadBackup.go
@@ -1,0 +1,48 @@
+package gcpnfsvolumerestore
+
+import (
+	"context"
+
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func loadBackup(ctx context.Context, st composed.State) (error, context.Context) {
+	logger := composed.LoggerFromCtx(ctx)
+	state := st.(*State)
+	restore := state.ObjAsGcpNfsVolumeRestore()
+
+	if composed.MarkedForDeletionPredicate(ctx, st) {
+		return nil, nil
+	}
+
+	if restore.Spec.Source.BackupUrl == "" {
+		logger.Info("Skipping backup load as no BackupUrl is provided")
+		return nil, nil
+	}
+
+	location := extractBackupLocation(restore.Spec.Source.BackupUrl)
+	gcpScope := state.Scope.Spec.Scope.Gcp
+	project := gcpScope.Project
+	name := extractBackupName(restore.Spec.Source.BackupUrl)
+
+	backup, err := state.fileBackupClient.GetFileBackup(ctx, project, location, name)
+
+	if err != nil {
+		restore.Status.State = cloudresourcesv1beta1.JobStateFailed
+		return composed.PatchStatus(restore).
+			SetExclusiveConditions(metav1.Condition{
+				Type:    cloudresourcesv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  cloudresourcesv1beta1.JobStateError,
+				Message: "Failed to get backup details for permission check",
+			}).
+			SuccessError(composed.StopAndForget).
+			Run(ctx, state)
+	}
+
+	state.fileBackup = backup
+
+	return nil, nil
+}

--- a/pkg/skr/gcpnfsvolumerestore/state.go
+++ b/pkg/skr/gcpnfsvolumerestore/state.go
@@ -2,12 +2,18 @@ package gcpnfsvolumerestore
 
 import (
 	"context"
+	"fmt"
+
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-resources/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common/abstractions"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
+	gcpnfsbackupclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsbackup/client"
 	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsrestore/client"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"google.golang.org/api/file/v1"
+
 	"k8s.io/klog/v2"
 )
 
@@ -21,7 +27,10 @@ type State struct {
 	GcpNfsVolume      *cloudresourcesv1beta1.GcpNfsVolume
 	SrcBackupFullPath string
 
+	fileBackup *file.Backup
+
 	fileRestoreClient client.FileRestoreClient
+	fileBackupClient  gcpnfsbackupclient.FileBackupClient
 }
 
 type StateFactory interface {
@@ -29,13 +38,16 @@ type StateFactory interface {
 }
 
 func NewStateFactory(kymaRef klog.ObjectRef, kcpCluster composed.StateCluster, skrCluster composed.StateCluster,
-	fileRestoreClientProvider gcpclient.ClientProvider[client.FileRestoreClient], env abstractions.Environment) StateFactory {
+	fileRestoreClientProvider gcpclient.ClientProvider[client.FileRestoreClient],
+	fileBackupClientProvider gcpclient.ClientProvider[gcpnfsbackupclient.FileBackupClient],
+	env abstractions.Environment) StateFactory {
 
 	return &stateFactory{
 		kymaRef:                   kymaRef,
 		kcpCluster:                kcpCluster,
 		skrCluster:                skrCluster,
 		fileRestoreClientProvider: fileRestoreClientProvider,
+		fileBackupClientProvider:  fileBackupClientProvider,
 		env:                       env,
 	}
 }
@@ -45,26 +57,66 @@ type stateFactory struct {
 	kcpCluster                composed.StateCluster
 	skrCluster                composed.StateCluster
 	fileRestoreClientProvider gcpclient.ClientProvider[client.FileRestoreClient]
+	fileBackupClientProvider  gcpclient.ClientProvider[gcpnfsbackupclient.FileBackupClient]
 	env                       abstractions.Environment
 }
 
 func (f *stateFactory) NewState(ctx context.Context, baseState composed.State) (*State, error) {
-	fbc, err := f.fileRestoreClientProvider(
-		ctx,
-		f.env.Get("GCP_SA_JSON_KEY_PATH"),
-	)
+	saPath := f.env.Get("GCP_SA_JSON_KEY_PATH")
+	frc, err := f.fileRestoreClientProvider(ctx, saPath)
 	if err != nil {
 		return nil, err
 	}
+
+	fbc, err := f.fileBackupClientProvider(ctx, saPath)
+	if err != nil {
+		return nil, err
+	}
+
 	return &State{
 		State:             baseState,
 		KymaRef:           f.kymaRef,
 		KcpCluster:        f.kcpCluster,
 		SkrCluster:        f.skrCluster,
-		fileRestoreClient: fbc,
+		fileRestoreClient: frc,
+		fileBackupClient:  fbc,
 	}, nil
 }
 
 func (s *State) ObjAsGcpNfsVolumeRestore() *cloudresourcesv1beta1.GcpNfsVolumeRestore {
 	return s.Obj().(*cloudresourcesv1beta1.GcpNfsVolumeRestore)
+}
+
+func (s *State) IsAllowedToRestoreBackup() bool {
+	if s.fileBackup == nil {
+		return false
+	}
+
+	labels := s.fileBackup.Labels
+	if labels == nil {
+		return false
+	}
+
+	shootName := s.Scope.Spec.ShootName
+
+	managed, exists := s.fileBackup.Labels[gcpclient.ManagedByKey]
+	if !exists || managed != gcpclient.ManagedByValue {
+		return false
+	}
+
+	allowed, exists := labels[ConvertToAccessibleFromKey(shootName)]
+	if exists && allowed == util.GcpLabelBackupAccessibleFrom {
+		return true
+	}
+
+	owner, exists := s.fileBackup.Labels[util.GcpLabelShootName]
+	if exists && owner == shootName {
+		return true
+	}
+
+	return false
+}
+
+func ConvertToAccessibleFromKey(name string) string {
+	return fmt.Sprintf("cm-allow-%s", name)
 }

--- a/pkg/skr/gcpnfsvolumerestore/util.go
+++ b/pkg/skr/gcpnfsvolumerestore/util.go
@@ -34,3 +34,27 @@ func convertBackupUrlToFullPath(project, backupUrl string) (string, error) {
 
 	return fmt.Sprintf("projects/%s/locations/%s/backups/%s", project, locationId, backupId), nil
 }
+
+// extractBackupLocation extracts just the location_id from the full backup name
+// in format: projects/{project_number}/locations/{location_id}/backups/{backup_id}
+// Returns the location_id or empty string if format is invalid
+func extractBackupLocation(backupUrl string) string {
+	parts := strings.Split(backupUrl, "/")
+	if len(parts) != 2 {
+		return ""
+	}
+
+	return parts[0]
+}
+
+// extractBackupLocation extracts just the location_id from the full backup name
+// in format: projects/{project_number}/locations/{location_id}/backups/{backup_id}
+// Returns the location_id or empty string if format is invalid
+func extractBackupName(backupUrl string) string {
+	parts := strings.Split(backupUrl, "/")
+	if len(parts) != 2 {
+		return ""
+	}
+
+	return parts[1]
+}


### PR DESCRIPTION
…estore

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- restore of GcpNfsVolumeBackup is only possible when the GCP Filestore backup has the appropriate label (either allows current shootId, or current shootId is the origin shoot)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
