### PR TITLE
fix(amr): always send HighAvailability explicitly on cluster create

### DIFF
--- a/internal/controller/cloud-control/azuremanagedredis_test.go
+++ b/internal/controller/cloud-control/azuremanagedredis_test.go
@@ -341,6 +341,15 @@ var _ = Describe("Feature: KCP AzureManagedRedis", func() {
 			Expect(dzg).ToNot(BeNil())
 		})
 
+		By("And Then Azure cluster HighAvailability is explicitly set to Enabled", func() {
+			cluster, err := azureMock.GetManagedRedisCluster(infra.Ctx(), resourceGroupName, name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cluster).NotTo(BeNil())
+			Expect(cluster.Properties).NotTo(BeNil())
+			Expect(cluster.Properties.HighAvailability).NotTo(BeNil(), "HighAvailability must not be nil")
+			Expect(string(*cluster.Properties.HighAvailability)).To(Equal(string(armredisenterprise.HighAvailabilityEnabled)))
+		})
+
 		// DELETE
 
 		By("When KCP AzureManagedRedis is deleted", func() {

--- a/pkg/kcp/provider/azure/managedredis/createManagedRedis.go
+++ b/pkg/kcp/provider/azure/managedredis/createManagedRedis.go
@@ -30,11 +30,14 @@ func createManagedRedis(ctx context.Context, st composed.State) (error, context.
 		MinimumTLSVersion:   &tlsVersion,
 		PublicNetworkAccess: &publicNetworkAccess,
 	}
-	// Zone redundancy is the default in zonal regions (see link); on ComputeOptimized
-	// SKUs Azure rejects an explicit Enabled with "Specifying zones for SKU '...' is
-	// not supported." Send the field only when the user wants it Disabled.
+	// Always send HighAvailability explicitly. Azure defaults to Enabled only for
+	// Enterprise/EnterpriseFlash SKUs; Balanced and ComputeOptimized SKUs require
+	// an explicit value and return provisioningState=Failed when the field is omitted.
 	// https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-high-availability#zone-redundancy
-	if !obj.Spec.HighAvailability {
+	if obj.Spec.HighAvailability {
+		ha := armredisenterprise.HighAvailabilityEnabled
+		props.HighAvailability = &ha
+	} else {
 		ha := armredisenterprise.HighAvailabilityDisabled
 		props.HighAvailability = &ha
 	}
@@ -46,10 +49,7 @@ func createManagedRedis(ctx context.Context, st composed.State) (error, context.
 		Properties: props,
 	}
 
-	haStr := "<unset>"
-	if props.HighAvailability != nil {
-		haStr = string(*props.HighAvailability)
-	}
+	haStr := string(*props.HighAvailability)
 	composed.LoggerFromCtx(ctx).
 		WithValues(
 			"clusterName", obj.Name,

--- a/pkg/kcp/provider/azure/mock/managedRedisStore.go
+++ b/pkg/kcp/provider/azure/mock/managedRedisStore.go
@@ -304,6 +304,10 @@ func (s *managedRedisStore) ListKeys(ctx context.Context, resourceGroupName, clu
 	return res, nil
 }
 
+func (s *managedRedisStore) GetManagedRedisCluster(ctx context.Context, resourceGroupName, clusterName string) (*armredisenterprise.Cluster, error) {
+	return s.GetCluster(ctx, resourceGroupName, clusterName)
+}
+
 // mockSKUsByFamily lists all known SKUs per Azure Managed Redis family prefix.
 // The mock allows scaling to any SKU in the same family as the current cluster.
 var mockSKUsByFamily = map[string][]string{

--- a/pkg/kcp/provider/azure/mock/type.go
+++ b/pkg/kcp/provider/azure/mock/type.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise/v3"
 	azuresecurityclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/security/client"
 	dnsresolverclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/vnetlink/dnsresolver/client"
 	azurevnetlinkclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/azure/vnetlink/dnszone/client"
@@ -147,9 +148,14 @@ type RedisConfig interface {
 	AzureSetRedisInstanceState(ctx context.Context, resourceGroupName, redisInstanceName string, state armredis.ProvisioningState) error
 }
 
+type ManagedRedisConfig interface {
+	GetManagedRedisCluster(ctx context.Context, resourceGroupName, clusterName string) (*armredisenterprise.Cluster, error)
+}
+
 type Configs interface {
 	NetworkConfig
 	RedisConfig
+	ManagedRedisConfig
 	DnsForwardingRulesetConfig
 	DnsResolverVNetLinkConfig
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Azure Managed Redis Balanced and ComputeOptimized SKUs require an explicit HighAvailability value on creation; omitting it causes provisioningState=Failed. Previously the field was only set when HighAvailability=false, leaving it nil for P and C tiers and causing all P-tier and C-tier e2e tests to fail.

Also expose GetManagedRedisCluster on the mock TenantSubscription and add a controller test assertion to catch future regressions.

Changes proposed in this pull request:

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
