### PR TITLE
chore: refactor AWS NFS VolumeRestore tests

### DIFF
--- a/internal/controller/cloud-resources/aws/awsnfsvolumerestore_test.go
+++ b/internal/controller/cloud-resources/aws/awsnfsvolumerestore_test.go
@@ -108,6 +108,12 @@ var _ = Describe("Feature: SKR AwsNfsVolumeRestore", func() {
 			Eventually(Delete).
 				WithArguments(infra.Ctx(), infra.SKR().Client(), awsNfsVolumeRestore).
 				Should(Succeed())
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), skrAwsNfsVolumeBackup).
+				Should(Succeed())
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), skrAwsNfsVolume).
+				Should(Succeed())
 		})
 	})
 
@@ -213,6 +219,15 @@ var _ = Describe("Feature: SKR AwsNfsVolumeRestore", func() {
 		By("Then the AwsNfsVolumeRestore in SKR is deleted", func() {
 			Eventually(IsDeleted).
 				WithArguments(infra.Ctx(), infra.SKR().Client(), awsNfsVolumeRestore).
+				Should(Succeed())
+		})
+
+		By("// cleanup: Delete remaining test resources", func() {
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), skrAwsNfsVolumeBackup).
+				Should(Succeed())
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.SKR().Client(), skrAwsNfsVolume).
 				Should(Succeed())
 		})
 	})


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Remove shared state variables (scope, skrAwsNfsVolume, skrAwsNfsVolumeBackup)
- Convert 2 Describe blocks into independent It() scenarios
- Each scenario uses unique UUID suffix for parallel-safe resource naming:
- Remove uuid import and use fixed UUID strings
- Move reconciliation Ignore calls before resource setup

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/cloud-manager/issues/1618