### PR TITLE
fix(test): stop KCP AzureManagedRedis flake by suppressing VpcNetwork reconciler

### DIFF
--- a/internal/controller/cloud-control/azuremanagedredis_test.go
+++ b/internal/controller/cloud-control/azuremanagedredis_test.go
@@ -16,8 +16,6 @@ var _ = Describe("Feature: KCP AzureManagedRedis", func() {
 
 	It("Scenario: KCP AzureManagedRedis is created and deleted", func() {
 
-		Skip("fix me, I', flaky....")
-
 		name := "a3b1c2d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6"
 		scope := &cloudcontrolv1beta1.Scope{}
 

--- a/internal/controller/cloud-control/azuremanagedredis_test.go
+++ b/internal/controller/cloud-control/azuremanagedredis_test.go
@@ -7,6 +7,7 @@ import (
 	azurecommon "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/common"
 	kcpscope "github.com/kyma-project/cloud-manager/pkg/kcp/scope"
 	kcpsubscription "github.com/kyma-project/cloud-manager/pkg/kcp/subscription"
+	kcpvpcnetwork "github.com/kyma-project/cloud-manager/pkg/kcp/vpcnetwork"
 	. "github.com/kyma-project/cloud-manager/pkg/testinfra/dsl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -58,6 +59,8 @@ var _ = Describe("Feature: KCP AzureManagedRedis", func() {
 				WithSubscription(name).
 				WithCidrBlocks("10.250.0.0/22").
 				Build()
+
+			kcpvpcnetwork.Ignore.AddName(name)
 
 			Eventually(CreateObj).
 				WithArguments(infra.Ctx(), infra.KCP().Client(), vpcNetwork).

--- a/pkg/testinfra/dsl/utilUpdate.go
+++ b/pkg/testinfra/dsl/utilUpdate.go
@@ -31,6 +31,11 @@ func UpdateStatus(ctx context.Context, clnt client.Client, obj client.Object, op
 	NewObjActions(opts...).
 		ApplyOnStatus(obj)
 
+	fresh := obj.DeepCopyObject().(client.Object)
+	if err := clnt.Get(ctx, client.ObjectKeyFromObject(obj), fresh); err == nil {
+		obj.SetResourceVersion(fresh.GetResourceVersion())
+	}
+
 	err := clnt.Status().Update(ctx, obj)
 	return err
 }

--- a/pkg/testinfra/dsl/utilUpdate.go
+++ b/pkg/testinfra/dsl/utilUpdate.go
@@ -31,11 +31,6 @@ func UpdateStatus(ctx context.Context, clnt client.Client, obj client.Object, op
 	NewObjActions(opts...).
 		ApplyOnStatus(obj)
 
-	fresh := obj.DeepCopyObject().(client.Object)
-	if err := clnt.Get(ctx, client.ObjectKeyFromObject(obj), fresh); err == nil {
-		obj.SetResourceVersion(fresh.GetResourceVersion())
-	}
-
 	err := clnt.Status().Update(ctx, obj)
 	return err
 }


### PR DESCRIPTION
## Root cause

The test manually drives `VpcNetwork` to `Ready` via `UpdateStatus`, but the live `VpcNetwork` reconciler was running concurrently and writing to the same object. Both writers used the same `resourceVersion`, causing intermittent 409 Conflicts that timed out the `Eventually` block at line 70.

## Fix

Add `kcpvpcnetwork.Ignore.AddName(name)` before the `VpcNetwork` is created, preventing the reconciler from touching the object during the test. This is the established pattern used by every other controller test that manually drives object state (e.g. `runtime_controller_azure_test.go`, `runtime_controller_gcp_test.go`).

## What changed

- `internal/controller/cloud-control/azuremanagedredis_test.go` - import `kcpvpcnetwork`; register the name in `Ignore` before `CreateObj`; remove `Skip`
- `pkg/testinfra/dsl/utilUpdate.go` - revert the resourceVersion side-channel refresh added in the previous commit; it masked the root cause and silently changed behavior for all callers of `UpdateStatus`

## Verification

Test run 20 consecutive times without a single failure:

```
Ginkgo ran 1 suite in 4.807983083s - Test Suite Passed (20/20)
```

Closes #1911.