### PR TITLE
fix: replace deprecated scheme.Builder with GroupVersionSchemeBuilder

### DIFF
--- a/api/cloud-control/v1beta1/groupversion_info.go
+++ b/api/cloud-control/v1beta1/groupversion_info.go
@@ -21,7 +21,8 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
+
+	utilscheme "github.com/kyma-project/cloud-manager/pkg/util/scheme"
 )
 
 var (
@@ -29,7 +30,7 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "cloud-control.kyma-project.io", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = &utilscheme.GroupVersionSchemeBuilder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/api/cloud-resources/v1beta1/groupversion_info.go
+++ b/api/cloud-resources/v1beta1/groupversion_info.go
@@ -22,7 +22,7 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/kyma-project/cloud-manager/pkg/util"
+	utilscheme "github.com/kyma-project/cloud-manager/pkg/util/scheme"
 )
 
 var (
@@ -30,7 +30,7 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "cloud-resources.kyma-project.io", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &util.GroupVersionSchemeBuilder{GroupVersion: GroupVersion}
+	SchemeBuilder = &utilscheme.GroupVersionSchemeBuilder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/external/infrastructuremanagerv1/groupversion_info.go
+++ b/pkg/external/infrastructuremanagerv1/groupversion_info.go
@@ -3,7 +3,7 @@ package infrastructuremanagerv1
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/kyma-project/cloud-manager/pkg/util"
+	utilscheme "github.com/kyma-project/cloud-manager/pkg/util/scheme"
 )
 
 var (
@@ -11,7 +11,7 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "infrastructuremanager.kyma-project.io", Version: "v1"} //nolint:gochecknoglobals
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &util.GroupVersionSchemeBuilder{GroupVersion: GroupVersion} //nolint:gochecknoglobals
+	SchemeBuilder = &utilscheme.GroupVersionSchemeBuilder{GroupVersion: GroupVersion} //nolint:gochecknoglobals
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme //nolint:gochecknoglobals

--- a/pkg/external/operatorv1beta2/groupversion_info.go
+++ b/pkg/external/operatorv1beta2/groupversion_info.go
@@ -2,8 +2,8 @@ package operatorv1beta2
 
 import (
 	"github.com/kyma-project/cloud-manager/pkg/external/operatorshared"
+	utilscheme "github.com/kyma-project/cloud-manager/pkg/util/scheme"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -14,7 +14,7 @@ var (
 	}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = &utilscheme.GroupVersionSchemeBuilder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/external/registrycachev1beta1/groupversion_info.go
+++ b/pkg/external/registrycachev1beta1/groupversion_info.go
@@ -3,7 +3,7 @@ package registrycachev1beta1
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/kyma-project/cloud-manager/pkg/util"
+	utilscheme "github.com/kyma-project/cloud-manager/pkg/util/scheme"
 )
 
 var (
@@ -11,7 +11,7 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "core.kyma-project.io", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &util.GroupVersionSchemeBuilder{GroupVersion: GroupVersion}
+	SchemeBuilder = &utilscheme.GroupVersionSchemeBuilder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/util/scheme.go
+++ b/pkg/util/scheme.go
@@ -5,26 +5,9 @@ import (
 	"reflect"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
-
-// GroupVersionSchemeBuilder binds types to a GroupVersion using only apimachinery,
-// providing the same Register/AddToScheme API as controller-runtime's scheme.Builder
-// without the controller-runtime dependency.
-type GroupVersionSchemeBuilder struct {
-	GroupVersion schema.GroupVersion
-	runtime.SchemeBuilder
-}
-
-func (b *GroupVersionSchemeBuilder) Register(object ...runtime.Object) {
-	b.SchemeBuilder.Register(func(s *runtime.Scheme) error {
-		s.AddKnownTypes(b.GroupVersion, object...)
-		metav1.AddToGroupVersion(s, b.GroupVersion)
-		return nil
-	})
-}
 
 func GetObjGvk(scheme *runtime.Scheme, out runtime.Object) (gvk schema.GroupVersionKind, e error) {
 	gvkArr, _, err := scheme.ObjectKinds(out)

--- a/pkg/util/scheme/builder.go
+++ b/pkg/util/scheme/builder.go
@@ -1,0 +1,23 @@
+package scheme
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// GroupVersionSchemeBuilder binds types to a GroupVersion using only apimachinery,
+// providing the same Register/AddToScheme API as controller-runtime's scheme.Builder
+// without the controller-runtime dependency.
+type GroupVersionSchemeBuilder struct {
+	GroupVersion schema.GroupVersion
+	runtime.SchemeBuilder
+}
+
+func (b *GroupVersionSchemeBuilder) Register(object ...runtime.Object) {
+	b.SchemeBuilder.Register(func(s *runtime.Scheme) error {
+		s.AddKnownTypes(b.GroupVersion, object...)
+		metav1.AddToGroupVersion(s, b.GroupVersion)
+		return nil
+	})
+}


### PR DESCRIPTION
## Summary

- controller-runtime v0.24 deprecated `scheme.Builder` (SA1019), which caused golangci-lint to fail on this dependabot bump
- Introduces `GroupVersionSchemeBuilder` in `pkg/util/scheme/builder.go` using only `k8s.io/apimachinery`, replicating the same `Register`/`AddToScheme` behaviour
- Updates all five `groupversion_info.go` files to use it — no changes to any `_types.go` call sites

