### PR TITLE
feat(amr): within-family tier scaling for Azure Managed Redis

### DIFF
--- a/api/cloud-control/v1beta1/azuremanagedredis_types.go
+++ b/api/cloud-control/v1beta1/azuremanagedredis_types.go
@@ -23,7 +23,7 @@ type AzureManagedRedisSpec struct {
 
 	// SKU defines the pricing tier.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule=(self == oldSelf), message="sku is immutable."
+	// +kubebuilder:validation:XValidation:rule=(self.split('_')[0] == oldSelf.split('_')[0]), message="sku family is immutable: changing between Balanced, ComputeOptimized, MemoryOptimized, FlashOptimized, or Enterprise families is not allowed."
 	// +kubebuilder:validation:Enum=Balanced_B0;Balanced_B1;Balanced_B3;Balanced_B5;Balanced_B10;Balanced_B20;Balanced_B50;Balanced_B100;Balanced_B150;Balanced_B250;Balanced_B350;Balanced_B500;Balanced_B700;Balanced_B1000;ComputeOptimized_X3;ComputeOptimized_X5;ComputeOptimized_X10;ComputeOptimized_X20;ComputeOptimized_X50;ComputeOptimized_X100;ComputeOptimized_X150;ComputeOptimized_X250;ComputeOptimized_X350;ComputeOptimized_X500;ComputeOptimized_X700;MemoryOptimized_M10;MemoryOptimized_M20;MemoryOptimized_M50;MemoryOptimized_M100;MemoryOptimized_M150;MemoryOptimized_M250;MemoryOptimized_M350;MemoryOptimized_M500;MemoryOptimized_M700;MemoryOptimized_M1000;MemoryOptimized_M1500;MemoryOptimized_M2000;FlashOptimized_A250;FlashOptimized_A500;FlashOptimized_A700;FlashOptimized_A1000;FlashOptimized_A1500;FlashOptimized_A2000;FlashOptimized_A4500;Enterprise_E1;Enterprise_E5;Enterprise_E10;Enterprise_E20;Enterprise_E50;Enterprise_E100;Enterprise_E200;Enterprise_E400;EnterpriseFlash_F300;EnterpriseFlash_F700;EnterpriseFlash_F1500
 	SKU string `json:"sku"`
 

--- a/api/cloud-resources/v1beta1/azuremanagedredis_types.go
+++ b/api/cloud-resources/v1beta1/azuremanagedredis_types.go
@@ -15,7 +15,7 @@ type AzureManagedRedisSpec struct {
 	// Switching between families is not allowed because it changes the clustering
 	// policy or high-availability mode, which Azure does not support after creation.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule=(self[0] == oldSelf[0]), message="redisTier family is immutable: switching between S, P, and C families is not allowed."
+	// +kubebuilder:validation:XValidation:rule=(self.startsWith("S") == oldSelf.startsWith("S") && self.startsWith("P") == oldSelf.startsWith("P") && self.startsWith("C") == oldSelf.startsWith("C")),message="redisTier family is immutable: switching between S, P, and C families is not allowed."
 	RedisTier AzureManagedRedisTier `json:"redisTier"`
 
 	// AuthSecret customises the name and labels of the generated connection secret.

--- a/api/cloud-resources/v1beta1/azuremanagedredis_types.go
+++ b/api/cloud-resources/v1beta1/azuremanagedredis_types.go
@@ -11,8 +11,11 @@ type AzureManagedRedisSpec struct {
 	// RedisTier defines the Kyma service tier. The letter encodes the workload class:
 	// S = single-node dev, P = HA production, C = clustered (sharded) HA.
 	// All tiers map to a single underlying Azure Managed Redis cluster.
+	// Scaling within the same family is allowed (e.g. S1→S3, P1→P3, C3→C5).
+	// Switching between families is not allowed because it changes the clustering
+	// policy or high-availability mode, which Azure does not support after creation.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule=(self == oldSelf), message="redisTier is immutable."
+	// +kubebuilder:validation:XValidation:rule=(self[0] == oldSelf[0]), message="redisTier family is immutable: switching between S, P, and C families is not allowed."
 	RedisTier AzureManagedRedisTier `json:"redisTier"`
 
 	// AuthSecret customises the name and labels of the generated connection secret.

--- a/config/crd/bases/cloud-control.kyma-project.io_azuremanagedredis.yaml
+++ b/config/crd/bases/cloud-control.kyma-project.io_azuremanagedredis.yaml
@@ -148,8 +148,10 @@ spec:
                 - EnterpriseFlash_F1500
                 type: string
                 x-kubernetes-validations:
-                - message: sku is immutable.
-                  rule: (self == oldSelf)
+                - message: 'sku family is immutable: changing between Balanced, ComputeOptimized,
+                    MemoryOptimized, FlashOptimized, or Enterprise families is not
+                    allowed.'
+                  rule: (self.split('_')[0] == oldSelf.split('_')[0])
               vpcNetwork:
                 description: |-
                   LocalObjectReference contains enough information to let you locate the

--- a/config/crd/bases/cloud-resources.kyma-project.io_azuremanagedredis.yaml
+++ b/config/crd/bases/cloud-resources.kyma-project.io_azuremanagedredis.yaml
@@ -115,7 +115,7 @@ spec:
                   type: string
                   x-kubernetes-validations:
                     - message: 'redisTier family is immutable: switching between S, P, and C families is not allowed.'
-                      rule: (self[0] == oldSelf[0])
+                      rule: (self.startsWith("S") == oldSelf.startsWith("S") && self.startsWith("P") == oldSelf.startsWith("P") && self.startsWith("C") == oldSelf.startsWith("C"))
               required:
                 - redisTier
               type: object

--- a/config/crd/bases/cloud-resources.kyma-project.io_azuremanagedredis.yaml
+++ b/config/crd/bases/cloud-resources.kyma-project.io_azuremanagedredis.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    cloud-resources.kyma-project.io/version: v0.0.2
+    cloud-resources.kyma-project.io/version: v0.0.3
   name: azuremanagedredis.cloud-resources.kyma-project.io
 spec:
   group: cloud-resources.kyma-project.io
@@ -93,6 +93,9 @@ spec:
                     RedisTier defines the Kyma service tier. The letter encodes the workload class:
                     S = single-node dev, P = HA production, C = clustered (sharded) HA.
                     All tiers map to a single underlying Azure Managed Redis cluster.
+                    Scaling within the same family is allowed (e.g. S1→S3, P1→P3, C3→C5).
+                    Switching between families is not allowed because it changes the clustering
+                    policy or high-availability mode, which Azure does not support after creation.
                   enum:
                     - S1
                     - S2
@@ -111,8 +114,8 @@ spec:
                     - C7
                   type: string
                   x-kubernetes-validations:
-                    - message: redisTier is immutable.
-                      rule: (self == oldSelf)
+                    - message: 'redisTier family is immutable: switching between S, P, and C families is not allowed.'
+                      rule: (self[0] == oldSelf[0])
               required:
                 - redisTier
               type: object

--- a/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_azuremanagedredis.yaml
+++ b/config/dist/kcp/crd/bases/cloud-control.kyma-project.io_azuremanagedredis.yaml
@@ -148,8 +148,10 @@ spec:
                 - EnterpriseFlash_F1500
                 type: string
                 x-kubernetes-validations:
-                - message: sku is immutable.
-                  rule: (self == oldSelf)
+                - message: 'sku family is immutable: changing between Balanced, ComputeOptimized,
+                    MemoryOptimized, FlashOptimized, or Enterprise families is not
+                    allowed.'
+                  rule: (self.split('_')[0] == oldSelf.split('_')[0])
               vpcNetwork:
                 description: |-
                   LocalObjectReference contains enough information to let you locate the

--- a/config/dist/skr/crd/bases/providers/azure/cloud-resources.kyma-project.io_azuremanagedredis.yaml
+++ b/config/dist/skr/crd/bases/providers/azure/cloud-resources.kyma-project.io_azuremanagedredis.yaml
@@ -115,7 +115,7 @@ spec:
                   type: string
                   x-kubernetes-validations:
                     - message: 'redisTier family is immutable: switching between S, P, and C families is not allowed.'
-                      rule: (self[0] == oldSelf[0])
+                      rule: (self.startsWith("S") == oldSelf.startsWith("S") && self.startsWith("P") == oldSelf.startsWith("P") && self.startsWith("C") == oldSelf.startsWith("C"))
               required:
                 - redisTier
               type: object

--- a/config/dist/skr/crd/bases/providers/azure/cloud-resources.kyma-project.io_azuremanagedredis.yaml
+++ b/config/dist/skr/crd/bases/providers/azure/cloud-resources.kyma-project.io_azuremanagedredis.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    cloud-resources.kyma-project.io/version: v0.0.2
+    cloud-resources.kyma-project.io/version: v0.0.3
   name: azuremanagedredis.cloud-resources.kyma-project.io
 spec:
   group: cloud-resources.kyma-project.io
@@ -93,6 +93,9 @@ spec:
                     RedisTier defines the Kyma service tier. The letter encodes the workload class:
                     S = single-node dev, P = HA production, C = clustered (sharded) HA.
                     All tiers map to a single underlying Azure Managed Redis cluster.
+                    Scaling within the same family is allowed (e.g. S1→S3, P1→P3, C3→C5).
+                    Switching between families is not allowed because it changes the clustering
+                    policy or high-availability mode, which Azure does not support after creation.
                   enum:
                     - S1
                     - S2
@@ -111,8 +114,8 @@ spec:
                     - C7
                   type: string
                   x-kubernetes-validations:
-                    - message: redisTier is immutable.
-                      rule: (self == oldSelf)
+                    - message: 'redisTier family is immutable: switching between S, P, and C families is not allowed.'
+                      rule: (self[0] == oldSelf[0])
               required:
                 - redisTier
               type: object

--- a/config/patchAfterMakeManifests.sh
+++ b/config/patchAfterMakeManifests.sh
@@ -35,4 +35,4 @@ yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.2
 yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.1"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_sapnfsvolumesnapshots.yaml
 yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.3"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_sapnfsvolumesnapshotrestores.yaml
 yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.1"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_sapnfsvolumesnapshotschedules.yaml
-yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.2"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_azuremanagedredis.yaml
+yq -i '.metadata.annotations."cloud-resources.kyma-project.io/version" = "v0.0.3"' $SCRIPT_DIR/crd/bases/cloud-resources.kyma-project.io_azuremanagedredis.yaml

--- a/docs/contributor/permissions/azure_default.json
+++ b/docs/contributor/permissions/azure_default.json
@@ -15,6 +15,7 @@
     "Microsoft.Cache/redisEnterprise/databases/regenerateKey/action",
     "Microsoft.Cache/redisEnterprise/databases/write",
     "Microsoft.Cache/redisEnterprise/delete",
+    "Microsoft.Cache/redisEnterprise/listSkusForScaling/action",
     "Microsoft.Cache/redisEnterprise/privateEndpointConnections/read",
     "Microsoft.Cache/redisEnterprise/privateEndpointConnections/write",
     "Microsoft.Cache/redisEnterprise/privateEndpointConnectionsApproval/action",

--- a/internal/api-tests/kcp_azuremanagedredis_test.go
+++ b/internal/api-tests/kcp_azuremanagedredis_test.go
@@ -109,13 +109,21 @@ var _ = Describe("Feature: KCP AzureManagedRedis", Ordered, func() {
 
 	Context("Scenario: SKU immutability", func() {
 
-		canNotChangeKcp(
-			"AzureManagedRedis sku cannot be changed",
+		canChangeKcp(
+			"AzureManagedRedis sku can be changed within the same family (Balanced_B5 -> Balanced_B10)",
 			newTestKcpAzureManagedRedisBuilder().WithSKU("Balanced_B5"),
 			func(b Builder[*cloudcontrolv1beta1.AzureManagedRedis]) {
 				b.(*testKcpAzureManagedRedisBuilder).WithSKU("Balanced_B10")
 			},
-			"sku is immutable",
+		)
+
+		canNotChangeKcp(
+			"AzureManagedRedis sku family is immutable (Balanced -> ComputeOptimized rejected)",
+			newTestKcpAzureManagedRedisBuilder().WithSKU("Balanced_B5"),
+			func(b Builder[*cloudcontrolv1beta1.AzureManagedRedis]) {
+				b.(*testKcpAzureManagedRedisBuilder).WithSKU("ComputeOptimized_X5")
+			},
+			"sku family is immutable",
 		)
 	})
 

--- a/internal/api-tests/skr_azuremanagedredis_test.go
+++ b/internal/api-tests/skr_azuremanagedredis_test.go
@@ -101,13 +101,21 @@ var _ = Describe("Feature: SKR AzureManagedRedis", Ordered, func() {
 			"spec.redisTier",
 		)
 
-		canNotChangeSkr(
-			"AzureManagedRedis tier is immutable",
+		canChangeSkr(
+			"AzureManagedRedis tier can be changed within the same family (P1 -> P2)",
 			newTestAzureManagedRedisBuilder().WithTier(cloudresourcesv1beta1.AzureManagedRedisTierP1),
 			func(b Builder[*cloudresourcesv1beta1.AzureManagedRedis]) {
 				b.(*testAzureManagedRedisBuilder).WithTier(cloudresourcesv1beta1.AzureManagedRedisTierP2)
 			},
-			"redisTier is immutable",
+		)
+
+		canNotChangeSkr(
+			"AzureManagedRedis tier family is immutable (P1 -> S1 rejected)",
+			newTestAzureManagedRedisBuilder().WithTier(cloudresourcesv1beta1.AzureManagedRedisTierP1),
+			func(b Builder[*cloudresourcesv1beta1.AzureManagedRedis]) {
+				b.(*testAzureManagedRedisBuilder).WithTier(cloudresourcesv1beta1.AzureManagedRedisTierS1)
+			},
+			"redisTier family is immutable",
 		)
 	})
 

--- a/internal/controller/cloud-control/azuremanagedredis_test.go
+++ b/internal/controller/cloud-control/azuremanagedredis_test.go
@@ -11,9 +11,192 @@ import (
 	. "github.com/kyma-project/cloud-manager/pkg/testinfra/dsl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Feature: KCP AzureManagedRedis", func() {
+
+	It("Scenario: KCP AzureManagedRedis scales SKU within family and rejects disallowed scale target", func() {
+
+		name := "b1c2d3e4-f5a6-7b8c-9d0e-f1a2b3c4d5e6"
+		scope := &cloudcontrolv1beta1.Scope{}
+
+		By("Given Scope exists", func() {
+			kcpscope.Ignore.AddName(name)
+			Eventually(CreateScopeAzure).
+				WithArguments(infra.Ctx(), infra, scope, WithName(name)).
+				Should(Succeed())
+		})
+
+		azureMock := infra.AzureMock().MockConfigs(scope.Spec.Scope.Azure.SubscriptionId, scope.Spec.Scope.Azure.TenantId)
+		_ = azureMock
+
+		subscription := &cloudcontrolv1beta1.Subscription{}
+
+		By("And Given Azure Subscription exists", func() {
+			kcpsubscription.Ignore.AddName(name)
+			Expect(
+				CreateSubscription(infra.Ctx(), infra, subscription,
+					WithName(name),
+					WithSubscriptionSpecGarden("binding-name")),
+			).To(Succeed())
+			Expect(
+				SubscriptionPatchStatusReadyAzure(infra.Ctx(), infra, subscription,
+					scope.Spec.Scope.Azure.TenantId, scope.Spec.Scope.Azure.SubscriptionId),
+			).To(Succeed())
+		})
+
+		vpcNetwork := &cloudcontrolv1beta1.VpcNetwork{}
+
+		By("And Given KCP VpcNetwork exists in Ready state", func() {
+			vpcNetworkName := scope.Spec.Scope.Azure.VpcNetwork
+			vpcNetwork = cloudcontrolv1beta1.NewVpcNetworkBuilder().
+				WithName(name).
+				WithVpcNetworkName(&vpcNetworkName).
+				WithRegion(scope.Spec.Region).
+				WithSubscription(name).
+				WithCidrBlocks("10.250.0.0/22").
+				Build()
+			kcpvpcnetwork.Ignore.AddName(name)
+			Eventually(CreateObj).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), vpcNetwork).
+				Should(Succeed())
+			Eventually(UpdateStatus).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), vpcNetwork,
+					WithConditions(KcpReadyCondition()),
+				).
+				Should(Succeed(), "Expected KCP VpcNetwork to become ready")
+		})
+
+		kcpIpRangeName := "6c0d9c9b-3c9b-5a1f-0d3b-0c2d2e2f2a2b"
+		kcpIpRange := &cloudcontrolv1beta1.IpRange{}
+
+		By("And Given KCP IpRange exists in Ready state", func() {
+			kcpiprange.Ignore.AddName(kcpIpRangeName)
+			Eventually(CreateKcpIpRange).
+				WithArguments(
+					infra.Ctx(), infra.KCP().Client(), kcpIpRange,
+					WithName(kcpIpRangeName),
+					WithKcpIpRangeRemoteRef("amr-scale-iprange"),
+					WithKcpIpRangeNetwork(name),
+					WithScope(name),
+				).
+				Should(Succeed())
+			Eventually(UpdateStatus).
+				WithArguments(
+					infra.Ctx(), infra.KCP().Client(), kcpIpRange,
+					WithKcpIpRangeStatusCidr(kcpIpRange.Spec.Cidr),
+					WithConditions(KcpReadyCondition()),
+				).
+				Should(Succeed(), "Expected KCP IpRange to become ready")
+		})
+
+		azureManagedRedis := &cloudcontrolv1beta1.AzureManagedRedis{}
+
+		By("When KCP AzureManagedRedis is created with Balanced_B5", func() {
+			Eventually(CreateKcpAzureManagedRedis).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), azureManagedRedis,
+					WithName(name),
+					WithRemoteRef("skr-amr-scale-example"),
+					WithKcpAzureManagedRedisVpcNetwork(name),
+					WithIpRange(kcpIpRangeName),
+					WithKcpAzureManagedRedisSKU(armredisenterprise.SKUNameBalancedB5),
+					WithKcpAzureManagedRedisClusteringPolicy(armredisenterprise.ClusteringPolicyEnterpriseCluster),
+					WithKcpAzureManagedRedisHighAvailability(false),
+				).
+				Should(Succeed(), "failed creating AzureManagedRedis")
+		})
+
+		By("Then KCP AzureManagedRedis becomes Ready", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), azureManagedRedis,
+					NewObjActions(),
+					HavingState(string(cloudcontrolv1beta1.StateReady)),
+					HavingConditionTrue(cloudcontrolv1beta1.ConditionTypeReady),
+				).
+				Should(Succeed(), "expected AzureManagedRedis to reach Ready state")
+		})
+
+		By("When spec SKU is changed to Balanced_B10 (scale-up within family)", func() {
+			Eventually(func() error {
+				if err := LoadAndCheck(infra.Ctx(), infra.KCP().Client(), azureManagedRedis, NewObjActions()); err != nil {
+					return err
+				}
+				return UpdateObj(infra.Ctx(), infra.KCP().Client(), azureManagedRedis,
+					WithKcpAzureManagedRedisSKU(armredisenterprise.SKUNameBalancedB10))
+			}).Should(Succeed(), "failed updating AzureManagedRedis SKU to Balanced_B10")
+		})
+
+		By("Then KCP AzureManagedRedis becomes Ready again with Balanced_B10", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), azureManagedRedis,
+					NewObjActions(),
+					HavingState(string(cloudcontrolv1beta1.StateReady)),
+					HavingConditionTrue(cloudcontrolv1beta1.ConditionTypeReady),
+				).
+				Should(Succeed(), "expected AzureManagedRedis to return to Ready after scale-up")
+		})
+
+		By("When spec SKU is changed to Balanced_B0 (not in allowed scale targets)", func() {
+			Eventually(func() error {
+				if err := LoadAndCheck(infra.Ctx(), infra.KCP().Client(), azureManagedRedis, NewObjActions()); err != nil {
+					return err
+				}
+				return UpdateObj(infra.Ctx(), infra.KCP().Client(), azureManagedRedis,
+					WithKcpAzureManagedRedisSKU(armredisenterprise.SKUNameBalancedB0))
+			}).Should(Succeed(), "failed updating AzureManagedRedis SKU to Balanced_B0")
+		})
+
+		By("Then KCP AzureManagedRedis enters Error state with CloudProviderError", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), azureManagedRedis,
+					NewObjActions(),
+					HavingState(string(cloudcontrolv1beta1.StateError)),
+					HavingCondition(
+						cloudcontrolv1beta1.ConditionTypeError,
+						metav1.ConditionTrue,
+						cloudcontrolv1beta1.ReasonCloudProviderError,
+						"is not a valid scale target",
+					),
+				).
+				Should(Succeed(), "expected AzureManagedRedis to be in Error state for disallowed scale target")
+		})
+
+		// Restore to valid SKU before deletion
+		By("When spec SKU is restored to Balanced_B10", func() {
+			Eventually(func() error {
+				if err := LoadAndCheck(infra.Ctx(), infra.KCP().Client(), azureManagedRedis, NewObjActions()); err != nil {
+					return err
+				}
+				return UpdateObj(infra.Ctx(), infra.KCP().Client(), azureManagedRedis,
+					WithKcpAzureManagedRedisSKU(armredisenterprise.SKUNameBalancedB10))
+			}).Should(Succeed(), "failed restoring AzureManagedRedis SKU to Balanced_B10")
+		})
+
+		By("Then KCP AzureManagedRedis becomes Ready again", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), azureManagedRedis,
+					NewObjActions(),
+					HavingState(string(cloudcontrolv1beta1.StateReady)),
+					HavingConditionTrue(cloudcontrolv1beta1.ConditionTypeReady),
+				).
+				Should(Succeed(), "expected AzureManagedRedis to return to Ready after SKU restore")
+		})
+
+		// DELETE
+
+		By("When KCP AzureManagedRedis is deleted", func() {
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), azureManagedRedis).
+				Should(Succeed(), "failed deleting AzureManagedRedis")
+		})
+
+		By("Then KCP AzureManagedRedis does not exist", func() {
+			Eventually(IsDeleted).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), azureManagedRedis).
+				Should(Succeed(), "expected AzureManagedRedis not to exist (be deleted), but it still exists")
+		})
+	})
 
 	It("Scenario: KCP AzureManagedRedis is created and deleted", func() {
 

--- a/pkg/kcp/provider/azure/managedredis/client/client.go
+++ b/pkg/kcp/provider/azure/managedredis/client/client.go
@@ -30,6 +30,8 @@ type ManagedRedisClient interface {
 	DeleteDatabase(ctx context.Context, resourceGroupName, clusterName, databaseName string) error
 	// ListKeys retrieves the access keys for the default database.
 	ListKeys(ctx context.Context, resourceGroupName, clusterName, databaseName string) (*armredisenterprise.AccessKeys, error)
+	// ListSKUsForScaling returns the SKUs that the cluster can be scaled to.
+	ListSKUsForScaling(ctx context.Context, resourceGroupName, clusterName string) ([]string, error)
 }
 
 // Client composes ManagedRedisClient with reused networking clients.
@@ -157,6 +159,20 @@ func (c *managedRedisClientImpl) ListKeys(ctx context.Context, resourceGroupName
 		return nil, err
 	}
 	return &resp.AccessKeys, nil
+}
+
+func (c *managedRedisClientImpl) ListSKUsForScaling(ctx context.Context, resourceGroupName, clusterName string) ([]string, error) {
+	resp, err := c.clustersClient.ListSKUsForScaling(ctx, resourceGroupName, clusterName, nil)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]string, 0, len(resp.SKUs))
+	for _, sku := range resp.SKUs {
+		if sku != nil && sku.Name != nil {
+			result = append(result, *sku.Name)
+		}
+	}
+	return result, nil
 }
 
 // compositeClient embeds all sub-clients.

--- a/pkg/kcp/provider/azure/managedredis/new.go
+++ b/pkg/kcp/provider/azure/managedredis/new.go
@@ -75,6 +75,7 @@ func (r *managedRedisReconciler) newAction() composed.Action {
 				composed.If(composed.NotMarkedForDeletionPredicate,
 					composed.ComposeActionsNoName(
 						createManagedRedis,
+						scaleManagedRedis,
 						waitManagedRedisAvailable,
 						updateStatusId,
 						createDatabase,

--- a/pkg/kcp/provider/azure/managedredis/scaleManagedRedis.go
+++ b/pkg/kcp/provider/azure/managedredis/scaleManagedRedis.go
@@ -1,0 +1,83 @@
+package managedredis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/util"
+)
+
+// scaleManagedRedis issues a PATCH SKU update when the cluster exists but its
+// current SKU differs from the desired spec SKU (within-family resize).
+func scaleManagedRedis(ctx context.Context, st composed.State) (error, context.Context) {
+	state := st.(*State)
+	obj := state.ObjAsAzureManagedRedis()
+
+	// Only act when the cluster already exists.
+	if state.managedRedis == nil {
+		return nil, ctx
+	}
+
+	// Compare current Azure SKU with desired spec SKU.
+	if state.managedRedis.SKU == nil || state.managedRedis.SKU.Name == nil {
+		return nil, ctx
+	}
+	currentSKU := string(*state.managedRedis.SKU.Name)
+	desiredSKU := obj.Spec.SKU
+	if currentSKU == desiredSKU {
+		return nil, ctx
+	}
+
+	skuName := armredisenterprise.SKUName(desiredSKU)
+	update := armredisenterprise.ClusterUpdate{
+		SKU: &armredisenterprise.SKU{
+			Name: &skuName,
+		},
+	}
+
+	composed.LoggerFromCtx(ctx).
+		WithValues(
+			"clusterName", obj.Name,
+			"currentSKU", currentSKU,
+			"desiredSKU", desiredSKU,
+		).
+		Info("Submitting Azure Managed Redis cluster scale (SKU update)")
+
+	err := state.client.UpdateCluster(ctx, state.resourceGroupName, obj.Name, update)
+	if err != nil {
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) {
+			composed.LoggerFromCtx(ctx).
+				WithValues(
+					"errorCode", respErr.ErrorCode,
+					"statusCode", respErr.StatusCode,
+				).
+				Error(err, "Azure rejected Managed Redis cluster scale (ResponseError)")
+		} else {
+			composed.LoggerFromCtx(ctx).Error(err, "Error scaling Azure Managed Redis cluster")
+		}
+		obj.Status.State = string(cloudcontrolv1beta1.StateError)
+		return composed.UpdateStatus(obj).
+			SetExclusiveConditions(metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+				Message: fmt.Sprintf("Failed to scale Azure Managed Redis: %s", err),
+			}).
+			SuccessError(composed.StopWithRequeueDelay(util.Timing.T60000ms())).
+			Run(ctx, st)
+	}
+
+	obj.Status.State = string(cloudcontrolv1beta1.StateProcessing)
+	composed.LoggerFromCtx(ctx).Info("Azure Managed Redis scale submitted, requeuing in 60s")
+	return composed.UpdateStatus(obj).
+		SuccessError(composed.StopWithRequeueDelay(util.Timing.T60000ms())).
+		Run(ctx, st)
+}

--- a/pkg/kcp/provider/azure/managedredis/scaleManagedRedis.go
+++ b/pkg/kcp/provider/azure/managedredis/scaleManagedRedis.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise/v3"
@@ -42,6 +44,45 @@ func scaleManagedRedis(ctx context.Context, st composed.State) (error, context.C
 		},
 	}
 
+	allowedSKUs, err := state.client.ListSKUsForScaling(ctx, state.resourceGroupName, obj.Name)
+	if err != nil {
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode == 403 {
+			// Service principal lacks listSkusForScaling/action permission — skip validation and attempt PATCH directly.
+			composed.LoggerFromCtx(ctx).
+				WithValues("currentSKU", currentSKU, "desiredSKU", desiredSKU).
+				Info("listSkusForScaling returned 403, skipping SKU validation and proceeding with scale PATCH")
+		} else {
+			composed.LoggerFromCtx(ctx).Error(err, "Failed to list allowed SKUs for scaling Azure Managed Redis")
+			obj.Status.State = string(cloudcontrolv1beta1.StateError)
+			return composed.UpdateStatus(obj).
+				SetExclusiveConditions(metav1.Condition{
+					Type:    cloudcontrolv1beta1.ConditionTypeError,
+					Status:  metav1.ConditionTrue,
+					Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+					Message: fmt.Sprintf("Failed to list allowed SKUs for scaling Azure Managed Redis: %s", err),
+				}).
+				SuccessError(composed.StopWithRequeueDelay(util.Timing.T60000ms())).
+				Run(ctx, st)
+		}
+	}
+	if len(allowedSKUs) > 0 && !slices.Contains(allowedSKUs, desiredSKU) {
+		msg := fmt.Sprintf("SKU %s is not a valid scale target from %s (allowed: %s)", desiredSKU, currentSKU, strings.Join(allowedSKUs, ", "))
+		composed.LoggerFromCtx(ctx).
+			WithValues("currentSKU", currentSKU, "desiredSKU", desiredSKU, "allowedSKUs", allowedSKUs).
+			Error(errors.New(msg), "Azure Managed Redis scale target not allowed")
+		obj.Status.State = string(cloudcontrolv1beta1.StateError)
+		return composed.UpdateStatus(obj).
+			SetExclusiveConditions(metav1.Condition{
+				Type:    cloudcontrolv1beta1.ConditionTypeError,
+				Status:  metav1.ConditionTrue,
+				Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
+				Message: msg,
+			}).
+			SuccessError(composed.StopWithRequeue).
+			Run(ctx, st)
+	}
+
 	composed.LoggerFromCtx(ctx).
 		WithValues(
 			"clusterName", obj.Name,
@@ -50,10 +91,15 @@ func scaleManagedRedis(ctx context.Context, st composed.State) (error, context.C
 		).
 		Info("Submitting Azure Managed Redis cluster scale (SKU update)")
 
-	err := state.client.UpdateCluster(ctx, state.resourceGroupName, obj.Name, update)
+	err = state.client.UpdateCluster(ctx, state.resourceGroupName, obj.Name, update)
 	if err != nil {
 		var respErr *azcore.ResponseError
 		if errors.As(err, &respErr) {
+			// Azure returns 400 "busy undergoing system maintenance" shortly after
+			// provisioning completes — treat as transient, not a permanent error.
+			if strings.Contains(respErr.Error(), "busy undergoing system maintenance") {
+				return composed.LogErrorAndReturn(err, "Azure Managed Redis busy, retrying scale", composed.StopWithRequeueDelay(util.Timing.T60000ms()), ctx)
+			}
 			composed.LoggerFromCtx(ctx).
 				WithValues(
 					"errorCode", respErr.ErrorCode,

--- a/pkg/kcp/provider/azure/managedredis/scaleManagedRedis.go
+++ b/pkg/kcp/provider/azure/managedredis/scaleManagedRedis.go
@@ -51,7 +51,7 @@ func scaleManagedRedis(ctx context.Context, st composed.State) (error, context.C
 			// Service principal lacks listSkusForScaling/action permission — skip validation and attempt PATCH directly.
 			composed.LoggerFromCtx(ctx).
 				WithValues("currentSKU", currentSKU, "desiredSKU", desiredSKU).
-				Info("listSkusForScaling returned 403, skipping SKU validation and proceeding with scale PATCH")
+				Info("WARNING: listSkusForScaling returned 403, SKU validation skipped - add Microsoft.Cache/redisEnterprise/listSkusForScaling/action permission to enable it")
 		} else {
 			composed.LoggerFromCtx(ctx).Error(err, "Failed to list allowed SKUs for scaling Azure Managed Redis")
 			obj.Status.State = string(cloudcontrolv1beta1.StateError)
@@ -79,7 +79,7 @@ func scaleManagedRedis(ctx context.Context, st composed.State) (error, context.C
 				Reason:  cloudcontrolv1beta1.ReasonCloudProviderError,
 				Message: msg,
 			}).
-			SuccessError(composed.StopWithRequeue).
+			SuccessError(composed.StopWithRequeueDelay(util.Timing.T60000ms())).
 			Run(ctx, st)
 	}
 

--- a/pkg/kcp/provider/azure/mock/managedRedisStore.go
+++ b/pkg/kcp/provider/azure/mock/managedRedisStore.go
@@ -122,6 +122,9 @@ func (s *managedRedisStore) UpdateCluster(ctx context.Context, resourceGroupName
 		return azuremeta.NewAzureNotFoundError()
 	}
 
+	if cluster.SKU != nil && cluster.SKU.Name != nil {
+		existing.SKU.Name = cluster.SKU.Name
+	}
 	if cluster.Properties != nil {
 		if cluster.Properties.MinimumTLSVersion != nil {
 			existing.Properties.MinimumTLSVersion = cluster.Properties.MinimumTLSVersion

--- a/pkg/kcp/provider/azure/mock/managedRedisStore.go
+++ b/pkg/kcp/provider/azure/mock/managedRedisStore.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise/v3"
@@ -298,4 +299,45 @@ func (s *managedRedisStore) ListKeys(ctx context.Context, resourceGroupName, clu
 		return nil, err
 	}
 	return res, nil
+}
+
+// mockSKUsByFamily lists all known SKUs per Azure Managed Redis family prefix.
+// The mock allows scaling to any SKU in the same family as the current cluster.
+var mockSKUsByFamily = map[string][]string{
+	"ComputeOptimized": {"ComputeOptimized_X5", "ComputeOptimized_X10", "ComputeOptimized_X20", "ComputeOptimized_X50", "ComputeOptimized_X100"},
+	"MemoryOptimized":  {"MemoryOptimized_M10", "MemoryOptimized_M20", "MemoryOptimized_M50", "MemoryOptimized_M100"},
+	"Balanced":         {"Balanced_B5", "Balanced_B10", "Balanced_B20", "Balanced_B50", "Balanced_B100"},
+	"FlashOptimized":   {"FlashOptimized_A250", "FlashOptimized_A500", "FlashOptimized_A1000", "FlashOptimized_A2000", "FlashOptimized_A4500"},
+}
+
+func (s *managedRedisStore) ListSKUsForScaling(ctx context.Context, resourceGroupName, clusterName string) ([]string, error) {
+	if isContextCanceled(ctx) {
+		return nil, context.Canceled
+	}
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if s.items[resourceGroupName] == nil {
+		return nil, azuremeta.NewAzureNotFoundError()
+	}
+	cluster, exists := s.items[resourceGroupName][clusterName]
+	if !exists {
+		return nil, azuremeta.NewAzureNotFoundError()
+	}
+	if cluster.SKU == nil || cluster.SKU.Name == nil {
+		return []string{}, nil
+	}
+	currentSKU := string(*cluster.SKU.Name)
+	for family, skus := range mockSKUsByFamily {
+		if strings.HasPrefix(currentSKU, family) {
+			result := make([]string, 0, len(skus)-1)
+			for _, s := range skus {
+				if s != currentSKU {
+					result = append(result, s)
+				}
+			}
+			return result, nil
+		}
+	}
+	return []string{}, nil
 }

--- a/pkg/skr/azuremanagedredis/modifyKcpAzureManagedRedis.go
+++ b/pkg/skr/azuremanagedredis/modifyKcpAzureManagedRedis.go
@@ -4,18 +4,44 @@ import (
 	"context"
 
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// modifyKcpAzureManagedRedis is intentionally a no-op.
-//
-// The KCP AzureManagedRedis spec is fully immutable (every field carries a CEL
-// `self == oldSelf` rule), and the SKR-side Tier is also immutable. There is
-// nothing to mutate after initial creation, so this action exists only for
-// symmetry with the AzureRedisInstance / AzureRedisCluster reconcilers, where
-// the comparable action handles capacity/SKU changes.
-//
-// If AMR ever grows mutable fields (e.g. tier upgrade), the resize logic
-// belongs here.
+// modifyKcpAzureManagedRedis patches the KCP AzureManagedRedis spec.sku when the
+// SKR redisTier changes within the same family (e.g. S1→S3, P1→P3, C3→C5).
+// Cross-family changes are rejected by the API server CEL rule before reaching here.
 func modifyKcpAzureManagedRedis(ctx context.Context, st composed.State) (error, context.Context) {
-	return nil, ctx
+	state := st.(*State)
+
+	if state.KcpAzureManagedRedis == nil {
+		return nil, ctx
+	}
+
+	skrTier := state.ObjAsAzureManagedRedis().Spec.RedisTier
+	desiredSpec, err := TierToSpec(skrTier)
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error resolving redisTier to Azure spec", composed.StopWithRequeue, ctx)
+	}
+
+	desiredSKU := string(desiredSpec.SKU)
+	if state.KcpAzureManagedRedis.Spec.SKU == desiredSKU {
+		return nil, ctx
+	}
+
+	composed.LoggerFromCtx(ctx).
+		WithValues(
+			"currentSKU", state.KcpAzureManagedRedis.Spec.SKU,
+			"desiredSKU", desiredSKU,
+			"tier", skrTier,
+		).
+		Info("Patching KCP AzureManagedRedis SKU for tier resize")
+
+	patch := client.MergeFrom(state.KcpAzureManagedRedis.DeepCopy())
+	state.KcpAzureManagedRedis.Spec.SKU = desiredSKU
+	err = state.KcpCluster.K8sClient().Patch(ctx, state.KcpAzureManagedRedis, patch)
+	if err != nil {
+		return composed.LogErrorAndReturn(err, "Error patching KCP AzureManagedRedis SKU", composed.StopWithRequeue, ctx)
+	}
+
+	return composed.StopWithRequeue, nil
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

  - **SKR API**: relax `redisTier` from fully immutable to family-locked - allows changes within the same family (S1↔S3, P1↔P3, C3↔C5); cross-family changes (P↔C, S↔P/C) remain blocked at the API server via CEL
  - **KCP API**: same family-lock rule on `spec.sku` (`Balanced_*`↔`Balanced_*`, etc.)
  - **SKR reconciler** (`modifyKcpAzureManagedRedis`): propagates `redisTier` changes to `spec.sku` on the KCP object                 
  - **KCP reconciler** (`scaleManagedRedis`): issues a PATCH SKU update when the live cluster SKU differs from spec; validates the target against Azure's `listSkusForScaling` API before submitting; gracefully skips validation on 403 (missing permission) and proceeds with PATCH                                                                                                                 
  - **Azure permissions**: added `Microsoft.Cache/redisEnterprise/listSkusForScaling/action` to `azure_default.json`                  
  - **Tests**: controller test covering scale-up (B5→B10→Ready), disallowed target (B0→Error), and recovery; mock updated to reflect SKU changes on `UpdateCluster`                                                                                                      
 
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
