### PR TITLE
fix(aws-redis): use user-group name builder in createUserGroup

### DIFF
--- a/pkg/kcp/provider/aws/rediscluster/createUserGroup.go
+++ b/pkg/kcp/provider/aws/rediscluster/createUserGroup.go
@@ -23,7 +23,7 @@ func createUserGroup(ctx context.Context, st composed.State) (error, context.Con
 	logger := composed.LoggerFromCtx(ctx)
 	redisInstance := state.ObjAsRedisCluster()
 
-	out, err := state.awsClient.CreateUserGroup(ctx, GetAwsElastiCacheParameterGroupName(state.Obj().GetName()), []types.Tag{
+	out, err := state.awsClient.CreateUserGroup(ctx, GetAwsElastiCacheUserGroupName(state.Obj().GetName()), []types.Tag{
 		{
 			Key:   ptr.To(common.TagCloudManagerName),
 			Value: new(state.Name().String()),

--- a/pkg/kcp/provider/aws/redisinstance/createUserGroup.go
+++ b/pkg/kcp/provider/aws/redisinstance/createUserGroup.go
@@ -23,7 +23,7 @@ func createUserGroup(ctx context.Context, st composed.State) (error, context.Con
 	logger := composed.LoggerFromCtx(ctx)
 	redisInstance := state.ObjAsRedisInstance()
 
-	out, err := state.awsClient.CreateUserGroup(ctx, GetAwsElastiCacheParameterGroupName(state.Obj().GetName()), []types.Tag{
+	out, err := state.awsClient.CreateUserGroup(ctx, GetAwsElastiCacheUserGroupName(state.Obj().GetName()), []types.Tag{
 		{
 			Key:   ptr.To(common.TagCloudManagerName),
 			Value: new(state.Name().String()),


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

`createUserGroup` called `GetAwsElastiCacheParameterGroupName` instead of `GetAwsElastiCacheUserGroupName`. Same output today (`cm-<name>`), so no behavior change — but the wrong builder will diverge once the names do. Fixed in both `rediscluster` and `redisinstance`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
