### PR TITLE
chore: switch to CredentialsBindingName since SecretBindingName is deprecated

### DIFF
--- a/e2e/sim/shootBuilder.go
+++ b/e2e/sim/shootBuilder.go
@@ -280,9 +280,7 @@ func (b *ShootBuilder) WithRuntime(rt *infrastructuremanagerv1.Runtime) *ShootBu
 	b.obj.Spec.Provider.Workers = rt.Spec.Shoot.Provider.Workers
 
 	b.obj.Spec.Region = rt.Spec.Shoot.Region
-	// SA1019 we keep support for secretBinding until all landscapes are migrated
-	// nolint:staticcheck
-	b.obj.Spec.SecretBindingName = ptr.To(rt.Spec.Shoot.SecretBindingName)
+	b.obj.Spec.CredentialsBindingName = ptr.To(rt.Spec.Shoot.SecretBindingName)
 
 	return b
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
