### PR TITLE
fix(aws-redis): surface cloud provider errors on KCP RedisInstance/RedisCluster status

### DIFF
--- a/pkg/kcp/provider/aws/rediscluster/authorizeSecurityGroupIngress.go
+++ b/pkg/kcp/provider/aws/rediscluster/authorizeSecurityGroupIngress.go
@@ -4,8 +4,11 @@ import (
 	"context"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -73,7 +76,25 @@ func authorizeSecurityGroupIngress(ctx context.Context, st composed.State) (erro
 
 	err := state.awsClient.AuthorizeElastiCacheSecurityGroupIngress(ctx, state.securityGroupId, permissions)
 	if err != nil {
-		return awsmeta.LogErrorAndReturn(err, "Error adding security group ingress", ctx)
+		logger.Error(err, "Error adding security group ingress")
+		redisInstance := state.ObjAsRedisCluster()
+		meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+			Type:    cloudcontrolv1beta1.ConditionTypeError,
+			Status:  "True",
+			Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+			Message: "Failed to authorize security group ingress",
+		})
+		redisInstance.Status.State = cloudcontrolv1beta1.StateError
+		updateErr := state.UpdateObjStatus(ctx)
+		if updateErr != nil {
+			return composed.LogErrorAndReturn(updateErr,
+				"Error updating RedisCluster status due failed security group ingress authorization",
+				composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+				ctx,
+			)
+		}
+
+		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 	}
 
 	return composed.StopWithRequeue, nil

--- a/pkg/kcp/provider/aws/rediscluster/createAuthTokenSecret.go
+++ b/pkg/kcp/provider/aws/rediscluster/createAuthTokenSecret.go
@@ -5,9 +5,12 @@ import (
 
 	secretsmanagertypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/utils/ptr"
 )
@@ -45,7 +48,24 @@ func createAuthTokenSecret(ctx context.Context, st composed.State) (error, conte
 		},
 	})
 	if err != nil {
-		return awsmeta.LogErrorAndReturn(err, "Error creating authToken secret", ctx)
+		logger.Error(err, "Error creating authToken secret")
+		meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+			Type:    cloudcontrolv1beta1.ConditionTypeError,
+			Status:  "True",
+			Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+			Message: "Failed to create authToken secret",
+		})
+		redisInstance.Status.State = cloudcontrolv1beta1.StateError
+		updateErr := state.UpdateObjStatus(ctx)
+		if updateErr != nil {
+			return composed.LogErrorAndReturn(updateErr,
+				"Error updating RedisCluster status due failed authToken secret creation",
+				composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+				ctx,
+			)
+		}
+
+		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 	}
 
 	logger.Info("AuthToken secret created")

--- a/pkg/kcp/provider/aws/rediscluster/createParameterGroup.go
+++ b/pkg/kcp/provider/aws/rediscluster/createParameterGroup.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
 	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/utils/ptr"
 )
@@ -45,7 +47,24 @@ func createParameterGroup(getParamGroup func(*State) *elasticachetypes.CachePara
 			},
 		})
 		if err != nil {
-			return awsmeta.LogErrorAndReturn(err, "Error creating parameter group", ctx)
+			logger.Error(err, "Error creating parameter group")
+			meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  "True",
+				Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+				Message: "Failed to create parameter group",
+			})
+			redisInstance.Status.State = cloudcontrolv1beta1.StateError
+			updateErr := state.UpdateObjStatus(ctx)
+			if updateErr != nil {
+				return composed.LogErrorAndReturn(updateErr,
+					"Error updating RedisCluster status due failed parameter group creation",
+					composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+					ctx,
+				)
+			}
+
+			return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 		}
 
 		logger = logger.WithValues("parameterGroupName", out.CacheParameterGroup.CacheParameterGroupName)

--- a/pkg/kcp/provider/aws/rediscluster/createSecurityGroup.go
+++ b/pkg/kcp/provider/aws/rediscluster/createSecurityGroup.go
@@ -4,9 +4,12 @@ import (
 	"context"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -43,7 +46,24 @@ func createSecurityGroup(ctx context.Context, st composed.State) (error, context
 		},
 	})
 	if err != nil {
-		return awsmeta.LogErrorAndReturn(err, "Error creating security group", ctx)
+		logger.Error(err, "Error creating security group")
+		meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+			Type:    cloudcontrolv1beta1.ConditionTypeError,
+			Status:  "True",
+			Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+			Message: "Failed to create security group",
+		})
+		redisInstance.Status.State = cloudcontrolv1beta1.StateError
+		updateErr := state.UpdateObjStatus(ctx)
+		if updateErr != nil {
+			return composed.LogErrorAndReturn(updateErr,
+				"Error updating RedisCluster status due failed security group creation",
+				composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+				ctx,
+			)
+		}
+
+		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 	}
 
 	logger = logger.WithValues("securityGroupId", sgId)

--- a/pkg/kcp/provider/aws/rediscluster/createSubnetGroup.go
+++ b/pkg/kcp/provider/aws/rediscluster/createSubnetGroup.go
@@ -8,7 +8,9 @@ import (
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/utils/ptr"
 )
@@ -45,7 +47,24 @@ func createSubnetGroup(ctx context.Context, st composed.State) (error, context.C
 		},
 	})
 	if err != nil {
-		return awsmeta.LogErrorAndReturn(err, "Error creating subnet group", ctx)
+		logger.Error(err, "Error creating subnet group")
+		meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+			Type:    cloudcontrolv1beta1.ConditionTypeError,
+			Status:  "True",
+			Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+			Message: "Failed to create subnet group",
+		})
+		redisInstance.Status.State = cloudcontrolv1beta1.StateError
+		updateErr := state.UpdateObjStatus(ctx)
+		if updateErr != nil {
+			return composed.LogErrorAndReturn(updateErr,
+				"Error updating RedisCluster status due failed subnet group creation",
+				composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+				ctx,
+			)
+		}
+
+		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 	}
 
 	logger = logger.WithValues("subnetGroupName", out.CacheSubnetGroup.CacheSubnetGroupName)

--- a/pkg/kcp/provider/aws/rediscluster/createUserGroup.go
+++ b/pkg/kcp/provider/aws/rediscluster/createUserGroup.go
@@ -4,9 +4,12 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -38,7 +41,24 @@ func createUserGroup(ctx context.Context, st composed.State) (error, context.Con
 		},
 	})
 	if err != nil {
-		return awsmeta.LogErrorAndReturn(err, "Error creating user group", ctx)
+		logger.Error(err, "Error creating user group")
+		meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+			Type:    cloudcontrolv1beta1.ConditionTypeError,
+			Status:  "True",
+			Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+			Message: "Failed to create user group",
+		})
+		redisInstance.Status.State = cloudcontrolv1beta1.StateError
+		updateErr := state.UpdateObjStatus(ctx)
+		if updateErr != nil {
+			return composed.LogErrorAndReturn(updateErr,
+				"Error updating RedisCluster status due failed user group creation",
+				composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+				ctx,
+			)
+		}
+
+		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 	}
 
 	logger = logger.WithValues("userGroupId", out.UserGroupId)

--- a/pkg/kcp/provider/aws/rediscluster/modifyAuthEnabled.go
+++ b/pkg/kcp/provider/aws/rediscluster/modifyAuthEnabled.go
@@ -3,8 +3,11 @@ package rediscluster
 import (
 	"context"
 
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -33,7 +36,24 @@ func modifyAuthEnabled(ctx context.Context, st composed.State) (error, context.C
 		logger.Info("Deleting authToken secret")
 		err := state.awsClient.DeleteAuthTokenSecret(ctx, *state.authTokenValue.Name)
 		if err != nil {
-			return awsmeta.LogErrorAndReturn(err, "Error deleting authToken secret", ctx)
+			logger.Error(err, "Error deleting authToken secret")
+			meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  "True",
+				Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+				Message: "Failed to delete authToken secret",
+			})
+			redisInstance.Status.State = cloudcontrolv1beta1.StateError
+			updateErr := state.UpdateObjStatus(ctx)
+			if updateErr != nil {
+				return composed.LogErrorAndReturn(updateErr,
+					"Error updating RedisCluster status due failed authToken secret deletion",
+					composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+					ctx,
+				)
+			}
+
+			return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 		}
 	}
 

--- a/pkg/kcp/provider/aws/rediscluster/modifyParameterGroup.go
+++ b/pkg/kcp/provider/aws/rediscluster/modifyParameterGroup.go
@@ -4,9 +4,11 @@ import (
 	"context"
 
 	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
 	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func modifyParameterGroup(
@@ -42,7 +44,24 @@ func modifyParameterGroup(
 		logger.Info("Modifying cache parameters")
 		err := state.awsClient.ModifyElastiCacheParameterGroup(ctx, name, ToParametersSlice(forUpdateParameters))
 		if err != nil {
-			return awsmeta.LogErrorAndReturn(err, "Error modifying cache parameters", ctx)
+			logger.Error(err, "Error modifying cache parameters")
+			meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  "True",
+				Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+				Message: "Failed to modify cache parameters",
+			})
+			redisInstance.Status.State = cloudcontrolv1beta1.StateError
+			updateErr := state.UpdateObjStatus(ctx)
+			if updateErr != nil {
+				return composed.LogErrorAndReturn(updateErr,
+					"Error updating RedisCluster status due failed cache parameters modification",
+					composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+					ctx,
+				)
+			}
+
+			return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 		}
 
 		return composed.StopWithRequeueDelay(5 * util.Timing.T1000ms()), nil

--- a/pkg/kcp/provider/aws/redisinstance/authorizeSecurityGroupIngress.go
+++ b/pkg/kcp/provider/aws/redisinstance/authorizeSecurityGroupIngress.go
@@ -4,8 +4,11 @@ import (
 	"context"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -73,7 +76,25 @@ func authorizeSecurityGroupIngress(ctx context.Context, st composed.State) (erro
 
 	err := state.awsClient.AuthorizeElastiCacheSecurityGroupIngress(ctx, state.securityGroupId, permissions)
 	if err != nil {
-		return awsmeta.LogErrorAndReturn(err, "Error adding security group ingress", ctx)
+		logger.Error(err, "Error adding security group ingress")
+		redisInstance := state.ObjAsRedisInstance()
+		meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+			Type:    cloudcontrolv1beta1.ConditionTypeError,
+			Status:  "True",
+			Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+			Message: "Failed to authorize security group ingress",
+		})
+		redisInstance.Status.State = cloudcontrolv1beta1.StateError
+		updateErr := state.UpdateObjStatus(ctx)
+		if updateErr != nil {
+			return composed.LogErrorAndReturn(updateErr,
+				"Error updating RedisInstance status due failed security group ingress authorization",
+				composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+				ctx,
+			)
+		}
+
+		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 	}
 
 	return composed.StopWithRequeue, nil

--- a/pkg/kcp/provider/aws/redisinstance/createAuthTokenSecret.go
+++ b/pkg/kcp/provider/aws/redisinstance/createAuthTokenSecret.go
@@ -5,9 +5,12 @@ import (
 
 	secretsmanagertypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/utils/ptr"
 )
@@ -45,7 +48,24 @@ func createAuthTokenSecret(ctx context.Context, st composed.State) (error, conte
 		},
 	})
 	if err != nil {
-		return awsmeta.LogErrorAndReturn(err, "Error creating authToken secret", ctx)
+		logger.Error(err, "Error creating authToken secret")
+		meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+			Type:    cloudcontrolv1beta1.ConditionTypeError,
+			Status:  "True",
+			Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+			Message: "Failed to create authToken secret",
+		})
+		redisInstance.Status.State = cloudcontrolv1beta1.StateError
+		updateErr := state.UpdateObjStatus(ctx)
+		if updateErr != nil {
+			return composed.LogErrorAndReturn(updateErr,
+				"Error updating RedisInstance status due failed authToken secret creation",
+				composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+				ctx,
+			)
+		}
+
+		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 	}
 
 	logger.Info("AuthToken secret created")

--- a/pkg/kcp/provider/aws/redisinstance/createParameterGroup.go
+++ b/pkg/kcp/provider/aws/redisinstance/createParameterGroup.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
 	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/utils/ptr"
 )
@@ -45,7 +47,24 @@ func createParameterGroup(getParamGroup func(*State) *elasticachetypes.CachePara
 			},
 		})
 		if err != nil {
-			return awsmeta.LogErrorAndReturn(err, "Error creating parameter group", ctx)
+			logger.Error(err, "Error creating parameter group")
+			meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  "True",
+				Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+				Message: "Failed to create parameter group",
+			})
+			redisInstance.Status.State = cloudcontrolv1beta1.StateError
+			updateErr := state.UpdateObjStatus(ctx)
+			if updateErr != nil {
+				return composed.LogErrorAndReturn(updateErr,
+					"Error updating RedisInstance status due failed parameter group creation",
+					composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+					ctx,
+				)
+			}
+
+			return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 		}
 
 		logger = logger.WithValues("parameterGroupName", out.CacheParameterGroup.CacheParameterGroupName)

--- a/pkg/kcp/provider/aws/redisinstance/createSecurityGroup.go
+++ b/pkg/kcp/provider/aws/redisinstance/createSecurityGroup.go
@@ -4,9 +4,12 @@ import (
 	"context"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -43,7 +46,24 @@ func createSecurityGroup(ctx context.Context, st composed.State) (error, context
 		},
 	})
 	if err != nil {
-		return awsmeta.LogErrorAndReturn(err, "Error creating security group", ctx)
+		logger.Error(err, "Error creating security group")
+		meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+			Type:    cloudcontrolv1beta1.ConditionTypeError,
+			Status:  "True",
+			Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+			Message: "Failed to create security group",
+		})
+		redisInstance.Status.State = cloudcontrolv1beta1.StateError
+		updateErr := state.UpdateObjStatus(ctx)
+		if updateErr != nil {
+			return composed.LogErrorAndReturn(updateErr,
+				"Error updating RedisInstance status due failed security group creation",
+				composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+				ctx,
+			)
+		}
+
+		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 	}
 
 	logger = logger.WithValues("securityGroupId", sgId)

--- a/pkg/kcp/provider/aws/redisinstance/createSubnetGroup.go
+++ b/pkg/kcp/provider/aws/redisinstance/createSubnetGroup.go
@@ -8,7 +8,9 @@ import (
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/utils/ptr"
 )
@@ -45,7 +47,24 @@ func createSubnetGroup(ctx context.Context, st composed.State) (error, context.C
 		},
 	})
 	if err != nil {
-		return awsmeta.LogErrorAndReturn(err, "Error creating subnet group", ctx)
+		logger.Error(err, "Error creating subnet group")
+		meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+			Type:    cloudcontrolv1beta1.ConditionTypeError,
+			Status:  "True",
+			Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+			Message: "Failed to create subnet group",
+		})
+		redisInstance.Status.State = cloudcontrolv1beta1.StateError
+		updateErr := state.UpdateObjStatus(ctx)
+		if updateErr != nil {
+			return composed.LogErrorAndReturn(updateErr,
+				"Error updating RedisInstance status due failed subnet group creation",
+				composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+				ctx,
+			)
+		}
+
+		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 	}
 
 	logger = logger.WithValues("subnetGroupName", out.CacheSubnetGroup.CacheSubnetGroupName)

--- a/pkg/kcp/provider/aws/redisinstance/createUserGroup.go
+++ b/pkg/kcp/provider/aws/redisinstance/createUserGroup.go
@@ -4,9 +4,12 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/common"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -38,7 +41,24 @@ func createUserGroup(ctx context.Context, st composed.State) (error, context.Con
 		},
 	})
 	if err != nil {
-		return awsmeta.LogErrorAndReturn(err, "Error creating user group", ctx)
+		logger.Error(err, "Error creating user group")
+		meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+			Type:    cloudcontrolv1beta1.ConditionTypeError,
+			Status:  "True",
+			Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+			Message: "Failed to create user group",
+		})
+		redisInstance.Status.State = cloudcontrolv1beta1.StateError
+		updateErr := state.UpdateObjStatus(ctx)
+		if updateErr != nil {
+			return composed.LogErrorAndReturn(updateErr,
+				"Error updating RedisInstance status due failed user group creation",
+				composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+				ctx,
+			)
+		}
+
+		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 	}
 
 	logger = logger.WithValues("userGroupId", out.UserGroupId)

--- a/pkg/kcp/provider/aws/redisinstance/modifyAuthEnabled.go
+++ b/pkg/kcp/provider/aws/redisinstance/modifyAuthEnabled.go
@@ -3,8 +3,11 @@ package redisinstance
 import (
 	"context"
 
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -33,7 +36,24 @@ func modifyAuthEnabled(ctx context.Context, st composed.State) (error, context.C
 		logger.Info("Deleting authToken secret")
 		err := state.awsClient.DeleteAuthTokenSecret(ctx, *state.authTokenValue.Name)
 		if err != nil {
-			return awsmeta.LogErrorAndReturn(err, "Error deleting authToken secret", ctx)
+			logger.Error(err, "Error deleting authToken secret")
+			meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  "True",
+				Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+				Message: "Failed to delete authToken secret",
+			})
+			redisInstance.Status.State = cloudcontrolv1beta1.StateError
+			updateErr := state.UpdateObjStatus(ctx)
+			if updateErr != nil {
+				return composed.LogErrorAndReturn(updateErr,
+					"Error updating RedisInstance status due failed authToken secret deletion",
+					composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+					ctx,
+				)
+			}
+
+			return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 		}
 	}
 

--- a/pkg/kcp/provider/aws/redisinstance/modifyParameterGroup.go
+++ b/pkg/kcp/provider/aws/redisinstance/modifyParameterGroup.go
@@ -4,9 +4,11 @@ import (
 	"context"
 
 	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
-	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
 	"github.com/kyma-project/cloud-manager/pkg/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func modifyParameterGroup(
@@ -42,7 +44,24 @@ func modifyParameterGroup(
 		logger.Info("Modifying cache parameters")
 		err := state.awsClient.ModifyElastiCacheParameterGroup(ctx, name, ToParametersSlice(forUpdateParameters))
 		if err != nil {
-			return awsmeta.LogErrorAndReturn(err, "Error modifying cache parameters", ctx)
+			logger.Error(err, "Error modifying cache parameters")
+			meta.SetStatusCondition(redisInstance.Conditions(), metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  "True",
+				Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+				Message: "Failed to modify cache parameters",
+			})
+			redisInstance.Status.State = cloudcontrolv1beta1.StateError
+			updateErr := state.UpdateObjStatus(ctx)
+			if updateErr != nil {
+				return composed.LogErrorAndReturn(updateErr,
+					"Error updating RedisInstance status due failed cache parameters modification",
+					composed.StopWithRequeueDelay(util.Timing.T10000ms()),
+					ctx,
+				)
+			}
+
+			return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 		}
 
 		return composed.StopWithRequeueDelay(5 * util.Timing.T1000ms()), nil


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

When AWS ElastiCache create/modify calls (e.g. `CreateUserGroup` returning `UserGroupQuotaExceeded`) failed, the reconciler logged the error and silently requeued — the failure was visible in the controller logs but not on the KCP resource itself, making operational diagnosis harder. Errors are now also reflected on `.status` (`ConditionTypeError` / `ReasonCloudProviderError` / `StateError`) and requeued every 60s.

**Affected actions** (RedisInstance + RedisCluster):
`createUserGroup`, `createSubnetGroup`, `createSecurityGroup`, `createParameterGroup`, `createAuthTokenSecret`, `authorizeSecurityGroupIngress`, `modifyParameterGroup`, `modifyAuthEnabled`.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
