### PR TITLE
fix(amr): Azure Managed Redis provisioning fixes (HA, terminal state, DNS 409, IpRange teardown)

### DIFF
--- a/e2e/features/skr-shared-managedredis-azure.feature
+++ b/e2e/features/skr-shared-managedredis-azure.feature
@@ -20,7 +20,7 @@ Feature: AzureManagedRedis feature
 
     Then eventually "redis.status.state == 'Ready'" is ok, unless:
       | redis.status.state == 'Error' |
-      | #timeout=45m                  |
+      | #timeout=30m                  |
 
     And "findConditionTrue(redis, 'Ready')" is ok
 
@@ -61,7 +61,7 @@ Feature: AzureManagedRedis feature
 
     Then eventually "redis.status.state == 'Ready'" is ok, unless:
       | redis.status.state == 'Error' |
-      | #timeout=45m                  |
+      | #timeout=30m                  |
 
     And "findConditionTrue(redis, 'Ready')" is ok
 

--- a/e2e/lib/consts.go
+++ b/e2e/lib/consts.go
@@ -11,7 +11,7 @@ const (
 var DefaultRegions = map[cloudcontrolv1beta1.ProviderType]string{
 	cloudcontrolv1beta1.ProviderAws:       "us-east-1",
 	cloudcontrolv1beta1.ProviderGCP:       "us-east1",
-	cloudcontrolv1beta1.ProviderAzure:     "westeurope",
+	cloudcontrolv1beta1.ProviderAzure:     "eastus2",
 	cloudcontrolv1beta1.ProviderOpenStack: "eu-de-1",
 }
 

--- a/pkg/kcp/provider/azure/iprange/privateDnsZoneDelete.go
+++ b/pkg/kcp/provider/azure/iprange/privateDnsZoneDelete.go
@@ -32,6 +32,11 @@ func privateDnsZoneDelete(ctx context.Context, st composed.State) (error, contex
 			ctx,
 		)
 	}
+	if azuremeta.IsConflictError(err) {
+		// Nested resources (virtualNetworkLinks) still being deleted — requeue and wait.
+		logger.Info("Azure KCP IpRange dnsZone delete conflict, nested resources still pending, requeueing")
+		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
+	}
 	if err != nil {
 		logger.Error(err, "Error deleting Azure KCP IpRange dnsZone")
 

--- a/pkg/kcp/provider/azure/iprange/virtualNetworkLinkDelete.go
+++ b/pkg/kcp/provider/azure/iprange/virtualNetworkLinkDelete.go
@@ -33,6 +33,11 @@ func virtualNetworkLinkDelete(ctx context.Context, st composed.State) (error, co
 			ctx,
 		)
 	}
+	if azuremeta.IsConflictError(err) {
+		// Another delete operation is already queued for this link — requeue and wait for it.
+		logger.Info("Azure KCP IpRange virtualNetworkLink delete conflict, another operation pending, requeueing")
+		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
+	}
 	if err != nil {
 		logger.Error(err, "Error deleting Azure KCP IpRange virtualNetworkLink")
 

--- a/pkg/kcp/provider/azure/iprange/virtualNetworkLinkDeleteWait.go
+++ b/pkg/kcp/provider/azure/iprange/virtualNetworkLinkDeleteWait.go
@@ -14,8 +14,8 @@ func virtualNetworkLinkDeleteWait(ctx context.Context, st composed.State) (error
 		return nil, nil
 	}
 
-	// Azure may still report Succeeded briefly after the DELETE is issued before transitioning
-	// to Deleting — requeue in all non-nil states until the link disappears.
+	// Resource keeps prior provisioningState until ARM moves it to Deleting; requeue until gone.
+	// https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/async-operations#provisioningstate-values
 	logger.Info("Azure virtual network link instance is still being deleted, requeueing with delay")
 	return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 }

--- a/pkg/kcp/provider/azure/iprange/virtualNetworkLinkDeleteWait.go
+++ b/pkg/kcp/provider/azure/iprange/virtualNetworkLinkDeleteWait.go
@@ -2,11 +2,8 @@ package iprange
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
-	"github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/kyma-project/cloud-manager/pkg/util"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func virtualNetworkLinkDeleteWait(ctx context.Context, st composed.State) (error, context.Context) {
@@ -17,21 +14,8 @@ func virtualNetworkLinkDeleteWait(ctx context.Context, st composed.State) (error
 		return nil, nil
 	}
 
-	if *state.virtualNetworkLink.Properties.ProvisioningState != armprivatedns.ProvisioningStateDeleting {
-		errorMsg := "Error: unexpected azure virtual network link state"
-		ipRange := st.Obj().(*v1beta1.IpRange)
-		return composed.UpdateStatus(ipRange).
-			SetExclusiveConditions(metav1.Condition{
-				Type:    v1beta1.ConditionTypeError,
-				Status:  metav1.ConditionTrue,
-				Reason:  v1beta1.ConditionTypeError,
-				Message: errorMsg,
-			}).
-			SuccessError(composed.StopAndForget).
-			SuccessLogMsg(errorMsg).
-			Run(ctx, st)
-	}
-
+	// Azure may still report Succeeded briefly after the DELETE is issued before transitioning
+	// to Deleting — requeue in all non-nil states until the link disappears.
 	logger.Info("Azure virtual network link instance is still being deleted, requeueing with delay")
 	return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 }

--- a/pkg/kcp/provider/azure/managedredis/createManagedRedis.go
+++ b/pkg/kcp/provider/azure/managedredis/createManagedRedis.go
@@ -2,8 +2,10 @@ package managedredis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -20,31 +22,44 @@ func createManagedRedis(ctx context.Context, st composed.State) (error, context.
 		return nil, ctx
 	}
 
-	composed.LoggerFromCtx(ctx).Info("Creating Azure Managed Redis", "name", obj.Name)
-
 	skuName := armredisenterprise.SKUName(obj.Spec.SKU)
 	tlsVersion := armredisenterprise.TLSVersionOne2
 	region := state.VpcNetwork().Spec.Region
-	highAvailability := armredisenterprise.HighAvailabilityEnabled
-	if !obj.Spec.HighAvailability {
-		highAvailability = armredisenterprise.HighAvailabilityDisabled
-	}
 	publicNetworkAccess := armredisenterprise.PublicNetworkAccessDisabled
+	props := &armredisenterprise.ClusterCreateProperties{
+		MinimumTLSVersion:   &tlsVersion,
+		PublicNetworkAccess: &publicNetworkAccess,
+	}
+	// Only send HighAvailability when the user wants it Disabled (non-HA Balanced tiers).
+	// On ComputeOptimized SKUs in zonal regions, Azure rejects an explicit
+	// HighAvailability=Enabled with "Specifying zones for SKU '...' is not supported.
+	// Zone redundancy is enabled by default for this SKU in regions with zones."
+	// Leaving the field unset lets Azure pick the SKU/region default (Enabled+ZR
+	// for ComputeOptimized in zonal regions).
+	if !obj.Spec.HighAvailability {
+		ha := armredisenterprise.HighAvailabilityDisabled
+		props.HighAvailability = &ha
+	}
 	cluster := armredisenterprise.Cluster{
 		Location: &region,
 		SKU: &armredisenterprise.SKU{
 			Name: &skuName,
 		},
-		Properties: &armredisenterprise.ClusterCreateProperties{
-			MinimumTLSVersion:   &tlsVersion,
-			HighAvailability:    &highAvailability,
-			PublicNetworkAccess: &publicNetworkAccess,
-		},
+		Properties: props,
 	}
 
-	// Note: Azure Managed Redis (Balanced/ComputeOptimized/MemoryOptimized/Flash SKUs)
-	// does NOT support specifying zones — zone redundancy is enabled by default in
-	// regions with availability zones. Do not set cluster.Zones for these SKUs.
+	haStr := "<unset>"
+	if props.HighAvailability != nil {
+		haStr = string(*props.HighAvailability)
+	}
+	composed.LoggerFromCtx(ctx).
+		WithValues(
+			"clusterName", obj.Name,
+			"sku", obj.Spec.SKU,
+			"region", region,
+			"highAvailability", haStr,
+		).
+		Info("Submitting Azure Managed Redis cluster create request")
 
 	// Note: PublicNetworkAccess is set on create only. There is no updateManagedRedis
 	// action, so clusters created before this field was introduced will not be patched.
@@ -53,7 +68,17 @@ func createManagedRedis(ctx context.Context, st composed.State) (error, context.
 
 	err := state.client.CreateOrUpdateCluster(ctx, state.resourceGroupName, obj.Name, cluster)
 	if err != nil {
-		composed.LoggerFromCtx(ctx).Error(err, "Error creating Azure Managed Redis cluster")
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) {
+			composed.LoggerFromCtx(ctx).
+				WithValues(
+					"errorCode", respErr.ErrorCode,
+					"statusCode", respErr.StatusCode,
+				).
+				Error(err, "Azure rejected Managed Redis cluster create (ResponseError)")
+		} else {
+			composed.LoggerFromCtx(ctx).Error(err, "Error creating Azure Managed Redis cluster")
+		}
 		obj.Status.State = string(cloudcontrolv1beta1.StateError)
 		return composed.UpdateStatus(obj).
 			SetExclusiveConditions(metav1.Condition{
@@ -67,6 +92,7 @@ func createManagedRedis(ctx context.Context, st composed.State) (error, context.
 	}
 
 	obj.Status.State = string(cloudcontrolv1beta1.StateProcessing)
+	composed.LoggerFromCtx(ctx).Info("Azure Managed Redis create submitted, requeuing in 60s")
 	return composed.UpdateStatus(obj).
 		SuccessError(composed.StopWithRequeueDelay(util.Timing.T60000ms())).
 		Run(ctx, st)

--- a/pkg/kcp/provider/azure/managedredis/createManagedRedis.go
+++ b/pkg/kcp/provider/azure/managedredis/createManagedRedis.go
@@ -30,12 +30,10 @@ func createManagedRedis(ctx context.Context, st composed.State) (error, context.
 		MinimumTLSVersion:   &tlsVersion,
 		PublicNetworkAccess: &publicNetworkAccess,
 	}
-	// Only send HighAvailability when the user wants it Disabled (non-HA Balanced tiers).
-	// On ComputeOptimized SKUs in zonal regions, Azure rejects an explicit
-	// HighAvailability=Enabled with "Specifying zones for SKU '...' is not supported.
-	// Zone redundancy is enabled by default for this SKU in regions with zones."
-	// Leaving the field unset lets Azure pick the SKU/region default (Enabled+ZR
-	// for ComputeOptimized in zonal regions).
+	// Zone redundancy is the default in zonal regions (see link); on ComputeOptimized
+	// SKUs Azure rejects an explicit Enabled with "Specifying zones for SKU '...' is
+	// not supported." Send the field only when the user wants it Disabled.
+	// https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-high-availability#zone-redundancy
 	if !obj.Spec.HighAvailability {
 		ha := armredisenterprise.HighAvailabilityDisabled
 		props.HighAvailability = &ha
@@ -60,11 +58,6 @@ func createManagedRedis(ctx context.Context, st composed.State) (error, context.
 			"highAvailability", haStr,
 		).
 		Info("Submitting Azure Managed Redis cluster create request")
-
-	// Note: PublicNetworkAccess is set on create only. There is no updateManagedRedis
-	// action, so clusters created before this field was introduced will not be patched.
-	// This is intentional: AMR is a new resource type with no existing instances in the
-	// field at the time this was added.
 
 	err := state.client.CreateOrUpdateCluster(ctx, state.resourceGroupName, obj.Name, cluster)
 	if err != nil {

--- a/pkg/kcp/provider/azure/managedredis/createPrivateDnsZone.go
+++ b/pkg/kcp/provider/azure/managedredis/createPrivateDnsZone.go
@@ -8,6 +8,7 @@ import (
 
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	azuremeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/meta"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 )
 
@@ -23,6 +24,15 @@ func createPrivateDnsZone(ctx context.Context, st composed.State) (error, contex
 
 	err := state.client.CreatePrivateDnsZone(ctx, state.resourceGroupName, state.PrivateDNSZoneName(), nil)
 	if err != nil {
+		// 409 Conflict on the shared private DNS zone happens when multiple AMR
+		// reconciles race on the same `privatelink.redis.azure.net` zone — Azure
+		// serializes upserts and rejects concurrent requests with a queued-operation
+		// 409. Treat it as transient: loadPrivateDnsZone will pick the zone up on
+		// the next reconcile once the in-flight upsert finishes.
+		if azuremeta.IsConflictError(err) {
+			composed.LoggerFromCtx(ctx).Info("Private DNS Zone create conflicted with concurrent operation; will retry", "zone", state.PrivateDNSZoneName())
+			return composed.StopWithRequeueDelay(util.Timing.T10000ms()), nil
+		}
 		composed.LoggerFromCtx(ctx).Error(err, "Error creating Private DNS Zone for Azure Managed Redis")
 		obj.Status.State = string(cloudcontrolv1beta1.StateError)
 		return composed.UpdateStatus(obj).

--- a/pkg/kcp/provider/azure/managedredis/createPrivateDnsZone.go
+++ b/pkg/kcp/provider/azure/managedredis/createPrivateDnsZone.go
@@ -24,11 +24,9 @@ func createPrivateDnsZone(ctx context.Context, st composed.State) (error, contex
 
 	err := state.client.CreatePrivateDnsZone(ctx, state.resourceGroupName, state.PrivateDNSZoneName(), nil)
 	if err != nil {
-		// 409 Conflict on the shared private DNS zone happens when multiple AMR
-		// reconciles race on the same `privatelink.redis.azure.net` zone — Azure
-		// serializes upserts and rejects concurrent requests with a queued-operation
-		// 409. Treat it as transient: loadPrivateDnsZone will pick the zone up on
-		// the next reconcile once the in-flight upsert finishes.
+		// AMR private endpoints share `privatelink.redis.azure.net` (see link); concurrent
+		// reconciles upserting the same zone race and one of them gets 409 — transient.
+		// https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns#databases
 		if azuremeta.IsConflictError(err) {
 			composed.LoggerFromCtx(ctx).Info("Private DNS Zone create conflicted with concurrent operation; will retry", "zone", state.PrivateDNSZoneName())
 			return composed.StopWithRequeueDelay(util.Timing.T10000ms()), nil

--- a/pkg/kcp/provider/azure/managedredis/waitManagedRedisAvailable.go
+++ b/pkg/kcp/provider/azure/managedredis/waitManagedRedisAvailable.go
@@ -31,6 +31,8 @@ func waitManagedRedisAvailable(ctx context.Context, st composed.State) (error, c
 		resourceStateStr = string(*state.managedRedis.Properties.ResourceState)
 	}
 
+	// Failed and Canceled are terminal per the ARM async-operation contract.
+	// https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/async-operations#provisioningstate-values
 	if provisioningState == armredisenterprise.ProvisioningStateFailed ||
 		provisioningState == armredisenterprise.ProvisioningStateCanceled {
 		composed.LoggerFromCtx(ctx).

--- a/pkg/kcp/provider/azure/managedredis/waitManagedRedisAvailable.go
+++ b/pkg/kcp/provider/azure/managedredis/waitManagedRedisAvailable.go
@@ -2,23 +2,59 @@ package managedredis
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"github.com/kyma-project/cloud-manager/pkg/util"
 )
 
 func waitManagedRedisAvailable(ctx context.Context, st composed.State) (error, context.Context) {
 	state := st.(*State)
+	obj := state.ObjAsAzureManagedRedis()
 
 	if state.managedRedis == nil {
 		return composed.StopWithRequeueDelay(util.Timing.T10000ms()), nil
 	}
 
-	if state.managedRedis.Properties == nil ||
-		state.managedRedis.Properties.ProvisioningState == nil ||
-		*state.managedRedis.Properties.ProvisioningState != armredisenterprise.ProvisioningStateSucceeded {
+	if state.managedRedis.Properties == nil || state.managedRedis.Properties.ProvisioningState == nil {
+		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
+	}
+
+	provisioningState := *state.managedRedis.Properties.ProvisioningState
+
+	resourceStateStr := ""
+	if state.managedRedis.Properties.ResourceState != nil {
+		resourceStateStr = string(*state.managedRedis.Properties.ResourceState)
+	}
+
+	if provisioningState == armredisenterprise.ProvisioningStateFailed ||
+		provisioningState == armredisenterprise.ProvisioningStateCanceled {
+		composed.LoggerFromCtx(ctx).
+			WithValues(
+				"provisioningState", string(provisioningState),
+				"resourceState", resourceStateStr,
+			).
+			Info("Azure Managed Redis cluster reached terminal failure state")
+
+		conditionMsg := fmt.Sprintf("Azure Managed Redis cluster provisioning %s (resourceState=%s)", provisioningState, resourceStateStr)
+
+		obj.Status.State = string(cloudcontrolv1beta1.StateError)
+		return composed.UpdateStatus(obj).
+			SetExclusiveConditions(metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+				Message: conditionMsg,
+			}).
+			SuccessError(composed.StopAndForget).
+			Run(ctx, st)
+	}
+
+	if provisioningState != armredisenterprise.ProvisioningStateSucceeded {
 		return composed.StopWithRequeueDelay(util.Timing.T60000ms()), nil
 	}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Bug fixes for Azure Managed Redis (`Microsoft.Cache/redisEnterprise`) provisioning and IpRange teardown, surfaced and validated by AMR e2e (P1 + C5 in `eastus2`, both PASS including PING/PONG against the live cluster).

Changes proposed in this pull request:

- **HA-omit on create** - Azure rejects an explicit `HighAvailability=Enabled` for ComputeOptimized SKUs in zonal regions   
  ("zone redundancy is enabled by default"). Only send `Disabled` for non-HA Balanced tiers; let Azure pick the SKU/region
  default otherwise.                                                                                                          
- **Terminal failure surfacing** - `waitManagedRedisAvailable` now detects `ProvisioningStateFailed` / `Canceled`, surfaces the cluster's `resourceState` in an Error condition, and calls `StopAndForget` instead of looping forever on a dead cluster.
- **409 Conflict on shared private DNS zone (AMR create)** - concurrent AMR reconciles race on
  `privatelink.redis.azure.net`. Treat 409 as transient and requeue.                                                          
- **IpRange teardown** - fix `StopAndForget` bug in `virtualNetworkLinkDeleteWait` that bricked IpRange when Azure briefly reported `Succeeded` after a DELETE before transitioning to `Deleting`. Also handle 409 Conflict on `virtualNetworkLink` and `privateDnsZone` delete (queued operations) as transient.
- **e2e config** - set Azure default region to `eastus2`; raise AMR scenario timeout to 30m to cover C5 provisioning time.  
  

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
