### PR TITLE
docs: fix AwsNfsVolume tutorial to use status.id for PV lookup

### DIFF
--- a/docs/user/tutorials/01-20-10-aws-nfs-volume.md
+++ b/docs/user/tutorials/01-20-10-aws-nfs-volume.md
@@ -54,7 +54,7 @@ You have the Cloud Manager module added.
    {PV_NAME}  100G       RWX            Retain           Bound    {NAMESPACE_NAME}/my-vol               
    ```
 
-   Note the `RWX` access mode which allows the volume to be readable and writable from multiple workloads, and the `Bound` status which means the PersistentVolumeClaim claiming this PV is created.
+   Note the `RWX` access mode, which allows the volume to be readable and writable from multiple workloads, and the `Bound` status, which means the PersistentVolumeClaim claims that this PV has been created.
 
 5. Observe the generated PersistentVolumeClaim:
 
@@ -69,7 +69,7 @@ You have the Cloud Manager module added.
    my-vol   Bound    {PV_NAME}  100G       RWX                         
    ```
 
-   Similarly to PV, note the `RWX` access mode and `Bound` status.
+   Similarly to PV, note the `RWX` access mode and the `Bound` status.
 
 6. Create two workloads that both write to the volume:
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Step 4: Changed PV lookup to use status.id
- Step 5: Updated PVC output example to show {PV_NAME} placeholder instead of my-vol
- Improved wording consistency

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/cloud-manager/issues/1485