### PR TITLE
fix(security): harden build-image-pr workflow against untrusted-checkout

### DIFF
--- a/.github/workflows/build-image-pr.yaml
+++ b/.github/workflows/build-image-pr.yaml
@@ -6,16 +6,23 @@ on:
     paths-ignore:
       - .github/workflows/stale.yaml
       - docs/**
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    paths-ignore:
+      - .github/workflows/stale.yaml
+      - docs/**
 
 jobs:
   approve-image-build:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'pr-build-image') }}
+    if: ${{ github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'pr-build-image') }}
     environment: e2e
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - run: echo "Build approved"
 
   build-image:
+    if: ${{ github.event_name == 'pull_request_target' }}
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout
@@ -28,13 +35,15 @@ jobs:
 
   local-build:
     name: Build Image Locally
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'pr-build-image') }}
+    if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'pr-build-image') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Build Image Locally
         uses: docker/build-push-action@v7
         with:


### PR DESCRIPTION
## Summary

Split out from #1970 to break the chicken-and-egg gating problem: the workflow file this PR touches is the **same one whose stale base-branch copy is currently gating #1970**. By landing this small surgical change first, the next CI run on #1970 (and every other PR) picks up the fixed workflow and the failing `Build Image Locally` (pull_request_target ghost) disappears.

## Why split

#1970 cannot fix its own gating check. The `pull_request_target` job runs from the **base branch** workflow file, so the fix in the PR diff is never executed for the PR itself.

Supersedes #1971 (same content, pushed from upstream branch to avoid fork pull_request_target checkout restriction).