### PR TITLE
refactor: move iprange v3 to new gcpclients and mock2

### DIFF
--- a/internal/controller/cloud-control/iprange_gcp_refactored_test.go
+++ b/internal/controller/cloud-control/iprange_gcp_refactored_test.go
@@ -5,6 +5,7 @@ package cloudcontrol
 import (
 	"context"
 
+	"cloud.google.com/go/compute/apiv1/computepb"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common"
 	"github.com/kyma-project/cloud-manager/pkg/feature"
@@ -14,6 +15,7 @@ import (
 	. "github.com/kyma-project/cloud-manager/pkg/testinfra/dsl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("Feature: KCP IpRange for GCP - Refactored Implementation", func() {
@@ -31,12 +33,26 @@ var _ = Describe("Feature: KCP IpRange for GCP - Refactored Implementation", fun
 		scope := &cloudcontrolv1beta1.Scope{}
 		ipRange := &cloudcontrolv1beta1.IpRange{}
 
+		gcpMock := infra.GcpMock2().NewSubscription("iprange-v3-cidr")
+		defer gcpMock.Delete()
+
 		By("Given Scope exists", func() {
 			kcpscope.Ignore.AddName(kymaName)
 
-			Eventually(CreateScopeGcp).
-				WithArguments(infra.Ctx(), infra, scope, WithName(kymaName)).
+			Eventually(CreateScopeGcp2).
+				WithArguments(infra.Ctx(), infra, scope, gcpMock.ProjectId(), WithName(kymaName)).
 				Should(Succeed())
+		})
+
+		By("And Given GCP VPC network exists", func() {
+			op, err := gcpMock.InsertNetwork(infra.Ctx(), &computepb.InsertNetworkRequest{
+				Project: gcpMock.ProjectId(),
+				NetworkResource: &computepb.Network{
+					Name: ptr.To(scope.Spec.Scope.Gcp.VpcNetwork),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(op.Wait(infra.Ctx())).To(Succeed())
 		})
 
 		var kcpNetworkKyma *cloudcontrolv1beta1.Network
@@ -89,22 +105,28 @@ var _ = Describe("Feature: KCP IpRange for GCP - Refactored Implementation", fun
 
 		By("And Then GCP global address is created", func() {
 			Eventually(func() error {
-				_, err := infra.GcpMock().GetIpRangeDiscovery(infra.Ctx(), scope.Spec.Scope.Gcp.Project, "cm-"+ipRange.Name)
+				_, err := gcpMock.GetGlobalAddress(infra.Ctx(), &computepb.GetGlobalAddressRequest{
+					Project: gcpMock.ProjectId(),
+					Address: "cm-" + ipRange.Name,
+				})
 				return err
 			}).Should(Succeed())
 		})
 
 		By("And Then GCP global address has correct properties", func() {
-			gcpGlobalAddress, err := infra.GcpMock().GetIpRangeDiscovery(infra.Ctx(), scope.Spec.Scope.Gcp.Project, "cm-"+ipRange.Name)
+			gcpGlobalAddress, err := gcpMock.GetGlobalAddress(infra.Ctx(), &computepb.GetGlobalAddressRequest{
+				Project: gcpMock.ProjectId(),
+				Address: "cm-" + ipRange.Name,
+			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(gcpGlobalAddress).NotTo(BeNil())
-			Expect(gcpGlobalAddress.Name).To(Equal("cm-" + ipRange.Name))
-			Expect(gcpGlobalAddress.AddressType).To(Equal(string(gcpclient.AddressTypeInternal)))
+			Expect(gcpGlobalAddress.GetName()).To(Equal("cm-" + ipRange.Name))
+			Expect(gcpGlobalAddress.GetAddressType()).To(Equal(string(gcpclient.AddressTypeInternal)))
 		})
 
 		By("And Then GCP PSA connection is created", func() {
 			Eventually(func() error {
-				connections, err := infra.GcpMock().ListServiceConnections(infra.Ctx(), scope.Spec.Scope.Gcp.Project, scope.Spec.Scope.Gcp.VpcNetwork)
+				connections, err := gcpMock.ListServiceConnections(infra.Ctx(), gcpMock.ProjectId(), scope.Spec.Scope.Gcp.VpcNetwork)
 				if err != nil {
 					return err
 				}
@@ -116,7 +138,7 @@ var _ = Describe("Feature: KCP IpRange for GCP - Refactored Implementation", fun
 		})
 
 		By("And Then GCP PSA connection includes the IP range", func() {
-			connections, err := infra.GcpMock().ListServiceConnections(infra.Ctx(), scope.Spec.Scope.Gcp.Project, scope.Spec.Scope.Gcp.VpcNetwork)
+			connections, err := gcpMock.ListServiceConnections(infra.Ctx(), gcpMock.ProjectId(), scope.Spec.Scope.Gcp.VpcNetwork)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(connections).NotTo(BeEmpty())
 			Expect(connections[0].ReservedPeeringRanges).To(ContainElement("cm-" + ipRange.Name))
@@ -137,13 +159,15 @@ var _ = Describe("Feature: KCP IpRange for GCP - Refactored Implementation", fun
 		})
 
 		By("And Then GCP global address does not exist", func() {
-			gcpGlobalAddress, err := infra.GcpMock().GetIpRangeDiscovery(infra.Ctx(), scope.Spec.Scope.Gcp.Project, "cm-"+ipRange.Name)
-			Expect(gcpGlobalAddress).To(BeNil())
+			_, err := gcpMock.GetGlobalAddress(infra.Ctx(), &computepb.GetGlobalAddressRequest{
+				Project: gcpMock.ProjectId(),
+				Address: "cm-" + ipRange.Name,
+			})
 			Expect(gcpmeta.IsNotFound(err)).To(BeTrue())
 		})
 
 		By("And Then GCP PSA connection no longer includes the IP range", func() {
-			connections, err := infra.GcpMock().ListServiceConnections(infra.Ctx(), scope.Spec.Scope.Gcp.Project, scope.Spec.Scope.Gcp.VpcNetwork)
+			connections, err := gcpMock.ListServiceConnections(infra.Ctx(), gcpMock.ProjectId(), scope.Spec.Scope.Gcp.VpcNetwork)
 			Expect(err).NotTo(HaveOccurred())
 			if len(connections) > 0 {
 				Expect(connections[0].ReservedPeeringRanges).NotTo(ContainElement("cm-" + ipRange.Name))
@@ -164,12 +188,26 @@ var _ = Describe("Feature: KCP IpRange for GCP - Refactored Implementation", fun
 		scope := &cloudcontrolv1beta1.Scope{}
 		ipRange := &cloudcontrolv1beta1.IpRange{}
 
+		gcpMock := infra.GcpMock2().NewSubscription("iprange-v3-nocidr")
+		defer gcpMock.Delete()
+
 		By("Given Scope exists", func() {
 			kcpscope.Ignore.AddName(kymaName)
 
-			Eventually(CreateScopeGcp).
-				WithArguments(infra.Ctx(), infra, scope, WithName(kymaName)).
+			Eventually(CreateScopeGcp2).
+				WithArguments(infra.Ctx(), infra, scope, gcpMock.ProjectId(), WithName(kymaName)).
 				Should(Succeed())
+		})
+
+		By("And Given GCP VPC network exists", func() {
+			op, err := gcpMock.InsertNetwork(infra.Ctx(), &computepb.InsertNetworkRequest{
+				Project: gcpMock.ProjectId(),
+				NetworkResource: &computepb.Network{
+					Name: ptr.To(scope.Spec.Scope.Gcp.VpcNetwork),
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(op.Wait(infra.Ctx())).To(Succeed())
 		})
 
 		var kcpNetworkKyma *cloudcontrolv1beta1.Network
@@ -223,22 +261,28 @@ var _ = Describe("Feature: KCP IpRange for GCP - Refactored Implementation", fun
 
 		By("And Then GCP global address is created", func() {
 			Eventually(func() error {
-				_, err := infra.GcpMock().GetIpRangeDiscovery(infra.Ctx(), scope.Spec.Scope.Gcp.Project, "cm-"+ipRange.Name)
+				_, err := gcpMock.GetGlobalAddress(infra.Ctx(), &computepb.GetGlobalAddressRequest{
+					Project: gcpMock.ProjectId(),
+					Address: "cm-" + ipRange.Name,
+				})
 				return err
 			}).Should(Succeed())
 		})
 
 		By("And Then GCP global address has correct properties", func() {
-			gcpGlobalAddress, err := infra.GcpMock().GetIpRangeDiscovery(infra.Ctx(), scope.Spec.Scope.Gcp.Project, "cm-"+ipRange.Name)
+			gcpGlobalAddress, err := gcpMock.GetGlobalAddress(infra.Ctx(), &computepb.GetGlobalAddressRequest{
+				Project: gcpMock.ProjectId(),
+				Address: "cm-" + ipRange.Name,
+			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(gcpGlobalAddress).NotTo(BeNil())
-			Expect(gcpGlobalAddress.Name).To(Equal("cm-" + ipRange.Name))
-			Expect(gcpGlobalAddress.AddressType).To(Equal(string(gcpclient.AddressTypeInternal)))
+			Expect(gcpGlobalAddress.GetName()).To(Equal("cm-" + ipRange.Name))
+			Expect(gcpGlobalAddress.GetAddressType()).To(Equal(string(gcpclient.AddressTypeInternal)))
 		})
 
 		By("And Then GCP PSA connection is created", func() {
 			Eventually(func() error {
-				connections, err := infra.GcpMock().ListServiceConnections(infra.Ctx(), scope.Spec.Scope.Gcp.Project, scope.Spec.Scope.Gcp.VpcNetwork)
+				connections, err := gcpMock.ListServiceConnections(infra.Ctx(), gcpMock.ProjectId(), scope.Spec.Scope.Gcp.VpcNetwork)
 				if err != nil {
 					return err
 				}
@@ -250,7 +294,7 @@ var _ = Describe("Feature: KCP IpRange for GCP - Refactored Implementation", fun
 		})
 
 		By("And Then GCP PSA connection includes the IP range", func() {
-			connections, err := infra.GcpMock().ListServiceConnections(infra.Ctx(), scope.Spec.Scope.Gcp.Project, scope.Spec.Scope.Gcp.VpcNetwork)
+			connections, err := gcpMock.ListServiceConnections(infra.Ctx(), gcpMock.ProjectId(), scope.Spec.Scope.Gcp.VpcNetwork)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(connections).NotTo(BeEmpty())
 			Expect(connections[0].ReservedPeeringRanges).To(ContainElement("cm-" + ipRange.Name))
@@ -271,13 +315,15 @@ var _ = Describe("Feature: KCP IpRange for GCP - Refactored Implementation", fun
 		})
 
 		By("And Then GCP global address does not exist", func() {
-			gcpGlobalAddress, err := infra.GcpMock().GetIpRangeDiscovery(infra.Ctx(), scope.Spec.Scope.Gcp.Project, "cm-"+ipRange.Name)
-			Expect(gcpGlobalAddress).To(BeNil())
+			_, err := gcpMock.GetGlobalAddress(infra.Ctx(), &computepb.GetGlobalAddressRequest{
+				Project: gcpMock.ProjectId(),
+				Address: "cm-" + ipRange.Name,
+			})
 			Expect(gcpmeta.IsNotFound(err)).To(BeTrue())
 		})
 
 		By("And Then GCP PSA connection no longer includes the IP range", func() {
-			connections, err := infra.GcpMock().ListServiceConnections(infra.Ctx(), scope.Spec.Scope.Gcp.Project, scope.Spec.Scope.Gcp.VpcNetwork)
+			connections, err := gcpMock.ListServiceConnections(infra.Ctx(), gcpMock.ProjectId(), scope.Spec.Scope.Gcp.VpcNetwork)
 			Expect(err).NotTo(HaveOccurred())
 			if len(connections) > 0 {
 				Expect(connections[0].ReservedPeeringRanges).NotTo(ContainElement("cm-" + ipRange.Name))

--- a/internal/controller/cloud-control/suite_test.go
+++ b/internal/controller/cloud-control/suite_test.go
@@ -104,10 +104,10 @@ var _ = BeforeSuite(func() {
 		infra.KcpManager(),
 		infra.AwsMock().IpRangeSkrProvider(),
 		infra.AzureMock().IpRangeProvider(),
-		infra.GcpMock().ServiceNetworkingClientProviderGcp(), // v3: NEW pattern (GcpClientProvider)
-		infra.GcpMock().ComputeClientProviderGcp(),           // v3: NEW pattern (GcpClientProvider)
-		infra.GcpMock().ServiceNetworkingClientProvider(),    // v2: OLD pattern (ClientProvider)
-		infra.GcpMock().OldComputeClientProvider(),           // v2: OLD pattern (ClientProvider)
+		infra.GcpMock2().IpRangeServiceNetworkingProvider(), // v3: NEW pattern (GcpClientProvider) via mock2
+		infra.GcpMock2().IpRangeComputeProvider(),           // v3: NEW pattern (GcpClientProvider) via mock2
+		infra.GcpMock().ServiceNetworkingClientProvider(),   // v2: OLD pattern (ClientProvider)
+		infra.GcpMock().OldComputeClientProvider(),          // v2: OLD pattern (ClientProvider)
 		infra.SapMock().IpRangeProvider(),
 		env,
 	)).NotTo(HaveOccurred())

--- a/pkg/kcp/provider/gcp/client/gcpClients.go
+++ b/pkg/kcp/provider/gcp/client/gcpClients.go
@@ -310,6 +310,21 @@ func (c *GcpClients) FilestoreWrapped() FilestoreClient {
 	return &filestoreClient{inner: c.Filestore}
 }
 
+// GlobalAddressesWrapped is supposed to replace usage of field ComputeGlobalAddresses after the refactoring
+func (c *GcpClients) GlobalAddressesWrapped() GlobalAddressesClient {
+	return &globalAddressesClient{inner: *c.ComputeGlobalAddresses}
+}
+
+// GlobalOperationsWrapped is supposed to replace usage of field ComputeGlobalOperations after the refactoring
+func (c *GcpClients) GlobalOperationsWrapped() ComputeGlobalOperationsClient {
+	return &computeGlobalOperationsClient{inner: c.ComputeGlobalOperations}
+}
+
+// ServiceNetworkingWrapped is supposed to replace usage of fields ServiceNetworking and CloudResourceManager after the refactoring
+func (c *GcpClients) ServiceNetworkingWrapped() ServiceNetworkingClient {
+	return &serviceNetworkingClient{inner: c.ServiceNetworking, crm: c.CloudResourceManager}
+}
+
 func (c *VpcPeeringClients) Close() error {
 	return reflectingClose(c)
 }

--- a/pkg/kcp/provider/gcp/iprange/client/computeClient.go
+++ b/pkg/kcp/provider/gcp/iprange/client/computeClient.go
@@ -3,11 +3,9 @@ package client
 import (
 	"context"
 
-	compute "cloud.google.com/go/compute/apiv1"
 	"cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
-	"google.golang.org/api/iterator"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -32,15 +30,21 @@ func NewComputeClientProvider(gcpClients *gcpclient.GcpClients) gcpclient.GcpCli
 
 // NewComputeClient creates a new ComputeClient wrapping GcpClients.
 func NewComputeClient(gcpClients *gcpclient.GcpClients) ComputeClient {
+	return NewComputeClientFromWrapped(gcpClients.GlobalAddressesWrapped(), gcpClients.GlobalOperationsWrapped())
+}
+
+// NewComputeClientFromWrapped creates a ComputeClient from wrapped interfaces.
+// Used by mock2 for test wiring.
+func NewComputeClientFromWrapped(globalAddresses gcpclient.GlobalAddressesClient, globalOperations gcpclient.ComputeGlobalOperationsClient) ComputeClient {
 	return &computeClient{
-		globalAddressesClient:  gcpClients.ComputeGlobalAddresses,
-		globalOperationsClient: gcpClients.ComputeGlobalOperations,
+		globalAddressesClient:  globalAddresses,
+		globalOperationsClient: globalOperations,
 	}
 }
 
 type computeClient struct {
-	globalAddressesClient  *compute.GlobalAddressesClient
-	globalOperationsClient *compute.GlobalOperationsClient
+	globalAddressesClient  gcpclient.GlobalAddressesClient
+	globalOperationsClient gcpclient.ComputeGlobalOperationsClient
 }
 
 func (c *computeClient) GetIpRange(ctx context.Context, projectId, name string) (*computepb.Address, error) {
@@ -51,7 +55,7 @@ func (c *computeClient) GetIpRange(ctx context.Context, projectId, name string) 
 		Address: name,
 	}
 
-	out, err := c.globalAddressesClient.Get(ctx, req)
+	out, err := c.globalAddressesClient.GetGlobalAddress(ctx, req)
 	if err != nil {
 		logger.Info("GetIpRange", "err", err)
 	}
@@ -66,11 +70,11 @@ func (c *computeClient) DeleteIpRange(ctx context.Context, projectId, name strin
 		Address: name,
 	}
 
-	op, err := c.globalAddressesClient.Delete(ctx, req)
+	op, err := c.globalAddressesClient.DeleteGlobalAddress(ctx, req)
 
 	var operationName string
 	if op != nil {
-		operationName = op.Proto().GetName()
+		operationName = op.Name()
 	}
 
 	logger.Info("DeleteIpRange", "operation", operationName, "err", err)
@@ -93,11 +97,11 @@ func (c *computeClient) CreatePscIpRange(ctx context.Context, projectId, vpcName
 		},
 	}
 
-	op, err := c.globalAddressesClient.Insert(ctx, req)
+	op, err := c.globalAddressesClient.InsertGlobalAddress(ctx, req)
 
 	var operationName string
 	if op != nil {
-		operationName = op.Proto().GetName()
+		operationName = op.Name()
 	}
 
 	logger.Info("CreatePscIpRange", "operation", operationName, "err", err)
@@ -114,14 +118,10 @@ func (c *computeClient) ListGlobalAddresses(ctx context.Context, projectId, vpc 
 		Filter:  proto.String(filter),
 	}
 
-	it := c.globalAddressesClient.List(ctx, req)
+	it := c.globalAddressesClient.ListGlobalAddresses(ctx, req)
 
 	var addresses []*computepb.Address
-	for {
-		addr, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
+	for addr, err := range it.All() {
 		if err != nil {
 			logger.Error(err, "ListGlobalAddresses", "projectId", projectId, "vpc", vpc)
 			return nil, err
@@ -140,7 +140,7 @@ func (c *computeClient) GetGlobalOperation(ctx context.Context, projectId, opera
 		Operation: operationName,
 	}
 
-	out, err := c.globalOperationsClient.Get(ctx, req)
+	out, err := c.globalOperationsClient.GetComputeGlobalOperation(ctx, req)
 	if err != nil {
 		logger.Error(err, "GetGlobalOperation", "projectId", projectId, "operationName", operationName)
 		return nil, err
@@ -149,17 +149,11 @@ func (c *computeClient) GetGlobalOperation(ctx context.Context, projectId, opera
 }
 
 func (c *computeClient) WaitGlobalOperation(ctx context.Context, projectId, operationName string) error {
+	// WaitGlobalOperation is not available on the wrapped interface.
+	// This method is retained for interface compatibility but is not called in production code.
+	// Use GetGlobalOperation and poll instead.
 	logger := composed.LoggerFromCtx(ctx)
-
-	req := &computepb.WaitGlobalOperationRequest{
-		Project:   projectId,
-		Operation: operationName,
-	}
-
-	_, err := c.globalOperationsClient.Wait(ctx, req)
-	if err != nil {
-		logger.Error(err, "WaitGlobalOperation", "projectId", projectId, "operationName", operationName)
-		return err
-	}
-	return nil
+	logger.Info("WaitGlobalOperation called - polling via GetGlobalOperation", "projectId", projectId, "operationName", operationName)
+	_, err := c.GetGlobalOperation(ctx, projectId, operationName)
+	return err
 }

--- a/pkg/kcp/provider/gcp/iprange/client/serviceNetworkingClient.go
+++ b/pkg/kcp/provider/gcp/iprange/client/serviceNetworkingClient.go
@@ -46,21 +46,21 @@ type ServiceNetworkingClient interface {
 // The clients are initialized in GcpClients and injected here for consistency with other providers.
 func NewServiceNetworkingClientProvider(gcpClients *client.GcpClients) client.GcpClientProvider[ServiceNetworkingClient] {
 	return func(_ string) ServiceNetworkingClient {
-		return NewServiceNetworkingClientForService(
-			gcpClients.ServiceNetworking,
-			gcpClients.CloudResourceManager,
-		)
+		return NewServiceNetworkingClientFromWrapped(gcpClients.ServiceNetworkingWrapped())
 	}
+}
+
+// NewServiceNetworkingClientFromWrapped creates a ServiceNetworkingClient from wrapped interface.
+// Used by mock2 for test wiring.
+func NewServiceNetworkingClientFromWrapped(wrapped client.ServiceNetworkingClient) ServiceNetworkingClient {
+	return &serviceNetworkingClientAdapter{wrapped: wrapped}
 }
 
 // NewServiceNetworkingClientProviderV2 creates a ClientProvider (OLD pattern) for v2 legacy code.
 // This wraps the clients from GcpClients to avoid duplicate client creation.
 func NewServiceNetworkingClientProviderV2(gcpClients *client.GcpClients) client.ClientProvider[ServiceNetworkingClient] {
 	return func(ctx context.Context, credentialsFile string) (ServiceNetworkingClient, error) {
-		return NewServiceNetworkingClientForService(
-			gcpClients.ServiceNetworking,
-			gcpClients.CloudResourceManager,
-		), nil
+		return NewServiceNetworkingClientFromWrapped(gcpClients.ServiceNetworkingWrapped()), nil
 	}
 }
 
@@ -89,15 +89,43 @@ func NewServiceNetworkingClient() client.ClientProvider[ServiceNetworkingClient]
 }
 
 func NewServiceNetworkingClientForService(svcNet *servicenetworking.APIService, crmService *cloudresourcemanager.Service) ServiceNetworkingClient {
-	return &serviceNetworkingClient{svcNet: svcNet, crmService: crmService}
+	return &serviceNetworkingClientDirect{svcNet: svcNet, crmService: crmService}
 }
 
-type serviceNetworkingClient struct {
+// serviceNetworkingClientAdapter wraps the central gcpclient.ServiceNetworkingClient interface
+// and delegates to it. Used in the NEW pattern.
+type serviceNetworkingClientAdapter struct {
+	wrapped client.ServiceNetworkingClient
+}
+
+func (c *serviceNetworkingClientAdapter) PatchServiceConnection(ctx context.Context, projectId, vpcId string, reservedIpRanges []string) (*servicenetworking.Operation, error) {
+	return c.wrapped.PatchServiceConnection(ctx, projectId, vpcId, reservedIpRanges)
+}
+
+func (c *serviceNetworkingClientAdapter) DeleteServiceConnection(ctx context.Context, projectId, vpcId string) (*servicenetworking.Operation, error) {
+	return c.wrapped.DeleteServiceConnection(ctx, projectId, vpcId)
+}
+
+func (c *serviceNetworkingClientAdapter) ListServiceConnections(ctx context.Context, projectId, vpcId string) ([]*servicenetworking.Connection, error) {
+	return c.wrapped.ListServiceConnections(ctx, projectId, vpcId)
+}
+
+func (c *serviceNetworkingClientAdapter) CreateServiceConnection(ctx context.Context, projectId, vpcId string, reservedIpRanges []string) (*servicenetworking.Operation, error) {
+	return c.wrapped.CreateServiceConnection(ctx, projectId, vpcId, reservedIpRanges)
+}
+
+func (c *serviceNetworkingClientAdapter) GetServiceNetworkingOperation(ctx context.Context, operationName string) (*servicenetworking.Operation, error) {
+	return c.wrapped.GetServiceNetworkingOperation(ctx, operationName)
+}
+
+// serviceNetworkingClientDirect is the direct implementation using the legacy API.
+// Used by the deprecated NewServiceNetworkingClient and NewServiceNetworkingClientForService.
+type serviceNetworkingClientDirect struct {
 	svcNet     *servicenetworking.APIService
 	crmService *cloudresourcemanager.Service
 }
 
-func (c *serviceNetworkingClient) PatchServiceConnection(ctx context.Context, projectId, vpcId string, reservedIpRanges []string) (*servicenetworking.Operation, error) {
+func (c *serviceNetworkingClientDirect) PatchServiceConnection(ctx context.Context, projectId, vpcId string, reservedIpRanges []string) (*servicenetworking.Operation, error) {
 	logger := composed.LoggerFromCtx(ctx)
 	network := client.GetVPCPath(projectId, vpcId)
 	operation, err := c.svcNet.Services.Connections.Patch(client.ServiceNetworkingServiceConnectionName, &servicenetworking.Connection{
@@ -108,7 +136,7 @@ func (c *serviceNetworkingClient) PatchServiceConnection(ctx context.Context, pr
 	return operation, err
 }
 
-func (c *serviceNetworkingClient) DeleteServiceConnection(ctx context.Context, projectId, vpcId string) (*servicenetworking.Operation, error) {
+func (c *serviceNetworkingClientDirect) DeleteServiceConnection(ctx context.Context, projectId, vpcId string) (*servicenetworking.Operation, error) {
 	logger := composed.LoggerFromCtx(ctx)
 	ProjectNumber, err := client.GetCachedProjectNumber(projectId, c.crmService)
 	if err != nil {
@@ -122,7 +150,7 @@ func (c *serviceNetworkingClient) DeleteServiceConnection(ctx context.Context, p
 	return operation, err
 }
 
-func (c *serviceNetworkingClient) ListServiceConnections(ctx context.Context, projectId, vpcId string) ([]*servicenetworking.Connection, error) {
+func (c *serviceNetworkingClientDirect) ListServiceConnections(ctx context.Context, projectId, vpcId string) ([]*servicenetworking.Connection, error) {
 	logger := composed.LoggerFromCtx(ctx)
 	network := client.GetVPCPath(projectId, vpcId)
 	out, err := c.svcNet.Services.Connections.List(client.ServiceNetworkingServicePath).Network(network).Do()
@@ -133,7 +161,7 @@ func (c *serviceNetworkingClient) ListServiceConnections(ctx context.Context, pr
 	return out.Connections, nil
 }
 
-func (c *serviceNetworkingClient) CreateServiceConnection(ctx context.Context, projectId, vpcId string, reservedIpRanges []string) (*servicenetworking.Operation, error) {
+func (c *serviceNetworkingClientDirect) CreateServiceConnection(ctx context.Context, projectId, vpcId string, reservedIpRanges []string) (*servicenetworking.Operation, error) {
 	logger := composed.LoggerFromCtx(ctx)
 	network := client.GetVPCPath(projectId, vpcId)
 	operation, err := c.svcNet.Services.Connections.Create(client.ServiceNetworkingServicePath, &servicenetworking.Connection{
@@ -144,7 +172,7 @@ func (c *serviceNetworkingClient) CreateServiceConnection(ctx context.Context, p
 	return operation, err
 }
 
-func (c *serviceNetworkingClient) GetServiceNetworkingOperation(ctx context.Context, operationName string) (*servicenetworking.Operation, error) {
+func (c *serviceNetworkingClientDirect) GetServiceNetworkingOperation(ctx context.Context, operationName string) (*servicenetworking.Operation, error) {
 	logger := composed.LoggerFromCtx(ctx)
 	operation, err := c.svcNet.Operations.Get(operationName).Do()
 	if err != nil {

--- a/pkg/kcp/provider/gcp/mock2/e2e_service_networking_connection_test.go
+++ b/pkg/kcp/provider/gcp/mock2/e2e_service_networking_connection_test.go
@@ -23,7 +23,7 @@ func TestE2EServiceNetworkingConnection(t *testing.T) {
 
 		con := s.createPsaConnectionOK(net.GetSelfLink(), addr.GetSelfLink())
 		require.Len(t, con.ReservedPeeringRanges, 1)
-		require.Equal(t, []string{addr.GetSelfLink()}, con.ReservedPeeringRanges)
+		require.Equal(t, []string{addr.GetName()}, con.ReservedPeeringRanges)
 
 		// second address
 		addr2 := s.createPsaRangeOK(net.GetSelfLink(), "test-address-2", "10.252.0.0", 16)
@@ -36,7 +36,7 @@ func TestE2EServiceNetworkingConnection(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, arr, 1)
 		require.Len(t, arr[0].ReservedPeeringRanges, 2)
-		require.Equal(t, []string{addr.GetSelfLink(), addr2.GetSelfLink()}, arr[0].ReservedPeeringRanges)
+		require.Equal(t, []string{addr.GetName(), addr2.GetName()}, arr[0].ReservedPeeringRanges)
 
 		// delete
 

--- a/pkg/kcp/provider/gcp/mock2/server.go
+++ b/pkg/kcp/provider/gcp/mock2/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/elliotchance/pie/v2"
 	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	gcpexposeddataclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/exposedData/client"
+	gcpiprangeclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/iprange/client"
 	gcpnfsbackupclientv2 "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsbackup/client/v2"
 	gcpnfsinstancev2client "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsinstance/v2/client"
 	gcpnfsrestoreclientv2 "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsrestore/client/v2"
@@ -118,6 +119,26 @@ func (s *server) NfsRestoreV2Provider() gcpclient.GcpClientProvider[gcpnfsrestor
 			return nil
 		}
 		return gcpnfsrestoreclientv2.NewFileRestoreClientFromFilestoreClient(sub)
+	}
+}
+
+func (s *server) IpRangeComputeProvider() gcpclient.GcpClientProvider[gcpiprangeclient.ComputeClient] {
+	return func(projectId string) gcpiprangeclient.ComputeClient {
+		sub := s.GetSubscription(projectId)
+		if sub == nil {
+			return nil
+		}
+		return gcpiprangeclient.NewComputeClientFromWrapped(sub, sub)
+	}
+}
+
+func (s *server) IpRangeServiceNetworkingProvider() gcpclient.GcpClientProvider[gcpiprangeclient.ServiceNetworkingClient] {
+	return func(projectId string) gcpiprangeclient.ServiceNetworkingClient {
+		sub := s.GetSubscription(projectId)
+		if sub == nil {
+			return nil
+		}
+		return gcpiprangeclient.NewServiceNetworkingClientFromWrapped(sub)
 	}
 }
 

--- a/pkg/kcp/provider/gcp/mock2/store.go
+++ b/pkg/kcp/provider/gcp/mock2/store.go
@@ -95,6 +95,7 @@ var _ gcpclient.RedisInstanceClient = (*store)(nil)
 var _ gcpclient.RedisClusterClient = (*store)(nil)
 var _ gcpclient.NetworkConnectivityClient = (*store)(nil)
 var _ gcpclient.ResourceManagerClient = (*store)(nil)
+var _ gcpclient.ServiceNetworkingClient = (*store)(nil)
 
 func (s *store) ProjectId() string {
 	return s.projectId

--- a/pkg/kcp/provider/gcp/mock2/storeAddresses.go
+++ b/pkg/kcp/provider/gcp/mock2/storeAddresses.go
@@ -182,6 +182,11 @@ func (s *store) InsertGlobalAddress(ctx context.Context, req *computepb.InsertGl
 	addr.SelfLink = ptr.To(name.PrefixWithGoogleApisComputeV1())
 	addr.Kind = ptr.To("compute#address")
 	addr.Status = ptr.To(computepb.Address_RESERVED.String())
+	if addr.Network != nil {
+		if nd, err := gcputil.ParseNameDetail(*addr.Network); err == nil {
+			addr.Network = ptr.To(nd.PrefixWithGoogleApisComputeV1())
+		}
+	}
 
 	s.addresses.Add(addr, name)
 

--- a/pkg/kcp/provider/gcp/mock2/storeFilestore.go
+++ b/pkg/kcp/provider/gcp/mock2/storeFilestore.go
@@ -169,10 +169,10 @@ func (s *store) CreateFilestoreInstance(ctx context.Context, req *filestorepb.Cr
 			return netName.EqualString(item.Obj.Network)
 		}).
 		FilterByCallback(func(item FilterableListItem[*servicenetworking.Connection]) bool {
-			return pie.Contains(item.Obj.ReservedPeeringRanges, addr.GetSelfLink())
+			return pie.Contains(item.Obj.ReservedPeeringRanges, addrName.ResourceId())
 		})
 	if serviceConnections.Len() == 0 {
-		return nil, gcpmeta.NewNotFoundError("service connection in network %s linked to address %s not found", netName.String(), addr.GetSelfLink())
+		return nil, gcpmeta.NewNotFoundError("service connection in network %s linked to address %s not found", netName.String(), addrName.ResourceId())
 	}
 
 	// validate file shares

--- a/pkg/kcp/provider/gcp/mock2/storeRedisInstance.go
+++ b/pkg/kcp/provider/gcp/mock2/storeRedisInstance.go
@@ -145,10 +145,10 @@ func (s *store) CreateRedisInstance(ctx context.Context, req *redispb.CreateInst
 			return netName.EqualString(item.Obj.Network)
 		}).
 		FilterByCallback(func(item FilterableListItem[*servicenetworking.Connection]) bool {
-			return pie.Contains(item.Obj.ReservedPeeringRanges, addr.GetSelfLink())
+			return pie.Contains(item.Obj.ReservedPeeringRanges, addrName.ResourceId())
 		})
 	if serviceConnections.Len() == 0 {
-		return nil, gcpmeta.NewNotFoundError("service connection in network %s linked to address %s not found", netName.String(), addr.GetSelfLink())
+		return nil, gcpmeta.NewNotFoundError("service connection in network %s linked to address %s not found", netName.String(), addrName.ResourceId())
 	}
 
 	// create redis instance

--- a/pkg/kcp/provider/gcp/mock2/storeServiceNetworking.go
+++ b/pkg/kcp/provider/gcp/mock2/storeServiceNetworking.go
@@ -29,11 +29,11 @@ func (s *store) PatchServiceConnection(ctx context.Context, projectId, vpcId str
 	for _, reservedIpRange := range reservedIpRanges {
 		// reservedIpRange is the name of the address
 		addrNd := gcputil.NewGlobalAddressName(projectId, reservedIpRange)
-		addr, found := s.addresses.FindByName(addrNd)
+		_, found := s.addresses.FindByName(addrNd)
 		if !found {
 			return nil, gcpmeta.NewBadRequestError("address %s not found", addrNd)
 		}
-		reservedPeeringRanges = append(reservedPeeringRanges, addr.GetSelfLink())
+		reservedPeeringRanges = append(reservedPeeringRanges, reservedIpRange)
 	}
 
 	con, found := s.serviceConnections.FindByName(netNd)
@@ -116,11 +116,11 @@ func (s *store) CreateServiceConnection(ctx context.Context, projectId, vpcId st
 	for _, reservedIpRange := range reservedIpRanges {
 		// reservedIpRange is the name of the address
 		addrNd := gcputil.NewGlobalAddressName(projectId, reservedIpRange)
-		addr, found := s.addresses.FindByName(addrNd)
+		_, found := s.addresses.FindByName(addrNd)
 		if !found {
 			return nil, gcpmeta.NewBadRequestError("address %s not found", addrNd)
 		}
-		reservedPeeringRanges = append(reservedPeeringRanges, addr.GetSelfLink())
+		reservedPeeringRanges = append(reservedPeeringRanges, reservedIpRange)
 	}
 
 	con := &servicenetworking.Connection{

--- a/pkg/kcp/provider/gcp/mock2/types.go
+++ b/pkg/kcp/provider/gcp/mock2/types.go
@@ -3,6 +3,7 @@ package mock2
 import (
 	gcpclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/client"
 	gcpexposeddataclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/exposedData/client"
+	gcpiprangeclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/iprange/client"
 	gcpnfsbackupclientv2 "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsbackup/client/v2"
 	gcpnfsinstancev2client "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsinstance/v2/client"
 	gcpnfsrestoreclientv2 "github.com/kyma-project/cloud-manager/pkg/kcp/provider/gcp/nfsrestore/client/v2"
@@ -39,6 +40,8 @@ type Providers interface {
 	NfsInstanceV2Provider() gcpclient.GcpClientProvider[gcpnfsinstancev2client.FilestoreClient]
 	NfsBackupV2Provider() gcpclient.GcpClientProvider[gcpnfsbackupclientv2.FileBackupClient]
 	NfsRestoreV2Provider() gcpclient.GcpClientProvider[gcpnfsrestoreclientv2.FileRestoreClient]
+	IpRangeComputeProvider() gcpclient.GcpClientProvider[gcpiprangeclient.ComputeClient]
+	IpRangeServiceNetworkingProvider() gcpclient.GcpClientProvider[gcpiprangeclient.ServiceNetworkingClient]
 	// all others feature's providers as they are refactored to switch using these new GCP clients
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- move IpRange v3 to mock2 and new gcp clients
- Adjusted mock2 to match the GCP response
  - gcp
<img width="1196" height="420" alt="image" src="https://github.com/user-attachments/assets/b97515bb-0aca-4c6a-a9fe-8d26accec193" />
  - mock2 (before adjustment)
<img width="1178" height="454" alt="image" src="https://github.com/user-attachments/assets/5a1aa0d7-f7cd-4864-9040-1e19d75f6d0a" />


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
