### PR TITLE
fix: add explicit read permissions to e2e workflows

### DIFF
--- a/.github/workflows/e2e-all.yaml
+++ b/.github/workflows/e2e-all.yaml
@@ -35,6 +35,9 @@ on:
         description: Extra logs and prints
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   aws:
     if: ${{ inputs.aws }}

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -56,6 +56,9 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add permissions block to e2e-all.yaml and e2e-tests.yaml
- Set contents: read to follow least privilege principle
- Resolves CodeQL alert: missing-workflow-permissions

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Resolves CodeQL security alert actions/missing-workflow-permissions by adding explicit permissions blocks to both e2e workflows.

Action that proves workflow is correct: https://github.com/stekik/cloud-manager/actions/runs/23842826820/job/69502560920

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
