### PR TITLE
chore: add TEST_PATH argument to make test to target specific folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ IMG ?= controller:latest
 ENVTEST_K8S_VERSION = 1.34.1
 JV_VERSION = v0.5.0
 
+# TEST_PATH: optional target path for tests.
+# Usage: make test pkg/kcp/provider/gcp
+# When provided, targets ./{path}/... otherwise defaults to ./...
+TEST_PATH ?=
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -87,7 +92,7 @@ test-ff: jv download-flag-schema
 
 .PHONY: test
 test: manifests generate fmt vet envtest test-ff build_ui ## Run tests.
-	SKR_PROVIDERS="$(PROJECTROOT)/config/dist/skr/bases/providers" ENVTEST_K8S_VERSION="$(ENVTEST_K8S_VERSION)" PROJECTROOT="$(PROJECTROOT)" KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" GOFIPS140=v1.0.0 go test ./... -test.v -v -coverprofile cover.out
+	SKR_PROVIDERS="$(PROJECTROOT)/config/dist/skr/bases/providers" ENVTEST_K8S_VERSION="$(ENVTEST_K8S_VERSION)" PROJECTROOT="$(PROJECTROOT)" KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" GOFIPS140=v1.0.0 go test $(if $(TEST_PATH),./$(TEST_PATH)/...,./...) -test.v -v -coverprofile cover.out
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.54.2


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Adds support for running tests on a specific path instead of always targeting the entire codebase.

Changes proposed in this pull request:
- Added `TEST_PATH` variable to the Makefile
- Modified the test target to use the provided path or fallback to `./...`
- example: `make test TEST_PATH=internal/controller/cloud-resources/aws`

Running the full test suite takes significant time. This change allows developers to run tests only for the package they're working on, improving iteration speed during development.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
