### PR TITLE
chore: change codeowners for /docs/proposals

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,6 @@
 /docs/user/ @kyma-project/technical-writers
 
 # Proposals directory (Phoenix team owns these docs)
-/docs/proposals/ @kyma-project/Phoenix
-
+/docs/specs/ @kyma-project/Phoenix
 # All .md files
 *.md @kyma-project/technical-writers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,5 +4,8 @@
 # All files and subdirectories in /docs
 /docs/user/ @kyma-project/technical-writers
 
+# Proposals directory (Phoenix team owns these docs)
+/docs/proposals/ @kyma-project/Phoenix
+
 # All .md files
 *.md @kyma-project/technical-writers


### PR DESCRIPTION
Adding @kyma-project/phoenix as codeowners for /dock/proposals

This folder will be used to add varous feature proposals and allow easier collaboration.
Alternative to that is to use github discussions.
If you have oder idea please propose.