### PR TITLE
fix(security): address GitHub code scanning alerts

### DIFF
--- a/.github/workflows/build-image-pr.yaml
+++ b/.github/workflows/build-image-pr.yaml
@@ -6,23 +6,16 @@ on:
     paths-ignore:
       - .github/workflows/stale.yaml
       - docs/**
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
-    paths-ignore:
-      - .github/workflows/stale.yaml
-      - docs/**
 
 jobs:
   approve-image-build:
-    if: ${{ github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'pr-build-image') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'pr-build-image') }}
     environment: e2e
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - run: echo "Build approved"
 
   build-image:
-    if: ${{ github.event_name == 'pull_request_target' }}
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
@@ -35,15 +28,13 @@ jobs:
 
   local-build:
     name: Build Image Locally
-    if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'pr-build-image') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'pr-build-image') }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v7
         with:
-          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Build Image Locally
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/build-image-pr.yaml
+++ b/.github/workflows/build-image-pr.yaml
@@ -6,16 +6,23 @@ on:
     paths-ignore:
       - .github/workflows/stale.yaml
       - docs/**
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    paths-ignore:
+      - .github/workflows/stale.yaml
+      - docs/**
 
 jobs:
   approve-image-build:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'pr-build-image') }}
+    if: ${{ github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'pr-build-image') }}
     environment: e2e
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - run: echo "Build approved"
 
   build-image:
+    if: ${{ github.event_name == 'pull_request_target' }}
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
@@ -28,13 +35,15 @@ jobs:
 
   local-build:
     name: Build Image Locally
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'pr-build-image') }}
+    if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'pr-build-image') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Build Image Locally
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/check-go-version.yaml
+++ b/.github/workflows/check-go-version.yaml
@@ -13,6 +13,8 @@ on:
 jobs:
   check-go-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/e2e-all.yaml
+++ b/.github/workflows/e2e-all.yaml
@@ -40,6 +40,7 @@ on:
 jobs:
   aws:
     if: ${{ github.event_name == 'schedule' || inputs.aws }}
+    permissions: {}
     uses: ./.github/workflows/e2e-tests.yaml
     secrets: inherit
     with:
@@ -49,6 +50,7 @@ jobs:
       debug: ${{ inputs.debug || true }}
   azure:
     if: ${{ github.event_name == 'schedule' || inputs.azure }}
+    permissions: {}
     uses: ./.github/workflows/e2e-tests.yaml
     secrets: inherit
     with:
@@ -58,6 +60,7 @@ jobs:
       debug: ${{ inputs.debug || true }}
   gcp:
     if: ${{ github.event_name == 'schedule' || inputs.gcp }}
+    permissions: {}
     uses: ./.github/workflows/e2e-tests.yaml
     secrets: inherit
     with:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -60,6 +60,8 @@ jobs:
   test:
     name: Test ${{ inputs.provider }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       AWS_ROLE_NAME: CloudManagerRole
       AWS_PEERING_ROLE_NAME: CloudManagerPeeringRole

--- a/.github/workflows/gherkin-lint.yaml.yml
+++ b/.github/workflows/gherkin-lint.yaml.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   gherkin-lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7

--- a/.github/workflows/pr-check-crd-version-bump.yaml
+++ b/.github/workflows/pr-check-crd-version-bump.yaml
@@ -14,6 +14,8 @@ jobs:
   check-crd-version-bump:
     runs-on: ubuntu-latest
     name: Check CRD version bump
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/pr-check-modified-files.yml
+++ b/.github/workflows/pr-check-modified-files.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Check modified files
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/pr-docu-check.yaml
+++ b/.github/workflows/pr-docu-check.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -22,6 +22,8 @@ jobs:
             ffFile: pkg/feature/ff_edge.yaml
     runs-on: ubuntu-latest
     name: ${{ matrix.name }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   sonar:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Print details
         env:
@@ -29,6 +31,7 @@ jobs:
           # Disabling shallow clones is recommended for improving the relevancy of reporting
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
       - name: Download coverage artifacts
         if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/pkg/feature/providerConfig.go
+++ b/pkg/feature/providerConfig.go
@@ -40,7 +40,7 @@ func (p *providerConfig) IntVariation(ctx context.Context, flagKey string, defau
 	if res.Type == gjson.Null {
 		return defaultValue
 	}
-	v, err := strconv.ParseInt(res.String(), 10, 64)
+	v, err := strconv.ParseInt(res.String(), 10, 0)
 	if err != nil {
 		return defaultValue
 	}


### PR DESCRIPTION
**Description**

Workflow permissions (missing-workflow-permissions warnings):
- Add `permissions: contents: read` to all workflow jobs that were missing explicit permission blocks

Untrusted checkout in privileged context (high severity):
- sonarqube.yaml: add `permissions: contents: read` to the workflow_run job and `persist-credentials: false` to the checkout step to prevent token leakage from untrusted head_sha
- build-image-pr.yaml: add `permissions: contents: read` and `persist-credentials: false` to the pull_request_target local-build job; add `permissions: {}` to approve-image-build

Go integer conversion (incorrect-integer-conversion warning):
- providerConfig.go: use bitSize=0 in ParseInt so the result fits native int width, eliminating the unsafe 64→int narrowing cast

Supersedes #1970 (same content, pushed from upstream branch to avoid fork pull_request_target checkout restriction).