### PR TITLE
docs(user): add AzureManagedRedis user reference (beta) 

### DIFF
--- a/docs/user/resources/04-40-32-azure-managed-redis.md
+++ b/docs/user/resources/04-40-32-azure-managed-redis.md
@@ -16,46 +16,42 @@ A single SKR kind covers three workload classes — single-node dev, HA producti
 > [!TIP]
 > Only for advanced cases of network topology: IP addresses are allocated from the [IpRange CR](./04-10-iprange.md). If an IpRange CR is not specified in the AzureManagedRedis, then the default IpRange is used. If the default IpRange does not exist, it is automatically created. Manually create a non-default IpRange with specified Classless Inter-Domain Routing (CIDR) and use it only in advanced cases of network topology when you want to control the network segments to avoid range conflicts with other networks.
 
-When creating AzureManagedRedis, one field is mandatory: **redisTier**.
-
-Optionally, you can specify the **authSecret** and **ipRange** fields.
-
 ## Specification
 
-This table lists the parameters of **AzureManagedRedis.spec**.
+This table lists the parameters of **AzureManagedRedis.spec**:
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| **redisTier** (required) | string | Kyma service tier. Encodes the underlying SKU, high-availability, and clustering policy. See the [Tier Reference](#tier-reference) below. Allowed values: `S1`, `S2`, `S3`, `S4`, `S5`, `P1`, `P2`, `P3`, `P4`, `P5`, `C3`, `C4`, `C5`, `C6`, `C7`. **Immutable.** |
-| **authSecret** | object | Optional. Customizes the generated connection secret. |
-| **authSecret.name** | string | Optional. Name of the Secret. Defaults to the `AzureManagedRedis` resource name. **Immutable once set.** |
-| **authSecret.labels** | map[string]string | Optional. Labels applied to the Secret. |
-| **authSecret.annotations** | map[string]string | Optional. Annotations applied to the Secret. |
-| **authSecret.extraData** | map[string]string | Optional. Additional Secret keys, supporting Go templates that reference `host`, `port`, `primaryEndpoint`, `authString`. The templating follows the [Golang templating syntax](https://pkg.go.dev/text/template). |
-| **ipRange** | object | Optional. IpRange reference. If omitted, the default IpRange is used. If the default IpRange does not exist, it will be created. |
-| **ipRange.name** | string | Required when **ipRange** is specified. Name of the existing IpRange to use. |
+| Parameter | Type | Required | Immutable | Description |
+|-----------|------|----------|-----------|-------------|
+| **redisTier** | string | Yes | Yes | Kyma service tier. Encodes the underlying SKU, high-availability, and clustering policy. See the [Tier Reference](#tier-reference) below. Allowed values: `S1`, `S2`, `S3`, `S4`, `S5`, `P1`, `P2`, `P3`, `P4`, `P5`, `C3`, `C4`, `C5`, `C6`, `C7`. |
+| **authSecret** | object | No | No | Customizes the generated connection Secret. |
+| **authSecret.name** | string | No | Yes | Name of the Secret. Defaults to the `AzureManagedRedis` resource name. |
+| **authSecret.labels** | map[string]string | No | No | Labels applied to the Secret. |
+| **authSecret.annotations** | map[string]string | No | No | Annotations applied to the Secret. |
+| **authSecret.extraData** | map[string]string | No | No | Additional Secret keys, supporting Go templates that reference `host`, `port`, `primaryEndpoint`, `authString`. The templating follows the [Golang templating syntax](https://pkg.go.dev/text/template). |
+| **ipRange** | object | No | No | IpRange reference. If omitted, the default IpRange is used. If the default IpRange does not exist, it will be created. |
+| **ipRange.name** | string | Yes* | No | Name of the existing IpRange to use. *Required when **ipRange** is specified. |
 
 ### Tier Reference
 
 The `redisTier` letter encodes three things in one field. Choose by workload class first, then by size.
 
-| Tier | Underlying Azure SKU | Memory (GB) | High-Availability | Clustering Policy | Use case |
-|------|----------------------|-------------|-------------------|-------------------|----------|
-| `S1` | `Balanced_B0`        | 1   | No  | EnterpriseCluster | Dev / test (no replica, no HA)      |
-| `S2` | `Balanced_B3`        | 3   | No  | EnterpriseCluster | Dev / test (no replica, no HA)      |
-| `S3` | `Balanced_B5`        | 6   | No  | EnterpriseCluster | Dev / test (no replica, no HA)      |
-| `S4` | `Balanced_B10`       | 12  | No  | EnterpriseCluster | Dev / test (no replica, no HA)      |
-| `S5` | `Balanced_B20`       | 24  | No  | EnterpriseCluster | Dev / test (no replica, no HA)      |
-| `P1` | `ComputeOptimized_X5`   | 6   | Yes | EnterpriseCluster | Production single-shard HA       |
-| `P2` | `ComputeOptimized_X10`  | 12  | Yes | EnterpriseCluster | Production single-shard HA       |
-| `P3` | `ComputeOptimized_X20`  | 24  | Yes | EnterpriseCluster | Production single-shard HA       |
-| `P4` | `ComputeOptimized_X50`  | 60  | Yes | EnterpriseCluster | Production single-shard HA       |
-| `P5` | `ComputeOptimized_X100` | 120 | Yes | EnterpriseCluster | Production single-shard HA       |
-| `C3` | `ComputeOptimized_X5`   | 6   | Yes | OSSCluster        | Production sharded (Redis Cluster) |
-| `C4` | `ComputeOptimized_X10`  | 12  | Yes | OSSCluster        | Production sharded (Redis Cluster) |
-| `C5` | `ComputeOptimized_X20`  | 24  | Yes | OSSCluster        | Production sharded (Redis Cluster) |
-| `C6` | `ComputeOptimized_X50`  | 60  | Yes | OSSCluster        | Production sharded (Redis Cluster) |
-| `C7` | `ComputeOptimized_X100` | 120 | Yes | OSSCluster        | Production sharded (Redis Cluster) |
+| Tier | Underlying Azure SKU | Memory (GB) | High-Availability | Clustering Policy |
+|------|----------------------|-------------|-------------------|-------------------|
+| `S1` | `Balanced_B0`        | 1   | No  | EnterpriseCluster |
+| `S2` | `Balanced_B3`        | 3   | No  | EnterpriseCluster |
+| `S3` | `Balanced_B5`        | 6   | No  | EnterpriseCluster |
+| `S4` | `Balanced_B10`       | 12  | No  | EnterpriseCluster |
+| `S5` | `Balanced_B20`       | 24  | No  | EnterpriseCluster |
+| `P1` | `ComputeOptimized_X5`   | 6   | Yes | EnterpriseCluster |
+| `P2` | `ComputeOptimized_X10`  | 12  | Yes | EnterpriseCluster |
+| `P3` | `ComputeOptimized_X20`  | 24  | Yes | EnterpriseCluster |
+| `P4` | `ComputeOptimized_X50`  | 60  | Yes | EnterpriseCluster |
+| `P5` | `ComputeOptimized_X100` | 120 | Yes | EnterpriseCluster |
+| `C3` | `ComputeOptimized_X5`   | 6   | Yes | OSSCluster        |
+| `C4` | `ComputeOptimized_X10`  | 12  | Yes | OSSCluster        |
+| `C5` | `ComputeOptimized_X20`  | 24  | Yes | OSSCluster        |
+| `C6` | `ComputeOptimized_X50`  | 60  | Yes | OSSCluster        |
+| `C7` | `ComputeOptimized_X100` | 120 | Yes | OSSCluster        |
 
 P-tiers and C-tiers map to the **same Azure SKU at the same price** when their underlying SKU matches (P1↔C3, P2↔C4, P3↔C5, P4↔C6, P5↔C7); they differ only in the database-level `ClusteringPolicy`. Choose `C*` if your client uses Redis Cluster commands and key hash-slot routing. Choose `P*` for a single primary endpoint.
 
@@ -118,12 +114,12 @@ spec:
       url: "redis://:{{.authString}}@{{.host}}:{{.port}}"
 ```
 
-## Notes and Limitations
+## Limitations
 
-- **Immutable fields.** You can't change **spec.redisTier** and **spec.authSecret.name** after creation. To resize or change the tier, delete and recreate the resource (data will be lost). All other fields (**authSecret.labels**, **authSecret.annotations**, **authSecret.extraData**, **ipRange**) are mutable and take effect on the next reconciliation.
-- **Public network access is disabled.** Connections are only possible from within the Kyma SKR network through the auto-provisioned Private Endpoint.
 - **TLS only.** AMR enforces TLS 1.2 client connections. Plaintext is not supported.
-- **Redis version.** Azure Managed Redis runs Redis 7.4. There is no **redisVersion** field. The version is managed by Azure.
+- **Redis version.** Azure Managed Redis runs Redis 7.4. The version is managed by Azure; there is no **redisVersion** field.
 - **Single database per instance.** Cloud Manager provisions exactly one database (`default`) per `AzureManagedRedis` resource.
+- **Public network access is disabled.** Connections are only possible from within the Kyma SKR network through the auto-provisioned Private Endpoint.
 - **No sovereign cloud support.** AMR is not yet available in Azure China or US Government clouds. Use `AzureRedisInstance` / `AzureRedisCluster` (legacy `armredis` SKUs) on those landscapes.
-- **Auth secret name conflict.** If a Kubernetes Secret with the same name already exists in the namespace and belongs to a different `AzureManagedRedis` resource, the instance enters the `Error` state. Use a unique **spec.authSecret.name** to avoid conflicts.
+- **Auth Secret name conflict.** If a Kubernetes Secret with the same name already exists in the namespace and belongs to a different `AzureManagedRedis` resource, the instance enters the `Error` state. Use a unique **spec.authSecret.name** to avoid conflicts.
+- **Resize requires recreation.** You can't change **spec.redisTier** after creation. To resize or change the tier, delete and recreate the resource (data will be lost).

--- a/docs/user/resources/04-40-32-azure-managed-redis.md
+++ b/docs/user/resources/04-40-32-azure-managed-redis.md
@@ -15,7 +15,7 @@ This table lists the parameters of `AzureManagedRedis.spec`.
 |-----------|------|-------------|
 | **redisTier** (required) | string | Kyma service tier. Encodes the underlying SKU + high-availability + clustering policy. See the [Tier Reference](#tier-reference) below. Allowed values: `S1`, `S2`, `S3`, `S4`, `S5`, `P1`, `P2`, `P3`, `P4`, `P5`, `C3`, `C4`, `C5`, `C6`, `C7`. **Immutable.** |
 | **authSecret** | object | Customises the generated connection secret. |
-| **authSecret.name** | string | Name of the secret. Defaults to the `AzureManagedRedis` resource name. |
+| **authSecret.name** | string | Name of the secret. Defaults to the `AzureManagedRedis` resource name. **Immutable once set.** |
 | **authSecret.labels** | map[string]string | Labels applied to the secret. |
 | **authSecret.annotations** | map[string]string | Annotations applied to the secret. |
 | **authSecret.extraData** | map[string]string | Additional secret keys, supporting Go templates that reference `host`, `port`, `primaryEndpoint`, `authString`. |
@@ -44,7 +44,7 @@ The `redisTier` letter encodes three things in one field. Choose by workload cla
 | `C6` | `ComputeOptimized_X50`  | 60  | Yes | OSSCluster        | Production sharded (Redis Cluster) |
 | `C7` | `ComputeOptimized_X100` | 120 | Yes | OSSCluster        | Production sharded (Redis Cluster) |
 
-P-tiers and C-tiers of equal numeric rank (e.g. `P3` and `C5`) provision the **same Azure SKU at the same price**; they differ only in the database-level `ClusteringPolicy`. Choose `C*` if your client uses Redis Cluster commands and key hash-slot routing; choose `P*` for a single primary endpoint.
+P-tiers and C-tiers map to the **same Azure SKU at the same price** when their underlying SKU matches (P1↔C3, P2↔C4, P3↔C5, P4↔C6, P5↔C7); they differ only in the database-level `ClusteringPolicy`. Choose `C*` if your client uses Redis Cluster commands and key hash-slot routing; choose `P*` for a single primary endpoint.
 
 ## Status Fields
 
@@ -61,9 +61,9 @@ Once `state` is `Ready`, Cloud Manager creates (or updates) a Kubernetes `Secret
 
 | Key | Description |
 |-----|-------------|
-| `primaryEndpoint` | Hostname of the AMR cluster. |
-| `host` | Same as `primaryEndpoint` (kept for compatibility with other Redis SKR kinds). |
-| `port` | Redis client port (typically `10000` for AMR). |
+| `primaryEndpoint` | Hostname of the AMR cluster (hostname only, not `host:port`). |
+| `host` | Same as `primaryEndpoint`. |
+| `port` | Redis client port. Always `10000` for Azure Managed Redis. |
 | `authString` | Access key for client authentication. |
 
 Any keys you list under `spec.authSecret.extraData` are added on top, with Go template expansion against the four base keys above.

--- a/docs/user/resources/04-40-32-azure-managed-redis.md
+++ b/docs/user/resources/04-40-32-azure-managed-redis.md
@@ -1,0 +1,106 @@
+# AzureManagedRedis Custom Resource
+
+The `azuremanagedredis.cloud-resources.kyma-project.io` Custom Resource Definition (CRD) describes a single Azure Managed Redis (Microsoft.Cache/redisEnterprise) cluster provisioned in your Kyma runtime through Cloud Manager. A single SKR kind covers three workload classes — single-node dev, HA production, and HA + sharded clustered Redis — through the `redisTier` field.
+
+> Azure Managed Redis is a separate product from Azure Cache for Redis. It is **not yet available** in Azure China or Azure US Government regions; only commercial Azure regions are supported.
+
+## Specification
+
+This table lists the parameters of `AzureManagedRedis.spec`.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **redisTier** (required) | string | Kyma service tier. Encodes the underlying SKU + high-availability + clustering policy. See the [Tier Reference](#tier-reference) below. Allowed values: `S1`, `S2`, `S3`, `S4`, `S5`, `P1`, `P2`, `P3`, `P4`, `P5`, `C3`, `C4`, `C5`, `C6`, `C7`. **Immutable.** |
+| **authSecret** | object | Customises the generated connection secret. |
+| **authSecret.name** | string | Name of the secret. Defaults to the `AzureManagedRedis` resource name. |
+| **authSecret.labels** | map[string]string | Labels applied to the secret. |
+| **authSecret.annotations** | map[string]string | Annotations applied to the secret. |
+| **authSecret.extraData** | map[string]string | Additional secret keys, supporting Go templates that reference `host`, `port`, `primaryEndpoint`, `authString`. |
+| **ipRange** | object | Reference to an `IpRange` for private connectivity. If omitted, the default `IpRange` is used. |
+| **ipRange.name** | string | Name of the referenced `IpRange`. |
+
+### Tier Reference
+
+The `redisTier` letter encodes three things in one field. Choose by workload class first, then by size.
+
+| Tier | Underlying Azure SKU | Memory (GB) | High-Availability | Clustering Policy | Use case |
+|------|----------------------|-------------|-------------------|-------------------|----------|
+| `S1` | `Balanced_B0`        | 1   | No  | EnterpriseCluster | Dev / test                          |
+| `S2` | `Balanced_B3`        | 3   | No  | EnterpriseCluster | Dev / test                          |
+| `S3` | `Balanced_B5`        | 6   | No  | EnterpriseCluster | Dev / test                          |
+| `S4` | `Balanced_B10`       | 12  | No  | EnterpriseCluster | Dev / test                          |
+| `S5` | `Balanced_B20`       | 24  | No  | EnterpriseCluster | Dev / test                          |
+| `P1` | `ComputeOptimized_X5`   | 6   | Yes | EnterpriseCluster | Production single-shard HA       |
+| `P2` | `ComputeOptimized_X10`  | 12  | Yes | EnterpriseCluster | Production single-shard HA       |
+| `P3` | `ComputeOptimized_X20`  | 24  | Yes | EnterpriseCluster | Production single-shard HA       |
+| `P4` | `ComputeOptimized_X50`  | 60  | Yes | EnterpriseCluster | Production single-shard HA       |
+| `P5` | `ComputeOptimized_X100` | 120 | Yes | EnterpriseCluster | Production single-shard HA       |
+| `C3` | `ComputeOptimized_X5`   | 6   | Yes | OSSCluster        | Production sharded (Redis Cluster) |
+| `C4` | `ComputeOptimized_X10`  | 12  | Yes | OSSCluster        | Production sharded (Redis Cluster) |
+| `C5` | `ComputeOptimized_X20`  | 24  | Yes | OSSCluster        | Production sharded (Redis Cluster) |
+| `C6` | `ComputeOptimized_X50`  | 60  | Yes | OSSCluster        | Production sharded (Redis Cluster) |
+| `C7` | `ComputeOptimized_X100` | 120 | Yes | OSSCluster        | Production sharded (Redis Cluster) |
+
+P-tiers and C-tiers of equal numeric rank (e.g. `P3` and `C5`) provision the **same Azure SKU at the same price**; they differ only in the database-level `ClusteringPolicy`. Choose `C*` if your client uses Redis Cluster commands and key hash-slot routing; choose `P*` for a single primary endpoint.
+
+## Status Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| **id** | string | Internal Cloud Manager identifier. |
+| **state** | string | Lifecycle state: `Processing`, `Creating`, `Ready`, `Deleting`, `Error`. |
+| **primaryEndpoint** | string | Hostname for client connections. |
+| **port** | int32 | Redis client port (always `10000` for AMR). |
+| **observedGeneration** | int64 | Most recent reconciled `metadata.generation`. |
+| **conditions** | list | Standard Kubernetes conditions, including `Ready` and `Error`. |
+
+## Connection Secret
+
+Once `state` is `Ready`, Cloud Manager creates (or updates) a Kubernetes `Secret` in the same namespace with the following keys:
+
+| Key | Description |
+|-----|-------------|
+| `primaryEndpoint` | Hostname of the AMR cluster. |
+| `host` | Same as `primaryEndpoint` (kept for compatibility with other Redis SKR kinds). |
+| `port` | Always `10000`. |
+| `authString` | Access key for client authentication. |
+
+Any keys you list under `spec.authSecret.extraData` are added on top, with Go template expansion against the four base keys above.
+
+## Example
+
+```yaml
+apiVersion: cloud-resources.kyma-project.io/v1beta1
+kind: AzureManagedRedis
+metadata:
+  name: my-managed-redis
+  namespace: default
+spec:
+  redisTier: P2
+```
+
+A clustered example:
+
+```yaml
+apiVersion: cloud-resources.kyma-project.io/v1beta1
+kind: AzureManagedRedis
+metadata:
+  name: my-redis-cluster
+  namespace: default
+spec:
+  redisTier: C5
+  authSecret:
+    name: redis-cluster-conn
+    labels:
+      app: my-app
+    extraData:
+      url: "redis://:{{.authString}}@{{.host}}:{{.port}}"
+```
+
+## Notes and Limitations
+
+- **Immutable fields.** `spec.redisTier`, `spec.ipRange`, and `spec.authSecret.name` cannot be changed after creation. To resize, delete and recreate the resource (data will be lost).
+- **Public network access is disabled.** Connections are only possible from within the Kyma SKR network through the auto-provisioned Private Endpoint.
+- **TLS only.** AMR enforces TLS 1.2 client connections; plaintext is not supported.
+- **Single database per cluster.** Cloud Manager provisions exactly one database (`default`) per `AzureManagedRedis` resource.
+- **No sovereign cloud support.** AMR is not yet available in Azure China or US Government clouds. Use `AzureRedisInstance` / `AzureRedisCluster` (legacy `armredis` SKUs) on those landscapes.

--- a/docs/user/resources/04-40-32-azure-managed-redis.md
+++ b/docs/user/resources/04-40-32-azure-managed-redis.md
@@ -8,31 +8,32 @@ It describes an Azure Managed Redis (Microsoft.Cache/redisEnterprise) instance p
 Once the instance is provisioned, a Kubernetes Secret with endpoint and credential details is provided in the same namespace.
 By default, the created auth Secret has the same name as the AzureManagedRedis, unless specified otherwise.
 
-A single SKR kind covers three workload classes — single-node dev, HA production, and HA + sharded clustered Redis — through the `redisTier` field.
+A single SKR kind covers three workload classes — single-node dev, HA production, and HA + sharded clustered Redis — through the **redisTier** field.
 
+> [!NOTE]
 > Azure Managed Redis is a separate product from Azure Cache for Redis. It is **not yet available** in Azure China or Azure US Government regions; only commercial Azure regions are supported.
 
-> [!TIP] _Only for advanced cases of network topology_
-> IP addresses are allocated from the [IpRange CR](./04-10-iprange.md). If an IpRange CR is not specified in the AzureManagedRedis, then the default IpRange is used. If the default IpRange does not exist, it is automatically created. Manually create a non-default IpRange with specified Classless Inter-Domain Routing (CIDR) and use it only in advanced cases of network topology when you want to control the network segments to avoid range conflicts with other networks.
+> [!TIP]
+> Only for advanced cases of network topology: IP addresses are allocated from the [IpRange CR](./04-10-iprange.md). If an IpRange CR is not specified in the AzureManagedRedis, then the default IpRange is used. If the default IpRange does not exist, it is automatically created. Manually create a non-default IpRange with specified Classless Inter-Domain Routing (CIDR) and use it only in advanced cases of network topology when you want to control the network segments to avoid range conflicts with other networks.
 
-When creating AzureManagedRedis, one field is mandatory: `redisTier`.
+When creating AzureManagedRedis, one field is mandatory: **redisTier**.
 
-Optionally, you can specify the `authSecret` and `ipRange` fields.
+Optionally, you can specify the **authSecret** and **ipRange** fields.
 
 ## Specification
 
-This table lists the parameters of `AzureManagedRedis.spec`.
+This table lists the parameters of **AzureManagedRedis.spec**.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| **redisTier** (required) | string | Kyma service tier. Encodes the underlying SKU + high-availability + clustering policy. See the [Tier Reference](#tier-reference) below. Allowed values: `S1`, `S2`, `S3`, `S4`, `S5`, `P1`, `P2`, `P3`, `P4`, `P5`, `C3`, `C4`, `C5`, `C6`, `C7`. **Immutable.** |
-| **authSecret** | object | Optional. Customises the generated connection secret. |
-| **authSecret.name** | string | Optional. Name of the secret. Defaults to the `AzureManagedRedis` resource name. **Immutable once set.** |
-| **authSecret.labels** | map[string]string | Optional. Labels applied to the secret. |
-| **authSecret.annotations** | map[string]string | Optional. Annotations applied to the secret. |
-| **authSecret.extraData** | map[string]string | Optional. Additional secret keys, supporting Go templates that reference `host`, `port`, `primaryEndpoint`, `authString`. The templating follows the [Golang templating syntax](https://pkg.go.dev/text/template). |
+| **redisTier** (required) | string | Kyma service tier. Encodes the underlying SKU, high-availability, and clustering policy. See the [Tier Reference](#tier-reference) below. Allowed values: `S1`, `S2`, `S3`, `S4`, `S5`, `P1`, `P2`, `P3`, `P4`, `P5`, `C3`, `C4`, `C5`, `C6`, `C7`. **Immutable.** |
+| **authSecret** | object | Optional. Customizes the generated connection secret. |
+| **authSecret.name** | string | Optional. Name of the Secret. Defaults to the `AzureManagedRedis` resource name. **Immutable once set.** |
+| **authSecret.labels** | map[string]string | Optional. Labels applied to the Secret. |
+| **authSecret.annotations** | map[string]string | Optional. Annotations applied to the Secret. |
+| **authSecret.extraData** | map[string]string | Optional. Additional Secret keys, supporting Go templates that reference `host`, `port`, `primaryEndpoint`, `authString`. The templating follows the [Golang templating syntax](https://pkg.go.dev/text/template). |
 | **ipRange** | object | Optional. IpRange reference. If omitted, the default IpRange is used. If the default IpRange does not exist, it will be created. |
-| **ipRange.name** | string | Required when `ipRange` is specified. Name of the existing IpRange to use. |
+| **ipRange.name** | string | Required when **ipRange** is specified. Name of the existing IpRange to use. |
 
 ### Tier Reference
 
@@ -56,7 +57,7 @@ The `redisTier` letter encodes three things in one field. Choose by workload cla
 | `C6` | `ComputeOptimized_X50`  | 60  | Yes | OSSCluster        | Production sharded (Redis Cluster) |
 | `C7` | `ComputeOptimized_X100` | 120 | Yes | OSSCluster        | Production sharded (Redis Cluster) |
 
-P-tiers and C-tiers map to the **same Azure SKU at the same price** when their underlying SKU matches (P1↔C3, P2↔C4, P3↔C5, P4↔C6, P5↔C7); they differ only in the database-level `ClusteringPolicy`. Choose `C*` if your client uses Redis Cluster commands and key hash-slot routing; choose `P*` for a single primary endpoint.
+P-tiers and C-tiers map to the **same Azure SKU at the same price** when their underlying SKU matches (P1↔C3, P2↔C4, P3↔C5, P4↔C6, P5↔C7); they differ only in the database-level `ClusteringPolicy`. Choose `C*` if your client uses Redis Cluster commands and key hash-slot routing. Choose `P*` for a single primary endpoint.
 
 > [!NOTE]
 > S-tiers have no replica and no automatic failover. A node failure results in downtime and potential data loss. Use S-tiers for development and testing only.
@@ -72,20 +73,20 @@ P-tiers and C-tiers map to the **same Azure SKU at the same price** when their u
 
 ## Auth Secret Details
 
-Once `state` is `Ready`, Cloud Manager creates (or updates) a Kubernetes `Secret` in the same namespace.
+Once **state** is `Ready`, Cloud Manager creates (or updates) a Kubernetes Secret in the same namespace.
 The following table lists the meaningful parameters of the auth Secret:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | **.metadata.name** | string | Name of the auth Secret. It shares the name with AzureManagedRedis unless specified otherwise. |
-| **.metadata.labels** | object | Specified custom labels (if any). |
-| **.metadata.annotations** | object | Specified custom annotations (if any). |
+| **.metadata.labels** | object | Specifies custom labels (if any). |
+| **.metadata.annotations** | object | Specifies custom annotations (if any). |
 | **.data.primaryEndpoint** | string | Hostname of the AMR instance (hostname only, not `host:port`). Base64 encoded. |
-| **.data.host** | string | Same as `primaryEndpoint`. Base64 encoded. |
+| **.data.host** | string | Hostname of the AMR instance (hostname only, not `host:port`). The value is the same as **primaryEndpoint**. Base64 encoded. |
 | **.data.port** | string | Redis client port. Always `10000` for Azure Managed Redis. Base64 encoded. |
 | **.data.authString** | string | Access key for client authentication. Base64 encoded. |
 
-Any keys you list under `spec.authSecret.extraData` are added on top, with Go template expansion against the four base keys above.
+Any keys you list under **spec.authSecret.extraData** are added on top, with Go template expansion against the four base keys above.
 
 ## Sample Custom Resource
 
@@ -119,10 +120,10 @@ spec:
 
 ## Notes and Limitations
 
-- **Immutable fields.** `spec.redisTier` and `spec.authSecret.name` cannot be changed after creation. To resize or change the tier, delete and recreate the resource (data will be lost). All other fields (`authSecret.labels`, `authSecret.annotations`, `authSecret.extraData`, `ipRange`) are mutable and take effect on the next reconciliation.
+- **Immutable fields.** You can't change **spec.redisTier** and **spec.authSecret.name** after creation. To resize or change the tier, delete and recreate the resource (data will be lost). All other fields (**authSecret.labels**, **authSecret.annotations**, **authSecret.extraData**, **ipRange**) are mutable and take effect on the next reconciliation.
 - **Public network access is disabled.** Connections are only possible from within the Kyma SKR network through the auto-provisioned Private Endpoint.
-- **TLS only.** AMR enforces TLS 1.2 client connections; plaintext is not supported.
-- **Redis version.** Azure Managed Redis runs Redis 7.4. There is no `redisVersion` field; the version is managed by Azure.
+- **TLS only.** AMR enforces TLS 1.2 client connections. Plaintext is not supported.
+- **Redis version.** Azure Managed Redis runs Redis 7.4. There is no **redisVersion** field. The version is managed by Azure.
 - **Single database per instance.** Cloud Manager provisions exactly one database (`default`) per `AzureManagedRedis` resource.
 - **No sovereign cloud support.** AMR is not yet available in Azure China or US Government clouds. Use `AzureRedisInstance` / `AzureRedisCluster` (legacy `armredis` SKUs) on those landscapes.
-- **Auth secret name conflict.** If a Kubernetes Secret with the same name already exists in the namespace and belongs to a different `AzureManagedRedis` resource, the instance will enter `Error` state. Use a unique `spec.authSecret.name` to avoid conflicts.
+- **Auth secret name conflict.** If a Kubernetes Secret with the same name already exists in the namespace and belongs to a different `AzureManagedRedis` resource, the instance enters the `Error` state. Use a unique **spec.authSecret.name** to avoid conflicts.

--- a/docs/user/resources/04-40-32-azure-managed-redis.md
+++ b/docs/user/resources/04-40-32-azure-managed-redis.md
@@ -1,5 +1,8 @@
 # AzureManagedRedis Custom Resource
 
+> [!WARNING]
+> This is a beta feature available only per request for SAP-internal teams.
+
 The `azuremanagedredis.cloud-resources.kyma-project.io` Custom Resource Definition (CRD) describes a single Azure Managed Redis (Microsoft.Cache/redisEnterprise) cluster provisioned in your Kyma runtime through Cloud Manager. A single SKR kind covers three workload classes — single-node dev, HA production, and HA + sharded clustered Redis — through the `redisTier` field.
 
 > Azure Managed Redis is a separate product from Azure Cache for Redis. It is **not yet available** in Azure China or Azure US Government regions; only commercial Azure regions are supported.

--- a/docs/user/resources/04-40-32-azure-managed-redis.md
+++ b/docs/user/resources/04-40-32-azure-managed-redis.md
@@ -4,8 +4,8 @@
 > This is a beta feature available only per request for SAP-internal teams.
 
 The `azuremanagedredis.cloud-resources.kyma-project.io` is a namespace-scoped custom resource (CR).
-It describes a single Azure Managed Redis (Microsoft.Cache/redisEnterprise) cluster provisioned in your Kyma runtime through Cloud Manager.
-Once the cluster is provisioned, a Kubernetes Secret with endpoint and credential details is provided in the same namespace.
+It describes an Azure Managed Redis (Microsoft.Cache/redisEnterprise) instance provisioned in your Kyma runtime through Cloud Manager.
+Once the instance is provisioned, a Kubernetes Secret with endpoint and credential details is provided in the same namespace.
 By default, the created auth Secret has the same name as the AzureManagedRedis, unless specified otherwise.
 
 A single SKR kind covers three workload classes — single-node dev, HA production, and HA + sharded clustered Redis — through the `redisTier` field.
@@ -32,7 +32,7 @@ This table lists the parameters of `AzureManagedRedis.spec`.
 | **authSecret.annotations** | map[string]string | Optional. Annotations applied to the secret. |
 | **authSecret.extraData** | map[string]string | Optional. Additional secret keys, supporting Go templates that reference `host`, `port`, `primaryEndpoint`, `authString`. The templating follows the [Golang templating syntax](https://pkg.go.dev/text/template). |
 | **ipRange** | object | Optional. IpRange reference. If omitted, the default IpRange is used. If the default IpRange does not exist, it will be created. |
-| **ipRange.name** | string | Required. Name of the existing IpRange to use. |
+| **ipRange.name** | string | Required when `ipRange` is specified. Name of the existing IpRange to use. |
 
 ### Tier Reference
 
@@ -40,11 +40,11 @@ The `redisTier` letter encodes three things in one field. Choose by workload cla
 
 | Tier | Underlying Azure SKU | Memory (GB) | High-Availability | Clustering Policy | Use case |
 |------|----------------------|-------------|-------------------|-------------------|----------|
-| `S1` | `Balanced_B0`        | 1   | No  | EnterpriseCluster | Dev / test                          |
-| `S2` | `Balanced_B3`        | 3   | No  | EnterpriseCluster | Dev / test                          |
-| `S3` | `Balanced_B5`        | 6   | No  | EnterpriseCluster | Dev / test                          |
-| `S4` | `Balanced_B10`       | 12  | No  | EnterpriseCluster | Dev / test                          |
-| `S5` | `Balanced_B20`       | 24  | No  | EnterpriseCluster | Dev / test                          |
+| `S1` | `Balanced_B0`        | 1   | No  | EnterpriseCluster | Dev / test (no replica, no HA)      |
+| `S2` | `Balanced_B3`        | 3   | No  | EnterpriseCluster | Dev / test (no replica, no HA)      |
+| `S3` | `Balanced_B5`        | 6   | No  | EnterpriseCluster | Dev / test (no replica, no HA)      |
+| `S4` | `Balanced_B10`       | 12  | No  | EnterpriseCluster | Dev / test (no replica, no HA)      |
+| `S5` | `Balanced_B20`       | 24  | No  | EnterpriseCluster | Dev / test (no replica, no HA)      |
 | `P1` | `ComputeOptimized_X5`   | 6   | Yes | EnterpriseCluster | Production single-shard HA       |
 | `P2` | `ComputeOptimized_X10`  | 12  | Yes | EnterpriseCluster | Production single-shard HA       |
 | `P3` | `ComputeOptimized_X20`  | 24  | Yes | EnterpriseCluster | Production single-shard HA       |
@@ -58,6 +58,9 @@ The `redisTier` letter encodes three things in one field. Choose by workload cla
 
 P-tiers and C-tiers map to the **same Azure SKU at the same price** when their underlying SKU matches (P1↔C3, P2↔C4, P3↔C5, P4↔C6, P5↔C7); they differ only in the database-level `ClusteringPolicy`. Choose `C*` if your client uses Redis Cluster commands and key hash-slot routing; choose `P*` for a single primary endpoint.
 
+> [!NOTE]
+> S-tiers have no replica and no automatic failover. A node failure results in downtime and potential data loss. Use S-tiers for development and testing only.
+
 ## Status Fields
 
 | Field | Type | Description |
@@ -65,10 +68,11 @@ P-tiers and C-tiers map to the **same Azure SKU at the same price** when their u
 | **id** | string | Internal Cloud Manager identifier. |
 | **state** | string | Lifecycle state: `Processing`, `Creating`, `Ready`, `Deleting`, `Error`. |
 | **observedGeneration** | int64 | Most recent reconciled `metadata.generation`. |
-| **conditions** | list | Standard Kubernetes conditions, including `Ready` and `Error`. |
+| **conditions** | list | Standard Kubernetes conditions, including `Ready`, `Error`, and `Deleting`. |
 
 ## Auth Secret Details
 
+Once `state` is `Ready`, Cloud Manager creates (or updates) a Kubernetes `Secret` in the same namespace.
 The following table lists the meaningful parameters of the auth Secret:
 
 | Parameter | Type | Description |
@@ -76,7 +80,7 @@ The following table lists the meaningful parameters of the auth Secret:
 | **.metadata.name** | string | Name of the auth Secret. It shares the name with AzureManagedRedis unless specified otherwise. |
 | **.metadata.labels** | object | Specified custom labels (if any). |
 | **.metadata.annotations** | object | Specified custom annotations (if any). |
-| **.data.primaryEndpoint** | string | Hostname of the AMR cluster (hostname only, not `host:port`). Base64 encoded. |
+| **.data.primaryEndpoint** | string | Hostname of the AMR instance (hostname only, not `host:port`). Base64 encoded. |
 | **.data.host** | string | Same as `primaryEndpoint`. Base64 encoded. |
 | **.data.port** | string | Redis client port. Always `10000` for Azure Managed Redis. Base64 encoded. |
 | **.data.authString** | string | Access key for client authentication. Base64 encoded. |
@@ -115,8 +119,9 @@ spec:
 
 ## Notes and Limitations
 
-- **Immutable fields.** `spec.redisTier` and `spec.authSecret.name` cannot be changed after creation. To resize, delete and recreate the resource (data will be lost).
+- **All spec fields are immutable.** `spec.redisTier` and `spec.authSecret.name` cannot be changed after creation. To resize or change the tier, delete and recreate the resource (data will be lost).
 - **Public network access is disabled.** Connections are only possible from within the Kyma SKR network through the auto-provisioned Private Endpoint.
 - **TLS only.** AMR enforces TLS 1.2 client connections; plaintext is not supported.
-- **Single database per cluster.** Cloud Manager provisions exactly one database (`default`) per `AzureManagedRedis` resource.
+- **Redis version.** Azure Managed Redis runs Redis 7.4. There is no `redisVersion` field; the version is managed by Azure.
+- **Single database per instance.** Cloud Manager provisions exactly one database (`default`) per `AzureManagedRedis` resource.
 - **No sovereign cloud support.** AMR is not yet available in Azure China or US Government clouds. Use `AzureRedisInstance` / `AzureRedisCluster` (legacy `armredis` SKUs) on those landscapes.

--- a/docs/user/resources/04-40-32-azure-managed-redis.md
+++ b/docs/user/resources/04-40-32-azure-managed-redis.md
@@ -119,9 +119,10 @@ spec:
 
 ## Notes and Limitations
 
-- **All spec fields are immutable.** `spec.redisTier` and `spec.authSecret.name` cannot be changed after creation. To resize or change the tier, delete and recreate the resource (data will be lost).
+- **Immutable fields.** `spec.redisTier` and `spec.authSecret.name` cannot be changed after creation. To resize or change the tier, delete and recreate the resource (data will be lost). All other fields (`authSecret.labels`, `authSecret.annotations`, `authSecret.extraData`, `ipRange`) are mutable and take effect on the next reconciliation.
 - **Public network access is disabled.** Connections are only possible from within the Kyma SKR network through the auto-provisioned Private Endpoint.
 - **TLS only.** AMR enforces TLS 1.2 client connections; plaintext is not supported.
 - **Redis version.** Azure Managed Redis runs Redis 7.4. There is no `redisVersion` field; the version is managed by Azure.
 - **Single database per instance.** Cloud Manager provisions exactly one database (`default`) per `AzureManagedRedis` resource.
 - **No sovereign cloud support.** AMR is not yet available in Azure China or US Government clouds. Use `AzureRedisInstance` / `AzureRedisCluster` (legacy `armredis` SKUs) on those landscapes.
+- **Auth secret name conflict.** If a Kubernetes Secret with the same name already exists in the namespace and belongs to a different `AzureManagedRedis` resource, the instance will enter `Error` state. Use a unique `spec.authSecret.name` to avoid conflicts.

--- a/docs/user/resources/04-40-32-azure-managed-redis.md
+++ b/docs/user/resources/04-40-32-azure-managed-redis.md
@@ -3,9 +3,21 @@
 > [!WARNING]
 > This is a beta feature available only per request for SAP-internal teams.
 
-The `azuremanagedredis.cloud-resources.kyma-project.io` Custom Resource Definition (CRD) describes a single Azure Managed Redis (Microsoft.Cache/redisEnterprise) cluster provisioned in your Kyma runtime through Cloud Manager. A single SKR kind covers three workload classes — single-node dev, HA production, and HA + sharded clustered Redis — through the `redisTier` field.
+The `azuremanagedredis.cloud-resources.kyma-project.io` is a namespace-scoped custom resource (CR).
+It describes a single Azure Managed Redis (Microsoft.Cache/redisEnterprise) cluster provisioned in your Kyma runtime through Cloud Manager.
+Once the cluster is provisioned, a Kubernetes Secret with endpoint and credential details is provided in the same namespace.
+By default, the created auth Secret has the same name as the AzureManagedRedis, unless specified otherwise.
+
+A single SKR kind covers three workload classes — single-node dev, HA production, and HA + sharded clustered Redis — through the `redisTier` field.
 
 > Azure Managed Redis is a separate product from Azure Cache for Redis. It is **not yet available** in Azure China or Azure US Government regions; only commercial Azure regions are supported.
+
+> [!TIP] _Only for advanced cases of network topology_
+> IP addresses are allocated from the [IpRange CR](./04-10-iprange.md). If an IpRange CR is not specified in the AzureManagedRedis, then the default IpRange is used. If the default IpRange does not exist, it is automatically created. Manually create a non-default IpRange with specified Classless Inter-Domain Routing (CIDR) and use it only in advanced cases of network topology when you want to control the network segments to avoid range conflicts with other networks.
+
+When creating AzureManagedRedis, one field is mandatory: `redisTier`.
+
+Optionally, you can specify the `authSecret` and `ipRange` fields.
 
 ## Specification
 
@@ -14,13 +26,13 @@ This table lists the parameters of `AzureManagedRedis.spec`.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | **redisTier** (required) | string | Kyma service tier. Encodes the underlying SKU + high-availability + clustering policy. See the [Tier Reference](#tier-reference) below. Allowed values: `S1`, `S2`, `S3`, `S4`, `S5`, `P1`, `P2`, `P3`, `P4`, `P5`, `C3`, `C4`, `C5`, `C6`, `C7`. **Immutable.** |
-| **authSecret** | object | Customises the generated connection secret. |
-| **authSecret.name** | string | Name of the secret. Defaults to the `AzureManagedRedis` resource name. **Immutable once set.** |
-| **authSecret.labels** | map[string]string | Labels applied to the secret. |
-| **authSecret.annotations** | map[string]string | Annotations applied to the secret. |
-| **authSecret.extraData** | map[string]string | Additional secret keys, supporting Go templates that reference `host`, `port`, `primaryEndpoint`, `authString`. |
-| **ipRange** | object | Reference to an `IpRange` for private connectivity. If omitted, the default `IpRange` is used. |
-| **ipRange.name** | string | Name of the referenced `IpRange`. |
+| **authSecret** | object | Optional. Customises the generated connection secret. |
+| **authSecret.name** | string | Optional. Name of the secret. Defaults to the `AzureManagedRedis` resource name. **Immutable once set.** |
+| **authSecret.labels** | map[string]string | Optional. Labels applied to the secret. |
+| **authSecret.annotations** | map[string]string | Optional. Annotations applied to the secret. |
+| **authSecret.extraData** | map[string]string | Optional. Additional secret keys, supporting Go templates that reference `host`, `port`, `primaryEndpoint`, `authString`. The templating follows the [Golang templating syntax](https://pkg.go.dev/text/template). |
+| **ipRange** | object | Optional. IpRange reference. If omitted, the default IpRange is used. If the default IpRange does not exist, it will be created. |
+| **ipRange.name** | string | Required. Name of the existing IpRange to use. |
 
 ### Tier Reference
 
@@ -55,20 +67,23 @@ P-tiers and C-tiers map to the **same Azure SKU at the same price** when their u
 | **observedGeneration** | int64 | Most recent reconciled `metadata.generation`. |
 | **conditions** | list | Standard Kubernetes conditions, including `Ready` and `Error`. |
 
-## Connection Secret
+## Auth Secret Details
 
-Once `state` is `Ready`, Cloud Manager creates (or updates) a Kubernetes `Secret` in the same namespace with the following keys:
+The following table lists the meaningful parameters of the auth Secret:
 
-| Key | Description |
-|-----|-------------|
-| `primaryEndpoint` | Hostname of the AMR cluster (hostname only, not `host:port`). |
-| `host` | Same as `primaryEndpoint`. |
-| `port` | Redis client port. Always `10000` for Azure Managed Redis. |
-| `authString` | Access key for client authentication. |
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **.metadata.name** | string | Name of the auth Secret. It shares the name with AzureManagedRedis unless specified otherwise. |
+| **.metadata.labels** | object | Specified custom labels (if any). |
+| **.metadata.annotations** | object | Specified custom annotations (if any). |
+| **.data.primaryEndpoint** | string | Hostname of the AMR cluster (hostname only, not `host:port`). Base64 encoded. |
+| **.data.host** | string | Same as `primaryEndpoint`. Base64 encoded. |
+| **.data.port** | string | Redis client port. Always `10000` for Azure Managed Redis. Base64 encoded. |
+| **.data.authString** | string | Access key for client authentication. Base64 encoded. |
 
 Any keys you list under `spec.authSecret.extraData` are added on top, with Go template expansion against the four base keys above.
 
-## Example
+## Sample Custom Resource
 
 ```yaml
 apiVersion: cloud-resources.kyma-project.io/v1beta1

--- a/docs/user/resources/04-40-32-azure-managed-redis.md
+++ b/docs/user/resources/04-40-32-azure-managed-redis.md
@@ -52,8 +52,6 @@ P-tiers and C-tiers of equal numeric rank (e.g. `P3` and `C5`) provision the **s
 |-------|------|-------------|
 | **id** | string | Internal Cloud Manager identifier. |
 | **state** | string | Lifecycle state: `Processing`, `Creating`, `Ready`, `Deleting`, `Error`. |
-| **primaryEndpoint** | string | Hostname for client connections. |
-| **port** | int32 | Redis client port (always `10000` for AMR). |
 | **observedGeneration** | int64 | Most recent reconciled `metadata.generation`. |
 | **conditions** | list | Standard Kubernetes conditions, including `Ready` and `Error`. |
 
@@ -65,7 +63,7 @@ Once `state` is `Ready`, Cloud Manager creates (or updates) a Kubernetes `Secret
 |-----|-------------|
 | `primaryEndpoint` | Hostname of the AMR cluster. |
 | `host` | Same as `primaryEndpoint` (kept for compatibility with other Redis SKR kinds). |
-| `port` | Always `10000`. |
+| `port` | Redis client port (typically `10000` for AMR). |
 | `authString` | Access key for client authentication. |
 
 Any keys you list under `spec.authSecret.extraData` are added on top, with Go template expansion against the four base keys above.
@@ -102,7 +100,7 @@ spec:
 
 ## Notes and Limitations
 
-- **Immutable fields.** `spec.redisTier`, `spec.ipRange`, and `spec.authSecret.name` cannot be changed after creation. To resize, delete and recreate the resource (data will be lost).
+- **Immutable fields.** `spec.redisTier` and `spec.authSecret.name` cannot be changed after creation. To resize, delete and recreate the resource (data will be lost).
 - **Public network access is disabled.** Connections are only possible from within the Kyma SKR network through the auto-provisioned Private Endpoint.
 - **TLS only.** AMR enforces TLS 1.2 client connections; plaintext is not supported.
 - **Single database per cluster.** Cloud Manager provisions exactly one database (`default`) per `AzureManagedRedis` resource.

--- a/docs/user/resources/README.md
+++ b/docs/user/resources/README.md
@@ -80,6 +80,10 @@ The `gcpredisinstance.cloud-resources.kyma-project.io` CRD describes the Google 
 
 The `azureredisinstance.cloud-resources.kyma-project.io` CRD describes the Microsoft Azure Cache for Redis instance. For more information, see [AzureRedisInstance Custom Resource](./04-40-30-azure-redis-instance.md).
 
+### AzureManagedRedis CR [**Beta feature**]
+
+The `azuremanagedredis.cloud-resources.kyma-project.io` CRD describes the Azure Managed Redis (Microsoft.Cache/redisEnterprise) cluster. For more information, see [AzureManagedRedis Custom Resource](./04-40-32-azure-managed-redis.md).
+
 ## Redis Cluster Resources
 
 ### AwsRedisCluster CR [**Beta feature**]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Adds `docs/user/resources/04-40-32-azure-managed-redis.md` - single user-facing reference for the unified `AzureManagedRedis` SKR kind: spec/status fields, full S/P/C tier table (SKU, memory, HA, clustering policy, use case), connection-secret keys, P-tier and C-tier example manifests, and limitations (immutable fields, private-only access, TLS-only, single DB, no sovereign-cloud support).

Changes proposed in this pull request:

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
