### PR TITLE
chore: alicloud feature flag

### DIFF
--- a/pkg/feature/ffAlicloud.go
+++ b/pkg/feature/ffAlicloud.go
@@ -1,0 +1,23 @@
+package feature
+
+import (
+	"context"
+)
+
+const alicloudFlagName = "alicloud"
+
+// Alicloud gates all Alicloud provider code paths. While Alicloud support is
+// being rolled out, every routing decision that dispatches to the Alicloud
+// provider (scope creation, subscription handling, network reference,
+// vpcnetwork reconciler, iprange reconciler) MUST check this flag and skip
+// Alicloud handling when it returns false.
+//
+// Default is false — Alicloud is opt-in per landscape via ff_ga.yaml / ff_edge.yaml
+// targeting rules until the implementation reaches GA.
+var Alicloud = &alicloudInfo{}
+
+type alicloudInfo struct{}
+
+func (f *alicloudInfo) Value(ctx context.Context) bool {
+	return provider.BoolVariation(ctx, alicloudFlagName, false)
+}

--- a/pkg/feature/ff_edge.yaml
+++ b/pkg/feature/ff_edge.yaml
@@ -88,3 +88,10 @@ runtimeSecurityGcp:
     disabled: false
   defaultRule:
     variation: enabled
+
+alicloud:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: enabled

--- a/pkg/feature/ff_ga.yaml
+++ b/pkg/feature/ff_ga.yaml
@@ -112,3 +112,10 @@ runtimeSecurityGcp:
     disabled: false
   defaultRule:
     variation: disabled
+
+alicloud:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled


### PR DESCRIPTION
AliCloud feature flag. 
Disable all by default as this is initial support for AliCloud.
Enable on edge. 