### PR TITLE
test: fix `Regional_Without_FF` by resetting state in `Regional_With_FF`

### DIFF
--- a/pkg/kcp/provider/gcp/nfsinstance/syncNfsInstance_test.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/syncNfsInstance_test.go
@@ -412,8 +412,6 @@ func (s *syncNfsInstanceSuite) TestGetInstanceWithProtocol_Zonal_With_FF() {
 }
 
 func (s *syncNfsInstanceSuite) TestGetInstanceWithProtocol_Regional_Without_FF() {
-	s.T().Skip("I'm flaky, fix me please!!!")
-
 	gcpNfsInstance := getGcpNfsInstance()
 	gcpNfsInstance.Spec.Instance.Gcp.Tier = v1beta1.REGIONAL
 	fakeHttpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -457,6 +455,7 @@ func (s *syncNfsInstanceSuite) TestGetInstanceWithProtocol_Regional_With_FF() {
 	assert.Equal(s.T(), string(gcpclient.FilestoreProtocolNFSv41), instance.Protocol)
 	instance.Protocol = ""
 	assert.Equal(s.T(), testState.toInstance(), instance)
+	_ = feature.Initialize(ctx, logr.Discard())
 }
 
 func TestSyncNfsInstance(t *testing.T) {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Added `feature.Initialize` at the end of the test `TestGetInstanceWithProtocol_Regional_With_FF` to fix `TestGetInstanceWithProtocol_Regional_Without_FF`

### Problem 
The test `TestGetInstanceWithProtocol_Regional_Without_FF` is flaky due to the pollution from the test `TestGetInstanceWithProtocol_Regional_With_FF`. All tests inside `TestSyncNfsInstance` use `defer cancel()` to reset. However, the async cleanup might not finish before the next test started, leading to an assertion error where `instance.Protocol` is not empty.

### Solution 
Applied the same logic from the test `TestGetInstanceWithProtocol_Zonal_With_FF` by adding `feature.Initialize` at the end of the test `TestGetInstanceWithProtocol_Regional_With_FF`. This ensures the provider is reset when the test is done. Thus, it avoids polluting the subsequent tests like `TestGetInstanceWithProtocol_Regional_Without_FF`.

### Verification
The test now passes on local machine after running it 1,000 times using a loop to simulate the flaky behavior. 
```bash
GOMAXPROCS=1 go test -v -count=1000 -run "TestSyncNfsInstance" ./pkg/kcp/provider/gcp/nfsinstance
```

**Related issue(s)**
Fixes [#1526](https://github.com/kyma-project/cloud-manager/issues/1526)
