### PR TITLE
chore: add env gate on pull-request-target

### DIFF
--- a/.github/workflows/build-image-pr.yaml
+++ b/.github/workflows/build-image-pr.yaml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   build-image:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'pr-build-image') }}
+    environment: e2e
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: cloud-manager


### PR DESCRIPTION
## What changed 

This PR adds an Environment gate to the privileged image build path in \.github/workflows/build-image-pr.yaml and keeps local builds unchanged.

Build-image now runs with environment: `e2e` and still triggers only when PR has label `pr-build-image`. 

>  [!NOTE]
Branch `local-build` remains the default path when the label is missing.

## Security/behavior impact
Environment approval now acts as a manual checkpoint before the privileged reusable workflow runs.

Related issues: https://github.tools.sap/kyma/security-backlog/issues/114