### PR TITLE
chore: refactor aws nfs backup schedule tests

### DIFF
--- a/internal/controller/cloud-resources/aws/awsnfsbackupschedule_test.go
+++ b/internal/controller/cloud-resources/aws/awsnfsbackupschedule_test.go
@@ -43,21 +43,6 @@ var _ = Describe("Feature: SKR AwsNfsBackupSchedule", func() {
 			},
 		}
 
-		DeferCleanup(func() {
-			By("// cleanup: Delete test resources", func() {
-				Expect(Delete(infra.Ctx(), infra.SKR().Client(), backupSchedule)).To(Succeed())
-				Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.SKR().Client(), backupSchedule).Should(Succeed())
-				Expect(Delete(infra.Ctx(), infra.SKR().Client(), existingBackup)).To(Succeed())
-				Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.SKR().Client(), existingBackup).Should(Succeed())
-				Expect(Delete(infra.Ctx(), infra.SKR().Client(), skrNfsVolume)).To(Succeed())
-				Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.SKR().Client(), skrNfsVolume).Should(Succeed())
-				Expect(Delete(infra.Ctx(), infra.KCP().Client(), nfsInstance)).To(Succeed())
-				Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.KCP().Client(), nfsInstance).Should(Succeed())
-				Expect(Delete(infra.Ctx(), infra.KCP().Client(), scope)).To(Succeed())
-				Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.KCP().Client(), scope).Should(Succeed())
-			})
-		})
-
 		// Set tolerance for backup schedule timing
 		backupschedule.ToleranceInterval = toleranceWindow
 
@@ -176,6 +161,19 @@ var _ = Describe("Feature: SKR AwsNfsBackupSchedule", func() {
 			}, existingBackup)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		By("// cleanup: Delete test resources", func() {
+			Expect(Delete(infra.Ctx(), infra.SKR().Client(), backupSchedule)).To(Succeed())
+			Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.SKR().Client(), backupSchedule).Should(Succeed())
+			Expect(Delete(infra.Ctx(), infra.SKR().Client(), existingBackup)).To(Succeed())
+			Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.SKR().Client(), existingBackup).Should(Succeed())
+			Expect(Delete(infra.Ctx(), infra.SKR().Client(), skrNfsVolume)).To(Succeed())
+			Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.SKR().Client(), skrNfsVolume).Should(Succeed())
+			Expect(Delete(infra.Ctx(), infra.KCP().Client(), nfsInstance)).To(Succeed())
+			Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.KCP().Client(), nfsInstance).Should(Succeed())
+			Expect(Delete(infra.Ctx(), infra.KCP().Client(), scope)).To(Succeed())
+			Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.KCP().Client(), scope).Should(Succeed())
+		})
 	})
 
 	It("Scenario: Creates one-time backup schedule", func() {
@@ -187,17 +185,6 @@ var _ = Describe("Feature: SKR AwsNfsBackupSchedule", func() {
 		skrNfsVolume := &cloudresourcesv1beta1.AwsNfsVolume{}
 		nfsInstance := &cloudcontrolv1beta1.NfsInstance{}
 		backupSchedule := &cloudresourcesv1beta1.AwsNfsBackupSchedule{}
-
-		DeferCleanup(func() {
-			By("// cleanup: Delete test resources", func() {
-				Expect(Delete(infra.Ctx(), infra.SKR().Client(), backupSchedule)).To(Succeed())
-				Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.SKR().Client(), backupSchedule).Should(Succeed())
-				Expect(Delete(infra.Ctx(), infra.SKR().Client(), skrNfsVolume)).To(Succeed())
-				Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.SKR().Client(), skrNfsVolume).Should(Succeed())
-				Expect(Delete(infra.Ctx(), infra.KCP().Client(), scope)).To(Succeed())
-				Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.KCP().Client(), scope).Should(Succeed())
-			})
-		})
 
 		// Set tolerance and stop reconciliation
 		backupschedule.ToleranceInterval = toleranceWindow
@@ -287,6 +274,15 @@ var _ = Describe("Feature: SKR AwsNfsBackupSchedule", func() {
 					NewObjActions(WithName(expectedBackupName)),
 				).
 				Should(Succeed())
+		})
+
+		By("// cleanup: Delete test resources", func() {
+			Expect(Delete(infra.Ctx(), infra.SKR().Client(), backupSchedule)).To(Succeed())
+			Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.SKR().Client(), backupSchedule).Should(Succeed())
+			Expect(Delete(infra.Ctx(), infra.SKR().Client(), skrNfsVolume)).To(Succeed())
+			Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.SKR().Client(), skrNfsVolume).Should(Succeed())
+			Expect(Delete(infra.Ctx(), infra.KCP().Client(), scope)).To(Succeed())
+			Eventually(IsDeleted).WithArguments(infra.Ctx(), infra.KCP().Client(), scope).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

**Phase 1 of 3**: Refactor `awsnfsbackupschedule_test.go` to eliminate `BeforeEach` blocks and enable 100% parallel execution success rate.

### What Changed

Transformed monolithic test suite with global state into two independent, parallel-safe scenarios:
- Recurring backup schedule with existing backups
- One-time backup schedule

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/cloud-manager/issues/1618