### PR TITLE
test: fix `TestUpdateCapacity` and `TestCalculateOnetimeScheduleSuite` due to time truncation

### DIFF
--- a/pkg/skr/awsnfsvolumebackup/updateCapacity_test.go
+++ b/pkg/skr/awsnfsvolumebackup/updateCapacity_test.go
@@ -113,7 +113,7 @@ func (s *updateCapacitySuite) TestWhenUpdateIsNotDue() {
 }
 
 func (s *updateCapacitySuite) TestWhenLastCapacityUpdateNotExists() {
-
+	testStartTime := time.Now().Add(-1 * time.Second)
 	obj := awsNfsVolumeBackup.DeepCopy()
 	obj.Status.State = v1beta1.StateCreating
 	factory, err := newStateFactoryWithObj(obj)
@@ -147,12 +147,12 @@ func (s *updateCapacitySuite) TestWhenLastCapacityUpdateNotExists() {
 
 	s.Equal(v1beta1.StateCreating, fromK8s.Status.State)
 	s.Equal(backupSize, fromK8s.Status.Capacity.Value())
-	// TODO: this is flaky, happens to be >1s quite often, please fix me!!!
-	//s.GreaterOrEqual(1*time.Second, time.Since(fromK8s.Status.LastCapacityUpdate.Time))
+	s.True(fromK8s.Status.LastCapacityUpdate.Time.After(testStartTime),
+		"LastCapacityUpdate time should be updated")
 }
 
 func (s *updateCapacitySuite) TestWhenLastCapacityUpdateIsZero() {
-
+	testStartTime := time.Now().Add(-1 * time.Second)
 	obj := awsNfsVolumeBackup.DeepCopy()
 	obj.Status.State = v1beta1.StateCreating
 	obj.Status.LastCapacityUpdate = &metav1.Time{}
@@ -187,7 +187,8 @@ func (s *updateCapacitySuite) TestWhenLastCapacityUpdateIsZero() {
 
 	s.Equal(v1beta1.StateCreating, fromK8s.Status.State)
 	s.Equal(backupSize, fromK8s.Status.Capacity.Value())
-	s.GreaterOrEqual(1*time.Second, time.Since(fromK8s.Status.LastCapacityUpdate.Time))
+	s.True(fromK8s.Status.LastCapacityUpdate.Time.After(testStartTime),
+		"LastCapacityUpdate time should be updated")
 }
 
 func TestUpdateCapacity(t *testing.T) {

--- a/pkg/skr/backupschedule/calculateOnetimeSchedule_test.go
+++ b/pkg/skr/backupschedule/calculateOnetimeSchedule_test.go
@@ -119,7 +119,7 @@ func (s *calculateOnetimeScheduleSuite) TestScheduleWithStartTime() {
 }
 
 func (s *calculateOnetimeScheduleSuite) TestScheduleWithNoStartTime() {
-
+	testStartTime := time.Now().Add(-1 * time.Second)
 	obj := gcpNfsBackupSchedule.DeepCopy()
 	factory, err := newTestStateFactoryWithObj(obj)
 	s.Nil(err)
@@ -143,10 +143,9 @@ func (s *calculateOnetimeScheduleSuite) TestScheduleWithNoStartTime() {
 		fromK8s)
 	s.Nil(err)
 	s.Equal(1, len(fromK8s.Status.NextRunTimes))
-	_, err = time.Parse(time.RFC3339, fromK8s.Status.NextRunTimes[0])
+	runTime, err := time.Parse(time.RFC3339, fromK8s.Status.NextRunTimes[0])
 	s.Nil(err)
-	// TODO: this is flaky, it happens to be >1s quite frequently, fix me please!!!
-	//s.GreaterOrEqual(time.Second*1, time.Since(runTime))
+	s.True(runTime.After(testStartTime), "Status.NextRunTimes[0] was not set recently")
 }
 
 func (s *calculateOnetimeScheduleSuite) TestScheduleWithLastCreateRun() {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Added `testStartTime` variable at the start of the tests (both `updateCapacity_test.go` and `calculateOnetimeSchedule_test.go`)
- Changed assertion to check if `fromK8s.Status.LastCapacityUpdate.Time` is strictly after `testStartTime` (`updateCapacity_test.go`)
- Changed assertion to check if `runTime` is strictly after `testStartTime` (`calculateOnetimeSchedule_test.go`)

### Problem
The original assertion was easy to fail due to `metav1.Time` truncation (seconds-only precision). If an update occurs at T=0.999s, it will be stored as T=0.000s. When the assertion runs at T=1.004s, `time.Since()` returns 1.004s. This leads to the error: `"1s" is not greater than or equal to "1.004286259s"`. This flaw affected all assertions relying on `time.Since()` for recent timestamp checks.

### Solution
By using `testStartTime` at the start of the test (-1 because of sec precision), assert that `fromK8s.Status.LastCapacityUpdate.Time`/`runTime` is strictly after `testStartTime`. Since the comparison relies on `testStartTime` instead of the time interval between the recorded update and the assertion, this change ensures the object was updated, preventing both the precision truncation errors and potential slow CI runs.

I applied this fix to the following tests:
- `TestUpdateCapacity/TestWhenLastCapacityUpdateNotExists`
- `TestUpdateCapacity/TestWhenLastCapacityUpdateIsZero`
- `TestCalculateOnetimeScheduleSuite/TestScheduleWithNoStartTime`

### Verification
The test now passes on local machine after running it 10,000 times using a loop to simulate the flaky behavior within 211 seconds for `TestWhenLastCapacityUpdateNotExists`, `TestWhenLastCapacityUpdateIsZero` and `TestScheduleWithNoStartTime`.
```bash
# TestUpdateCapacity/TestWhenLastCapacityUpdateNotExists
go test -v -count=10000 -race -run "TestUpdateCapacity/TestWhenLastCapacityUpdateNotExists" ./pkg/skr/awsnfsvolumebackup
# TestUpdateCapacity/TestWhenLastCapacityUpdateIsZero
go test -v -count=10000 -race -run "TestUpdateCapacity/TestWhenLastCapacityUpdateIsZero" ./pkg/skr/awsnfsvolumebackup
# TestCalculateOnetimeScheduleSuite/TestScheduleWithNoStartTime
go test -v -count=10000 -race -run "TestCalculateOnetimeScheduleSuite/TestScheduleWithNoStartTime" ./pkg/skr/backupschedule
```

**Related issue(s)**
Fixes [#1524](https://github.com/kyma-project/cloud-manager/issues/1524)
Fixes [#1499](https://github.com/kyma-project/cloud-manager/issues/1499)
