### PR TITLE
chore: test remote peering connection state deleted

### DIFF
--- a/internal/controller/cloud-control/vpcpeering_aws_test.go
+++ b/internal/controller/cloud-control/vpcpeering_aws_test.go
@@ -1161,12 +1161,11 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 
 		// DELETE
 
-		//
+		// Forces delete remote peering connection
 		By("When remote peering connection is deleted", func() {
 			// The VPC peering connection remains visible to the party that deleted it for 2 hours
-			Expect(awsMockRemote.DeleteVpcPeeringConnection(infra.Ctx(), &kcpPeering.Status.RemoteId)).To(Succeed())
+			Expect(awsMockRemote.SetVpcPeeringConnectionStatusCode(localVpcId, remoteVpcId, ec2types.VpcPeeringConnectionStateReasonCodeDeleted)).To(Succeed())
 			//  and visible to the other party for 2 days
-			Expect(awsMockLocal.DeleteVpcPeeringConnection(infra.Ctx(), &kcpPeering.Status.Id)).To(Succeed())
 		})
 
 		By("When KCP VpcPeering is deleted", func() {
@@ -1201,8 +1200,9 @@ var _ = Describe("Feature: KCP VpcPeering", func() {
 		})
 
 		By("And Then remote VpcPeeringConnection is deleted", func() {
-			remotePeering, _ := awsMockRemote.DescribeVpcPeeringConnection(infra.Ctx(), kcpPeering.Status.Id)
-			Expect(remotePeering).To(BeNil())
+			remotePeering, err := awsMockRemote.DescribeVpcPeeringConnection(infra.Ctx(), kcpPeering.Status.Id)
+			Expect(err).To(BeNil())
+			Expect(remotePeering.Status.Code).To(Equal(ec2types.VpcPeeringConnectionStateReasonCodeDeleted))
 		})
 
 		By("And Then remote route tables have no peering route to local VPC CIDR", func() {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- fixes flaky test that was supposed to tests wheter local peering connection can be deleted when remote peering connection is deleted by the user 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
