### PR TITLE
fix(security): remove untrusted head_sha checkout from sonarqube workflow

### DIFF
--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -30,7 +30,6 @@ jobs:
         with:
           # Disabling shallow clones is recommended for improving the relevancy of reporting
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
 
       - name: Download coverage artifacts


### PR DESCRIPTION
Resolves CodeQL alert [#33](https://github.com/kyma-project/cloud-manager/security/code-scanning/33).

`workflow_run` runs with base repo secrets. Checking out `head_sha` from a PR is untrusted code in a privileged context. Sonar only needs `sonar-project.properties` - coverage is downloaded separately via `actions/download-artifact` - so checking out the default branch is sufficient.