### PR TITLE
fix: name resolution for gcp nfsinstance v2

### DIFF
--- a/pkg/kcp/provider/gcp/nfsinstance/v2/createInstance.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/v2/createInstance.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kyma-project/cloud-manager/pkg/feature"
 	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/config"
-	v2client "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsinstance/v2/client"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 )
 
@@ -30,7 +29,7 @@ func createInstance(ctx context.Context, st composed.State) (error, context.Cont
 
 	project := state.GetGcpProjectId()
 	location := state.GetGcpLocation()
-	name := v2client.GetFilestoreInstanceId(nfsInstance.Name)
+	name := nfsInstance.Name
 
 	instance := state.ToGcpInstance()
 

--- a/pkg/kcp/provider/gcp/nfsinstance/v2/deleteInstance.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/v2/deleteInstance.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/config"
-	v2client "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsinstance/v2/client"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 )
 
@@ -34,7 +33,7 @@ func deleteInstance(ctx context.Context, st composed.State) (error, context.Cont
 
 	project := state.GetGcpProjectId()
 	location := state.GetGcpLocation()
-	name := v2client.GetFilestoreInstanceId(nfsInstance.Name)
+	name := nfsInstance.Name
 
 	operationName, err := state.GetFilestoreClient().DeleteInstance(ctx, project, location, name)
 	if err != nil {

--- a/pkg/kcp/provider/gcp/nfsinstance/v2/loadInstance.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/v2/loadInstance.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/config"
-	v2client "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsinstance/v2/client"
 )
 
 // loadInstance loads the GCP Filestore instance from the API.
@@ -23,7 +22,7 @@ func loadInstance(ctx context.Context, st composed.State) (error, context.Contex
 
 	project := state.GetGcpProjectId()
 	location := state.GetGcpLocation()
-	name := v2client.GetFilestoreInstanceId(nfsInstance.Name)
+	name := nfsInstance.Name
 
 	instance, err := state.GetFilestoreClient().GetInstance(ctx, project, location, name)
 	if err != nil {

--- a/pkg/kcp/provider/gcp/nfsinstance/v2/updateInstance.go
+++ b/pkg/kcp/provider/gcp/nfsinstance/v2/updateInstance.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/config"
-	v2client "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsinstance/v2/client"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 )
 
@@ -39,7 +38,7 @@ func updateInstance(ctx context.Context, st composed.State) (error, context.Cont
 
 	project := state.GetGcpProjectId()
 	location := state.GetGcpLocation()
-	name := v2client.GetFilestoreInstanceId(nfsInstance.Name)
+	name := nfsInstance.Name
 
 	// Use the modified instance from state (updated by modify actions)
 	operationName, err := state.GetFilestoreClient().UpdateInstance(ctx, project, location, name, state.GetInstance(), state.updateMask)


### PR DESCRIPTION
# Fix: Name Resolution for GCP NFS Instance V2

🐛 **Bug Fix**: Corrected the name resolution logic for GCP Filestore instances by removing unnecessary name transformation.

### Changes

The pull request simplifies the Filestore instance name handling across multiple operations by using the native NFS instance name directly instead of applying a transformation function.

* `createInstance.go`: Removed `GetFilestoreInstanceId()` transformation and now uses `nfsInstance.Name` directly when creating new Filestore instances
* `deleteInstance.go`: Updated instance deletion logic to use the original instance name without transformation
* `loadInstance.go`: Modified instance retrieval to query using the unmodified instance name
* `updateInstance.go`: Adjusted instance update operations to reference instances by their original name

All files also removed the import of the `v2client` package, which is no longer needed after eliminating the `GetFilestoreInstanceId()` helper function.

### Related PRs

* [#123](https://github.com/kyma-project/cloud-manager/pull/123): GCP IpRange Reconciler unit tests
* [#33](https://github.com/kyma-project/cloud-manager/pull/33): GCP IpRange implementation
* [#43](https://github.com/kyma-project/cloud-manager/pull/43): IP Range SKR reconciliation

- [ ] 🔄 Regenerate and Update Summary

