### PR TITLE
fix(awsredis): delete shim UG after auth type swap

### DIFF
--- a/internal/controller/cloud-control/rediscluster_aws_test.go
+++ b/internal/controller/cloud-control/rediscluster_aws_test.go
@@ -8,13 +8,28 @@ import (
 	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	kcpiprange "github.com/kyma-project/cloud-manager/pkg/kcp/iprange"
+	awsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/client"
 	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	awsrediscluster "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/rediscluster"
 	kcpscope "github.com/kyma-project/cloud-manager/pkg/kcp/scope"
 	. "github.com/kyma-project/cloud-manager/pkg/testinfra/dsl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// isAuthChangingModify reports whether a recorded ModifyReplicationGroup
+// invocation touches any auth-related field (AuthTokenSecretString, or the
+// user-group attach/detach fields that AWS treats as an auth-flip via the
+// implicit AuthTokenUpdateStrategy=Delete on the real client). Used by the
+// detached-orphan backfill scenario to prove the reconciler issues no
+// auth-changing modify while cleaning up a legacy detached user group.
+func isAuthChangingModify(m awsclient.ModifyElastiCacheClusterOptions) bool {
+	return m.AuthTokenSecretString != nil ||
+		len(m.UserGroupIdsToAdd) > 0 ||
+		len(m.UserGroupIdsToRemove) > 0
+}
 
 var _ = Describe("Feature: KCP RedisCluster", func() {
 
@@ -149,6 +164,12 @@ var _ = Describe("Feature: KCP RedisCluster", func() {
 			Expect(redisCluster.Status.ReplicasPerShard).To(Equal(int32(readReplicas)))
 		})
 
+		By("And Then no transient user group was created (auth-enabled create path)", func() {
+			Expect(awsMock.CreateUserGroupCallCount()).To(Equal(0),
+				"expected zero CreateUserGroup calls on the auth-enabled create path, got %d",
+				awsMock.CreateUserGroupCallCount())
+		})
+
 		// DELETE
 
 		By("When RedisCluster is deleted", func() {
@@ -165,6 +186,326 @@ var _ = Describe("Feature: KCP RedisCluster", func() {
 			awsMock.DeleteAwsElastiCacheUserGroupByName(*awsElastiCacheClusterInstance.ReplicationGroupId)
 		})
 
+		By("Then RedisCluster does not exist", func() {
+			Eventually(IsDeleted, 5*time.Second).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisCluster).
+				Should(Succeed(), "expected RedisCluster not to exist (be deleted), but it still exists")
+		})
+	})
+
+	It("Scenario: KCP AWS RedisCluster downgrades auth (true -> false) via transient user group", func() {
+
+		awsAccount := infra.AwsMock().NewAccount()
+		defer awsAccount.Delete()
+
+		name := "15f363d9-d22d-408d-bc51-872d2f925133"
+		scope := &cloudcontrolv1beta1.Scope{}
+
+		By("Given Scope exists", func() {
+			kcpscope.Ignore.AddName(name)
+			Eventually(CreateScopeAws).
+				WithArguments(infra.Ctx(), infra, scope, awsAccount.AccountId(), WithName(name)).
+				Should(Succeed())
+		})
+
+		kcpIpRangeName := "86041363-3fda-4643-8cd5-75a871ba27e4"
+		kcpIpRange := &cloudcontrolv1beta1.IpRange{}
+		kcpiprange.Ignore.AddName(kcpIpRangeName)
+		By("And Given KCP IPRange exists", func() {
+			Eventually(CreateKcpIpRange).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), kcpIpRange,
+					WithName(kcpIpRangeName), WithScope(scope.Name)).
+				Should(Succeed())
+		})
+		By("And Given KCP IpRange has Ready condition", func() {
+			Eventually(UpdateStatus).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), kcpIpRange,
+					WithKcpIpRangeStatusCidr(kcpIpRange.Spec.Cidr),
+					WithConditions(KcpReadyCondition())).
+				Should(Succeed(), "Expected KCP IpRange to become ready")
+		})
+
+		redisCluster := &cloudcontrolv1beta1.RedisCluster{}
+		By("And Given RedisCluster is created with authEnabled=true", func() {
+			Eventually(CreateRedisCluster).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisCluster,
+					WithName(name),
+					WithRemoteRef("skr-redis-example-aws-downgrade"),
+					WithIpRange(kcpIpRangeName),
+					WithScope(name),
+					WithRedisClusterAws(),
+					WithKcpAwsCacheNodeType("cache.m5.large"),
+					WithKcpAwsEngineVersion("7.0"),
+					WithKcpAwsAutoMinorVersionUpgrade(true),
+					WithKcpAwsAuthEnabled(true),
+					WithKcpAwsShardCount(int32(3)),
+					WithKcpAwsReadReplicas(int32(1)),
+				).
+				Should(Succeed(), "failed creating RedisCluster")
+		})
+
+		awsMock := awsAccount.Region(scope.Spec.Region)
+
+		var awsElastiCacheClusterInstance *elasticachetypes.ReplicationGroup
+		By("And Given AWS Redis is created", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisCluster,
+					NewObjActions(),
+					HavingFieldSet("status", "id")).
+				Should(Succeed(), "expected RedisCluster to get status.id")
+			awsElastiCacheClusterInstance = awsMock.GetAwsElastiCacheByName(redisCluster.Status.Id)
+		})
+
+		By("And Given AWS Redis is Available", func() {
+			awsMock.SetAwsElastiCacheLifeCycleState(*awsElastiCacheClusterInstance.ReplicationGroupId, awsmeta.ElastiCache_AVAILABLE)
+		})
+
+		By("And Given RedisCluster has Ready condition", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisCluster,
+					NewObjActions(),
+					HavingConditionTrue(cloudcontrolv1beta1.ConditionTypeReady),
+					HavingState("Ready")).
+				Should(Succeed(), "expected RedisCluster to reach Ready before downgrade")
+		})
+
+		By("And Given no transient user group has been created yet", func() {
+			Expect(awsMock.CreateUserGroupCallCount()).To(Equal(0))
+		})
+
+		By("When RedisCluster spec.authEnabled flips to false", func() {
+			Eventually(UpdateRedisCluster).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisCluster,
+					WithKcpAwsAuthEnabled(false)).
+				Should(Succeed(), "failed flipping authEnabled to false")
+		})
+
+		expectedUGName := awsrediscluster.GetAwsElastiCacheUserGroupName(redisCluster.Name)
+
+		By("Then the transient user group is created and eventually reaches Active", func() {
+			Eventually(func() int {
+				return awsMock.CreateUserGroupCallCount()
+			}).Should(Equal(1), "expected exactly one CreateUserGroup call")
+			// Lock in at-most-once across subsequent reconcile passes.
+			Consistently(func() int {
+				return awsMock.CreateUserGroupCallCount()
+			}, 500*time.Millisecond).Should(Equal(1), "CreateUserGroup must be at-most-once")
+			awsMock.SetAwsElastiCacheUserGroupLifeCycleState(expectedUGName, awsmeta.ElastiCache_UserGroup_ACTIVE)
+		})
+
+		By("And Then the reconciler drives auth to disabled and the UG is detached", func() {
+			// AWS-side "modifying" needs to settle back to Available for the
+			// reconciler to make progress across passes.
+			Eventually(func() error {
+				awsMock.SetAwsElastiCacheLifeCycleState(*awsElastiCacheClusterInstance.ReplicationGroupId, awsmeta.ElastiCache_AVAILABLE)
+				rg := awsMock.GetAwsElastiCacheByName(*awsElastiCacheClusterInstance.ReplicationGroupId)
+				if ptr.Deref(rg.AuthTokenEnabled, true) {
+					return errors.New("AuthTokenEnabled still true")
+				}
+				if len(rg.UserGroupIds) != 0 {
+					return errors.New("UserGroupIds not empty yet")
+				}
+				return nil
+			}).Should(Succeed(), "expected AuthTokenEnabled=false and UserGroupIds=[]")
+		})
+
+		By("And Then the transient user group is deleted", func() {
+			Eventually(func() int {
+				return awsMock.DeleteUserGroupCallCount()
+			}).Should(Equal(1), "expected exactly one DeleteUserGroup call")
+			// Lock in at-most-once for DeleteUserGroup too.
+			Consistently(func() int {
+				return awsMock.DeleteUserGroupCallCount()
+			}, 500*time.Millisecond).Should(Equal(1), "DeleteUserGroup must be at-most-once")
+			// Reconciler waits for DELETING → gone; simulate final tombstone removal.
+			awsMock.DeleteAwsElastiCacheUserGroupByName(expectedUGName)
+		})
+
+		By("Then AWS call sequence is: Create, ModifyAdd, ModifyRemove, Delete — each exactly once", func() {
+			Expect(awsMock.CreateUserGroupCalls()).To(Equal([]string{expectedUGName}))
+			Expect(awsMock.DeleteUserGroupCalls()).To(Equal([]string{expectedUGName}))
+			modifies := awsMock.ModifyReplicationGroupCalls()
+			var addAt, removeAt int = -1, -1
+			for i, m := range modifies {
+				if len(m.UserGroupIdsToAdd) > 0 && addAt < 0 {
+					addAt = i
+					Expect(m.UserGroupIdsToAdd).To(Equal([]string{expectedUGName}))
+				}
+				if len(m.UserGroupIdsToRemove) > 0 && removeAt < 0 {
+					removeAt = i
+					Expect(m.UserGroupIdsToRemove).To(Equal([]string{expectedUGName}))
+				}
+			}
+			Expect(addAt).To(BeNumerically(">=", 0), "expected a ModifyReplicationGroup call adding the transient UG")
+			Expect(removeAt).To(BeNumerically(">", addAt), "Remove modify must occur strictly after Add modify")
+		})
+
+		By("And Then DescribeUserGroup(cm-<name>) returns not-found", func() {
+			Eventually(func() *elasticachetypes.UserGroup {
+				return awsMock.GetAwsElastiCacheUserGroupByName(expectedUGName)
+			}).Should(BeNil(), "user group must be gone from AWS inventory")
+		})
+
+		// Cleanup
+		By("When RedisCluster is deleted", func() {
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisCluster).
+				Should(Succeed(), "failed deleting RedisCluster")
+		})
+		By("And When AWS Redis state is deleted", func() {
+			awsMock.DeleteAwsElastiCacheByName(*awsElastiCacheClusterInstance.ReplicationGroupId)
+		})
+		By("Then RedisCluster does not exist", func() {
+			Eventually(IsDeleted, 5*time.Second).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisCluster).
+				Should(Succeed(), "expected RedisCluster not to exist (be deleted), but it still exists")
+		})
+	})
+
+	It("Scenario: KCP AWS RedisCluster with a detached-orphan user group backfills to zero", func() {
+		// Pre-fix legacy state: an auth-disabled Ready cluster with an
+		// existing detached cm-<name> user group. On the next reconcile the
+		// delete-side predicate must fire and drive the account to zero
+		// cm-<name> user groups.
+
+		awsAccount := infra.AwsMock().NewAccount()
+		defer awsAccount.Delete()
+
+		name := "6014090c-99e1-48e2-819b-0d07cb293109"
+		scope := &cloudcontrolv1beta1.Scope{}
+
+		By("Given Scope exists", func() {
+			kcpscope.Ignore.AddName(name)
+			Eventually(CreateScopeAws).
+				WithArguments(infra.Ctx(), infra, scope, awsAccount.AccountId(), WithName(name)).
+				Should(Succeed())
+		})
+
+		kcpIpRangeName := "86b69e36-16e1-47fa-b0f7-4ee6534e49f5"
+		kcpIpRange := &cloudcontrolv1beta1.IpRange{}
+		kcpiprange.Ignore.AddName(kcpIpRangeName)
+		By("And Given KCP IPRange exists", func() {
+			Eventually(CreateKcpIpRange).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), kcpIpRange,
+					WithName(kcpIpRangeName), WithScope(scope.Name)).
+				Should(Succeed())
+		})
+		By("And Given KCP IpRange has Ready condition", func() {
+			Eventually(UpdateStatus).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), kcpIpRange,
+					WithKcpIpRangeStatusCidr(kcpIpRange.Spec.Cidr),
+					WithConditions(KcpReadyCondition())).
+				Should(Succeed(), "Expected KCP IpRange to become ready")
+		})
+
+		redisCluster := &cloudcontrolv1beta1.RedisCluster{}
+		By("And Given RedisCluster is created with authEnabled=false", func() {
+			Eventually(CreateRedisCluster).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisCluster,
+					WithName(name),
+					WithRemoteRef("skr-redis-example-aws-orphan"),
+					WithIpRange(kcpIpRangeName),
+					WithScope(name),
+					WithRedisClusterAws(),
+					WithKcpAwsCacheNodeType("cache.m5.large"),
+					WithKcpAwsEngineVersion("7.0"),
+					WithKcpAwsAutoMinorVersionUpgrade(true),
+					WithKcpAwsAuthEnabled(false),
+					WithKcpAwsShardCount(int32(3)),
+					WithKcpAwsReadReplicas(int32(1)),
+				).
+				Should(Succeed(), "failed creating RedisCluster")
+		})
+
+		awsMock := awsAccount.Region(scope.Spec.Region)
+		expectedUGName := awsrediscluster.GetAwsElastiCacheUserGroupName(redisCluster.Name)
+
+		var awsElastiCacheClusterInstance *elasticachetypes.ReplicationGroup
+		By("And Given AWS Redis is created", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisCluster,
+					NewObjActions(),
+					HavingFieldSet("status", "id")).
+				Should(Succeed(), "expected RedisCluster to get status.id")
+			awsElastiCacheClusterInstance = awsMock.GetAwsElastiCacheByName(redisCluster.Status.Id)
+		})
+
+		By("And Given AWS Redis is Available", func() {
+			awsMock.SetAwsElastiCacheLifeCycleState(*awsElastiCacheClusterInstance.ReplicationGroupId, awsmeta.ElastiCache_AVAILABLE)
+		})
+
+		By("And Given RedisCluster reaches Ready (no user group involved yet)", func() {
+			// Establish the "auth-disabled Ready cluster" precondition BEFORE
+			// seeding the legacy orphan. Otherwise the delete-side predicate
+			// would fire during initial reconcile and block Ready until the
+			// orphan is cleaned up — inverting the scenario's semantics.
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisCluster,
+					NewObjActions(),
+					HavingConditionTrue(cloudcontrolv1beta1.ConditionTypeReady),
+					HavingState("Ready")).
+				Should(Succeed(), "expected RedisCluster to reach Ready before orphan is introduced")
+		})
+
+		var baselineDeleteCalls int
+		By("And Given we seed a detached legacy cm-<name> user group in Active status", func() {
+			// Simulate pre-fix state: the UG appears in the account (attached
+			// to nothing) after the cluster reached Ready.
+			awsMock.PreCreateUserGroup(expectedUGName, awsmeta.ElastiCache_UserGroup_ACTIVE)
+			baselineDeleteCalls = awsMock.DeleteUserGroupCallCount()
+		})
+
+		By("And When an annotation change triggers a reconcile", func() {
+			// The reconciler doesn't watch AWS-side state; a k8s-side change
+			// on the CR is what fires the watch event that picks up the
+			// newly-seeded orphan. Bumping an annotation is guaranteed to
+			// change resourceVersion and re-queue the object.
+			Eventually(func() error {
+				fresh := &cloudcontrolv1beta1.RedisCluster{}
+				if err := infra.KCP().Client().Get(infra.Ctx(),
+					client.ObjectKeyFromObject(redisCluster), fresh); err != nil {
+					return err
+				}
+				if fresh.Annotations == nil {
+					fresh.Annotations = map[string]string{}
+				}
+				fresh.Annotations["cloud-manager.kyma-project.io/orphan-backfill-test"] = "1"
+				return infra.KCP().Client().Update(infra.Ctx(), fresh)
+			}).Should(Succeed(), "failed touching RedisCluster to trigger reconcile")
+		})
+
+		By("Then reconciler deletes the detached orphan on the next reconcile", func() {
+			// Wait for the reconciler to observe the detached UG and issue Delete.
+			Eventually(func() int {
+				return awsMock.DeleteUserGroupCallCount()
+			}).Should(Equal(baselineDeleteCalls+1), "expected exactly one DeleteUserGroup call after orphan was introduced")
+			Consistently(func() int {
+				return awsMock.DeleteUserGroupCallCount()
+			}, 500*time.Millisecond).Should(Equal(baselineDeleteCalls+1), "backfill DeleteUserGroup must be at-most-once")
+
+			// No auth-changing modify was issued — this is pure backfill.
+			for _, m := range awsMock.ModifyReplicationGroupCalls() {
+				Expect(isAuthChangingModify(m)).To(BeFalse(),
+					"backfill must not issue an auth-changing modify, got %+v", m)
+			}
+		})
+
+		By("And Then final tombstone removal yields not-found", func() {
+			awsMock.DeleteAwsElastiCacheUserGroupByName(expectedUGName)
+			Eventually(func() *elasticachetypes.UserGroup {
+				return awsMock.GetAwsElastiCacheUserGroupByName(expectedUGName)
+			}).Should(BeNil())
+		})
+
+		// Cleanup
+		By("When RedisCluster is deleted", func() {
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisCluster).
+				Should(Succeed(), "failed deleting RedisCluster")
+		})
+		By("And When AWS Redis state is deleted", func() {
+			awsMock.DeleteAwsElastiCacheByName(*awsElastiCacheClusterInstance.ReplicationGroupId)
+		})
 		By("Then RedisCluster does not exist", func() {
 			Eventually(IsDeleted, 5*time.Second).
 				WithArguments(infra.Ctx(), infra.KCP().Client(), redisCluster).

--- a/internal/controller/cloud-control/rediscluster_aws_test.go
+++ b/internal/controller/cloud-control/rediscluster_aws_test.go
@@ -325,7 +325,7 @@ var _ = Describe("Feature: KCP RedisCluster", func() {
 			Expect(awsMock.CreateUserGroupCalls()).To(Equal([]string{expectedUGName}))
 			Expect(awsMock.DeleteUserGroupCalls()).To(Equal([]string{expectedUGName}))
 			modifies := awsMock.ModifyReplicationGroupCalls()
-			var addAt, removeAt int = -1, -1
+			var addAt, removeAt = -1, -1
 			for i, m := range modifies {
 				if len(m.UserGroupIdsToAdd) > 0 && addAt < 0 {
 					addAt = i

--- a/internal/controller/cloud-control/redisinstance_aws_test.go
+++ b/internal/controller/cloud-control/redisinstance_aws_test.go
@@ -9,11 +9,13 @@ import (
 	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
 	kcpiprange "github.com/kyma-project/cloud-manager/pkg/kcp/iprange"
 	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	awsredisinstance "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/redisinstance"
 	kcpscope "github.com/kyma-project/cloud-manager/pkg/kcp/scope"
 	. "github.com/kyma-project/cloud-manager/pkg/testinfra/dsl"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Feature: KCP RedisInstance", func() {
@@ -147,6 +149,12 @@ var _ = Describe("Feature: KCP RedisInstance", func() {
 			Expect(redisInstance.Status.ReplicaCount).To(Equal(int32(readReplicas)))
 		})
 
+		By("And Then no transient user group was created (auth-enabled create path)", func() {
+			Expect(awsMock.CreateUserGroupCallCount()).To(Equal(0),
+				"expected zero CreateUserGroup calls on the auth-enabled create path, got %d",
+				awsMock.CreateUserGroupCallCount())
+		})
+
 		// DELETE
 
 		By("When RedisInstance is deleted", func() {
@@ -163,6 +171,306 @@ var _ = Describe("Feature: KCP RedisInstance", func() {
 			awsMock.DeleteAwsElastiCacheUserGroupByName(*awsElastiCacheClusterInstance.ReplicationGroupId)
 		})
 
+		By("Then RedisInstance does not exist", func() {
+			Eventually(IsDeleted, 5*time.Second).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance).
+				Should(Succeed(), "expected RedisInstance not to exist (be deleted), but it still exists")
+		})
+	})
+
+	It("Scenario: KCP AWS RedisInstance downgrades auth (true -> false) via transient user group", func() {
+
+		awsAccount := infra.AwsMock().NewAccount()
+		defer awsAccount.Delete()
+
+		name := "f96812fd-7059-4a44-a63f-ce466e37b926"
+		scope := &cloudcontrolv1beta1.Scope{}
+
+		By("Given Scope exists", func() {
+			kcpscope.Ignore.AddName(name)
+			Eventually(CreateScopeAws).
+				WithArguments(infra.Ctx(), infra, scope, awsAccount.AccountId(), WithName(name)).
+				Should(Succeed())
+		})
+
+		kcpIpRangeName := "ac2a41f5-874b-456c-bf50-0b04d30b56f4"
+		kcpIpRange := &cloudcontrolv1beta1.IpRange{}
+		kcpiprange.Ignore.AddName(kcpIpRangeName)
+		By("And Given KCP IPRange exists", func() {
+			Eventually(CreateKcpIpRange).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), kcpIpRange,
+					WithName(kcpIpRangeName), WithScope(scope.Name)).
+				Should(Succeed())
+		})
+		By("And Given KCP IpRange has Ready condition", func() {
+			Eventually(UpdateStatus).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), kcpIpRange,
+					WithKcpIpRangeStatusCidr(kcpIpRange.Spec.Cidr),
+					WithConditions(KcpReadyCondition())).
+				Should(Succeed(), "Expected KCP IpRange to become ready")
+		})
+
+		redisInstance := &cloudcontrolv1beta1.RedisInstance{}
+		By("And Given RedisInstance is created with authEnabled=true", func() {
+			Eventually(CreateRedisInstance).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance,
+					WithName(name),
+					WithRemoteRef("skr-redis-example-aws-downgrade"),
+					WithIpRange(kcpIpRangeName),
+					WithScope(name),
+					WithRedisInstanceAws(),
+					WithKcpAwsCacheNodeType("cache.m5.large"),
+					WithKcpAwsEngineVersion("7.0"),
+					WithKcpAwsAutoMinorVersionUpgrade(true),
+					WithKcpAwsAuthEnabled(true),
+					WithKcpAwsReadReplicas(int32(1)),
+				).
+				Should(Succeed(), "failed creating RedisInstance")
+		})
+
+		awsMock := awsAccount.Region(scope.Spec.Region)
+
+		var awsElastiCacheClusterInstance *elasticachetypes.ReplicationGroup
+		By("And Given AWS Redis is created", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance,
+					NewObjActions(),
+					HavingFieldSet("status", "id")).
+				Should(Succeed(), "expected RedisInstance to get status.id")
+			awsElastiCacheClusterInstance = awsMock.GetAwsElastiCacheByName(redisInstance.Status.Id)
+		})
+
+		By("And Given AWS Redis is Available", func() {
+			awsMock.SetAwsElastiCacheLifeCycleState(*awsElastiCacheClusterInstance.ReplicationGroupId, awsmeta.ElastiCache_AVAILABLE)
+		})
+
+		By("And Given RedisInstance has Ready condition", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance,
+					NewObjActions(),
+					HavingConditionTrue(cloudcontrolv1beta1.ConditionTypeReady),
+					HavingState("Ready")).
+				Should(Succeed(), "expected RedisInstance to reach Ready before downgrade")
+		})
+
+		By("And Given no transient user group has been created yet", func() {
+			Expect(awsMock.CreateUserGroupCallCount()).To(Equal(0))
+		})
+
+		By("When RedisInstance spec.authEnabled flips to false", func() {
+			Eventually(UpdateRedisInstance).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance,
+					WithKcpAwsAuthEnabled(false)).
+				Should(Succeed(), "failed flipping authEnabled to false")
+		})
+
+		expectedUGName := awsredisinstance.GetAwsElastiCacheUserGroupName(redisInstance.Name)
+
+		By("Then the transient user group is created and eventually reaches Active", func() {
+			Eventually(func() int {
+				return awsMock.CreateUserGroupCallCount()
+			}).Should(Equal(1), "expected exactly one CreateUserGroup call")
+			Consistently(func() int {
+				return awsMock.CreateUserGroupCallCount()
+			}, 500*time.Millisecond).Should(Equal(1), "CreateUserGroup must be at-most-once")
+			awsMock.SetAwsElastiCacheUserGroupLifeCycleState(expectedUGName, awsmeta.ElastiCache_UserGroup_ACTIVE)
+		})
+
+		By("And Then the reconciler drives auth to disabled and the UG is detached", func() {
+			Eventually(func() error {
+				awsMock.SetAwsElastiCacheLifeCycleState(*awsElastiCacheClusterInstance.ReplicationGroupId, awsmeta.ElastiCache_AVAILABLE)
+				rg := awsMock.GetAwsElastiCacheByName(*awsElastiCacheClusterInstance.ReplicationGroupId)
+				if ptr.Deref(rg.AuthTokenEnabled, true) {
+					return errors.New("AuthTokenEnabled still true")
+				}
+				if len(rg.UserGroupIds) != 0 {
+					return errors.New("UserGroupIds not empty yet")
+				}
+				return nil
+			}).Should(Succeed(), "expected AuthTokenEnabled=false and UserGroupIds=[]")
+		})
+
+		By("And Then the transient user group is deleted", func() {
+			Eventually(func() int {
+				return awsMock.DeleteUserGroupCallCount()
+			}).Should(Equal(1), "expected exactly one DeleteUserGroup call")
+			Consistently(func() int {
+				return awsMock.DeleteUserGroupCallCount()
+			}, 500*time.Millisecond).Should(Equal(1), "DeleteUserGroup must be at-most-once")
+			awsMock.DeleteAwsElastiCacheUserGroupByName(expectedUGName)
+		})
+
+		By("Then AWS call sequence is: Create, ModifyAdd, ModifyRemove, Delete — each exactly once", func() {
+			Expect(awsMock.CreateUserGroupCalls()).To(Equal([]string{expectedUGName}))
+			Expect(awsMock.DeleteUserGroupCalls()).To(Equal([]string{expectedUGName}))
+			modifies := awsMock.ModifyReplicationGroupCalls()
+			var addAt, removeAt int = -1, -1
+			for i, m := range modifies {
+				if len(m.UserGroupIdsToAdd) > 0 && addAt < 0 {
+					addAt = i
+					Expect(m.UserGroupIdsToAdd).To(Equal([]string{expectedUGName}))
+				}
+				if len(m.UserGroupIdsToRemove) > 0 && removeAt < 0 {
+					removeAt = i
+					Expect(m.UserGroupIdsToRemove).To(Equal([]string{expectedUGName}))
+				}
+			}
+			Expect(addAt).To(BeNumerically(">=", 0), "expected a ModifyReplicationGroup call adding the transient UG")
+			Expect(removeAt).To(BeNumerically(">", addAt), "Remove modify must occur strictly after Add modify")
+		})
+
+		By("And Then DescribeUserGroup(cm-<name>) returns not-found", func() {
+			Eventually(func() *elasticachetypes.UserGroup {
+				return awsMock.GetAwsElastiCacheUserGroupByName(expectedUGName)
+			}).Should(BeNil(), "user group must be gone from AWS inventory")
+		})
+
+		// Cleanup
+		By("When RedisInstance is deleted", func() {
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance).
+				Should(Succeed(), "failed deleting RedisInstance")
+		})
+		By("And When AWS Redis state is deleted", func() {
+			awsMock.DeleteAwsElastiCacheByName(*awsElastiCacheClusterInstance.ReplicationGroupId)
+		})
+		By("Then RedisInstance does not exist", func() {
+			Eventually(IsDeleted, 5*time.Second).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance).
+				Should(Succeed(), "expected RedisInstance not to exist (be deleted), but it still exists")
+		})
+	})
+
+	It("Scenario: KCP AWS RedisInstance with a detached-orphan user group backfills to zero", func() {
+
+		awsAccount := infra.AwsMock().NewAccount()
+		defer awsAccount.Delete()
+
+		name := "99dfd834-54c5-4e96-b6ac-82cc6a3b7c5f"
+		scope := &cloudcontrolv1beta1.Scope{}
+
+		By("Given Scope exists", func() {
+			kcpscope.Ignore.AddName(name)
+			Eventually(CreateScopeAws).
+				WithArguments(infra.Ctx(), infra, scope, awsAccount.AccountId(), WithName(name)).
+				Should(Succeed())
+		})
+
+		kcpIpRangeName := "5c5438d7-50d0-428b-a5b1-34382bc7b30d"
+		kcpIpRange := &cloudcontrolv1beta1.IpRange{}
+		kcpiprange.Ignore.AddName(kcpIpRangeName)
+		By("And Given KCP IPRange exists", func() {
+			Eventually(CreateKcpIpRange).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), kcpIpRange,
+					WithName(kcpIpRangeName), WithScope(scope.Name)).
+				Should(Succeed())
+		})
+		By("And Given KCP IpRange has Ready condition", func() {
+			Eventually(UpdateStatus).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), kcpIpRange,
+					WithKcpIpRangeStatusCidr(kcpIpRange.Spec.Cidr),
+					WithConditions(KcpReadyCondition())).
+				Should(Succeed(), "Expected KCP IpRange to become ready")
+		})
+
+		redisInstance := &cloudcontrolv1beta1.RedisInstance{}
+		By("And Given RedisInstance is created with authEnabled=false", func() {
+			Eventually(CreateRedisInstance).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance,
+					WithName(name),
+					WithRemoteRef("skr-redis-example-aws-orphan"),
+					WithIpRange(kcpIpRangeName),
+					WithScope(name),
+					WithRedisInstanceAws(),
+					WithKcpAwsCacheNodeType("cache.m5.large"),
+					WithKcpAwsEngineVersion("7.0"),
+					WithKcpAwsAutoMinorVersionUpgrade(true),
+					WithKcpAwsAuthEnabled(false),
+					WithKcpAwsReadReplicas(int32(1)),
+				).
+				Should(Succeed(), "failed creating RedisInstance")
+		})
+
+		awsMock := awsAccount.Region(scope.Spec.Region)
+		expectedUGName := awsredisinstance.GetAwsElastiCacheUserGroupName(redisInstance.Name)
+
+		var awsElastiCacheClusterInstance *elasticachetypes.ReplicationGroup
+		By("And Given AWS Redis is created", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance,
+					NewObjActions(),
+					HavingFieldSet("status", "id")).
+				Should(Succeed(), "expected RedisInstance to get status.id")
+			awsElastiCacheClusterInstance = awsMock.GetAwsElastiCacheByName(redisInstance.Status.Id)
+		})
+
+		By("And Given AWS Redis is Available", func() {
+			awsMock.SetAwsElastiCacheLifeCycleState(*awsElastiCacheClusterInstance.ReplicationGroupId, awsmeta.ElastiCache_AVAILABLE)
+		})
+
+		By("And Given RedisInstance reaches Ready (no user group involved yet)", func() {
+			Eventually(LoadAndCheck).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance,
+					NewObjActions(),
+					HavingConditionTrue(cloudcontrolv1beta1.ConditionTypeReady),
+					HavingState("Ready")).
+				Should(Succeed(), "expected RedisInstance to reach Ready before orphan is introduced")
+		})
+
+		var baselineDeleteCalls int
+		By("And Given we seed a detached legacy cm-<name> user group in Active status", func() {
+			awsMock.PreCreateUserGroup(expectedUGName, awsmeta.ElastiCache_UserGroup_ACTIVE)
+			baselineDeleteCalls = awsMock.DeleteUserGroupCallCount()
+		})
+
+		By("And When an annotation change triggers a reconcile", func() {
+			// The reconciler doesn't watch AWS-side state; a k8s-side change
+			// on the CR is what fires the watch event that picks up the
+			// newly-seeded orphan.
+			Eventually(func() error {
+				fresh := &cloudcontrolv1beta1.RedisInstance{}
+				if err := infra.KCP().Client().Get(infra.Ctx(),
+					client.ObjectKeyFromObject(redisInstance), fresh); err != nil {
+					return err
+				}
+				if fresh.Annotations == nil {
+					fresh.Annotations = map[string]string{}
+				}
+				fresh.Annotations["cloud-manager.kyma-project.io/orphan-backfill-test"] = "1"
+				return infra.KCP().Client().Update(infra.Ctx(), fresh)
+			}).Should(Succeed(), "failed touching RedisInstance to trigger reconcile")
+		})
+
+		By("Then reconciler deletes the detached orphan on the next reconcile", func() {
+			Eventually(func() int {
+				return awsMock.DeleteUserGroupCallCount()
+			}).Should(Equal(baselineDeleteCalls+1), "expected exactly one DeleteUserGroup call after orphan was introduced")
+			Consistently(func() int {
+				return awsMock.DeleteUserGroupCallCount()
+			}, 500*time.Millisecond).Should(Equal(baselineDeleteCalls+1), "backfill DeleteUserGroup must be at-most-once")
+
+			for _, m := range awsMock.ModifyReplicationGroupCalls() {
+				Expect(isAuthChangingModify(m)).To(BeFalse(),
+					"backfill must not issue an auth-changing modify, got %+v", m)
+			}
+		})
+
+		By("And Then final tombstone removal yields not-found", func() {
+			awsMock.DeleteAwsElastiCacheUserGroupByName(expectedUGName)
+			Eventually(func() *elasticachetypes.UserGroup {
+				return awsMock.GetAwsElastiCacheUserGroupByName(expectedUGName)
+			}).Should(BeNil())
+		})
+
+		// Cleanup
+		By("When RedisInstance is deleted", func() {
+			Eventually(Delete).
+				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance).
+				Should(Succeed(), "failed deleting RedisInstance")
+		})
+		By("And When AWS Redis state is deleted", func() {
+			awsMock.DeleteAwsElastiCacheByName(*awsElastiCacheClusterInstance.ReplicationGroupId)
+		})
 		By("Then RedisInstance does not exist", func() {
 			Eventually(IsDeleted, 5*time.Second).
 				WithArguments(infra.Ctx(), infra.KCP().Client(), redisInstance).

--- a/internal/controller/cloud-control/redisinstance_aws_test.go
+++ b/internal/controller/cloud-control/redisinstance_aws_test.go
@@ -304,7 +304,7 @@ var _ = Describe("Feature: KCP RedisInstance", func() {
 			Expect(awsMock.CreateUserGroupCalls()).To(Equal([]string{expectedUGName}))
 			Expect(awsMock.DeleteUserGroupCalls()).To(Equal([]string{expectedUGName}))
 			modifies := awsMock.ModifyReplicationGroupCalls()
-			var addAt, removeAt int = -1, -1
+			var addAt, removeAt = -1, -1
 			for i, m := range modifies {
 				if len(m.UserGroupIdsToAdd) > 0 && addAt < 0 {
 					addAt = i

--- a/pkg/kcp/provider/aws/mock/elastiCacheClientFake.go
+++ b/pkg/kcp/provider/aws/mock/elastiCacheClientFake.go
@@ -27,6 +27,18 @@ type AwsElastiCacheMockUtils interface {
 	DeleteAwsElastiCacheByName(name string)
 	DeleteAwsElastiCacheUserGroupByName(name string)
 	DescribeAwsElastiCacheParametersByName(groupName string) map[string]string
+
+	CreateUserGroupCallCount() int
+	DeleteUserGroupCallCount() int
+	CreateUserGroupCalls() []string
+	DeleteUserGroupCalls() []string
+	ModifyReplicationGroupCalls() []awsclient.ModifyElastiCacheClusterOptions
+
+	// PreCreateUserGroup seeds a user group in the given status, simulating
+	// pre-fix legacy state for backfill tests.
+	PreCreateUserGroup(name string, state awsmeta.ElastiCacheUserGroupState)
+
+	GetAwsElastiCacheUserGroupByName(name string) *elasticachetypes.UserGroup
 }
 
 func getDefaultParams() map[string]elasticachetypes.Parameter {
@@ -60,6 +72,10 @@ type elastiCacheClientFake struct {
 	userGroups        map[string]*elasticachetypes.UserGroup
 	secretStore       map[string]*secretsmanager.GetSecretValueOutput
 	securityGroups    []*ec2types.SecurityGroup
+
+	createUserGroupCalls        []string
+	deleteUserGroupCalls        []string
+	modifyReplicationGroupCalls []awsclient.ModifyElastiCacheClusterOptions
 }
 
 func newElastiCacheClientFake() *elastiCacheClientFake {
@@ -115,6 +131,63 @@ func (client *elastiCacheClientFake) DeleteAwsElastiCacheUserGroupByName(name st
 	defer client.mutex.Unlock()
 
 	delete(client.userGroups, name)
+}
+
+func (client *elastiCacheClientFake) CreateUserGroupCallCount() int {
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
+	return len(client.createUserGroupCalls)
+}
+
+func (client *elastiCacheClientFake) DeleteUserGroupCallCount() int {
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
+	return len(client.deleteUserGroupCalls)
+}
+
+// CreateUserGroupCalls returns a copy of the recorded ids, preserving invocation order.
+func (client *elastiCacheClientFake) CreateUserGroupCalls() []string {
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
+	out := make([]string, len(client.createUserGroupCalls))
+	copy(out, client.createUserGroupCalls)
+	return out
+}
+
+// DeleteUserGroupCalls returns a copy of the recorded ids, preserving invocation order.
+func (client *elastiCacheClientFake) DeleteUserGroupCalls() []string {
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
+	out := make([]string, len(client.deleteUserGroupCalls))
+	copy(out, client.deleteUserGroupCalls)
+	return out
+}
+
+// ModifyReplicationGroupCalls returns a copy of the recorded options, preserving invocation order.
+func (client *elastiCacheClientFake) ModifyReplicationGroupCalls() []awsclient.ModifyElastiCacheClusterOptions {
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
+	out := make([]awsclient.ModifyElastiCacheClusterOptions, len(client.modifyReplicationGroupCalls))
+	copy(out, client.modifyReplicationGroupCalls)
+	return out
+}
+
+func (client *elastiCacheClientFake) PreCreateUserGroup(name string, state awsmeta.ElastiCacheUserGroupState) {
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
+
+	client.userGroups[name] = &elasticachetypes.UserGroup{
+		Engine:      new("redis"),
+		UserGroupId: new(name),
+		Status:      new(state),
+		UserIds:     []string{"default"},
+	}
+}
+
+func (client *elastiCacheClientFake) GetAwsElastiCacheUserGroupByName(name string) *elasticachetypes.UserGroup {
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
+	return client.userGroups[name]
 }
 
 func (client *elastiCacheClientFake) DescribeAwsElastiCacheParametersByName(groupName string) map[string]string {
@@ -400,6 +473,8 @@ func (client *elastiCacheClientFake) ModifyElastiCacheReplicationGroup(ctx conte
 	client.mutex.Lock()
 	defer client.mutex.Unlock()
 
+	client.modifyReplicationGroupCalls = append(client.modifyReplicationGroupCalls, options)
+
 	if instance, ok := client.replicationGroups[id]; ok {
 		instance.Status = new("modifying")
 		if options.CacheNodeType != nil {
@@ -509,6 +584,7 @@ func (client *elastiCacheClientFake) CreateUserGroup(ctx context.Context, id str
 	client.mutex.Lock()
 	defer client.mutex.Unlock()
 
+	client.createUserGroupCalls = append(client.createUserGroupCalls, id)
 	client.userGroups[id] = &elasticachetypes.UserGroup{
 		Engine:      new("redis"),
 		UserGroupId: new(id),
@@ -527,6 +603,7 @@ func (client *elastiCacheClientFake) DeleteUserGroup(ctx context.Context, id str
 	client.mutex.Lock()
 	defer client.mutex.Unlock()
 
+	client.deleteUserGroupCalls = append(client.deleteUserGroupCalls, id)
 	if instance, ok := client.userGroups[id]; ok {
 		instance.Status = new("deleting")
 	}

--- a/pkg/kcp/provider/aws/mock/elastiCacheClientFake_test.go
+++ b/pkg/kcp/provider/aws/mock/elastiCacheClientFake_test.go
@@ -1,0 +1,85 @@
+package mock
+
+import (
+	"context"
+	"testing"
+
+	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	awsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+// This suite locks the mock's semantics around auth-flip modifications so
+// controller-test assertions have a reliable substrate. The real AWS client
+// sets AuthTokenUpdateStrategy=Delete whenever UserGroupIdsToAdd is present,
+// so the fake must flip AuthTokenEnabled to false in the same request. On
+// the reverse (UserGroupIdsToRemove), auth stays as-is.
+func TestElastiCacheFake_AuthTokenPropagation(t *testing.T) {
+	newFakeWithAuthEnabledRG := func(name string) *elastiCacheClientFake {
+		client := newElastiCacheClientFake()
+		client.replicationGroups[name] = &elasticachetypes.ReplicationGroup{
+			ReplicationGroupId: ptr.To(name),
+			AuthTokenEnabled:   ptr.To(true),
+			UserGroupIds:       []string{},
+		}
+		return client
+	}
+
+	t.Run("Add path flips AuthTokenEnabled to false and attaches UG (downgrade)", func(t *testing.T) {
+		ctx := context.Background()
+		client := newFakeWithAuthEnabledRG("cm-test")
+
+		_, err := client.ModifyElastiCacheReplicationGroup(ctx, "cm-test", awsclient.ModifyElastiCacheClusterOptions{
+			UserGroupIdsToAdd: []string{"cm-test"},
+		})
+
+		require.NoError(t, err)
+		rg := client.GetAwsElastiCacheByName("cm-test")
+		assert.False(t, ptr.Deref(rg.AuthTokenEnabled, true),
+			"AuthTokenEnabled must flip to false when a user group is added (AuthTokenUpdateStrategy=Delete on the real client)")
+		assert.Equal(t, []string{"cm-test"}, rg.UserGroupIds)
+	})
+
+	t.Run("Remove path detaches UG without altering AuthTokenEnabled", func(t *testing.T) {
+		ctx := context.Background()
+		// Seed AuthTokenEnabled=true to prove non-mutation: if Remove wrongly
+		// touched the field, the assertion below would fail.
+		client := newElastiCacheClientFake()
+		client.replicationGroups["cm-test"] = &elasticachetypes.ReplicationGroup{
+			ReplicationGroupId: ptr.To("cm-test"),
+			AuthTokenEnabled:   ptr.To(true),
+			UserGroupIds:       []string{"cm-test"},
+		}
+
+		_, err := client.ModifyElastiCacheReplicationGroup(ctx, "cm-test", awsclient.ModifyElastiCacheClusterOptions{
+			UserGroupIdsToRemove: []string{"cm-test"},
+		})
+
+		require.NoError(t, err)
+		rg := client.GetAwsElastiCacheByName("cm-test")
+		assert.Empty(t, rg.UserGroupIds, "UG must be detached")
+		assert.True(t, ptr.Deref(rg.AuthTokenEnabled, false),
+			"AuthTokenEnabled must remain true — Remove must not mutate the auth flag")
+	})
+
+	t.Run("ModifyReplicationGroupCalls records each invocation in order", func(t *testing.T) {
+		ctx := context.Background()
+		client := newFakeWithAuthEnabledRG("cm-test")
+
+		_, err := client.ModifyElastiCacheReplicationGroup(ctx, "cm-test", awsclient.ModifyElastiCacheClusterOptions{
+			UserGroupIdsToAdd: []string{"cm-test"},
+		})
+		require.NoError(t, err)
+		_, err = client.ModifyElastiCacheReplicationGroup(ctx, "cm-test", awsclient.ModifyElastiCacheClusterOptions{
+			UserGroupIdsToRemove: []string{"cm-test"},
+		})
+		require.NoError(t, err)
+
+		calls := client.ModifyReplicationGroupCalls()
+		require.Len(t, calls, 2)
+		assert.Equal(t, []string{"cm-test"}, calls[0].UserGroupIdsToAdd)
+		assert.Equal(t, []string{"cm-test"}, calls[1].UserGroupIdsToRemove)
+	})
+}

--- a/pkg/kcp/provider/aws/mock/elastiCacheClientFake_test.go
+++ b/pkg/kcp/provider/aws/mock/elastiCacheClientFake_test.go
@@ -20,8 +20,8 @@ func TestElastiCacheFake_AuthTokenPropagation(t *testing.T) {
 	newFakeWithAuthEnabledRG := func(name string) *elastiCacheClientFake {
 		client := newElastiCacheClientFake()
 		client.replicationGroups[name] = &elasticachetypes.ReplicationGroup{
-			ReplicationGroupId: ptr.To(name),
-			AuthTokenEnabled:   ptr.To(true),
+			ReplicationGroupId: new(name),
+			AuthTokenEnabled:   new(true),
 			UserGroupIds:       []string{},
 		}
 		return client
@@ -48,8 +48,8 @@ func TestElastiCacheFake_AuthTokenPropagation(t *testing.T) {
 		// touched the field, the assertion below would fail.
 		client := newElastiCacheClientFake()
 		client.replicationGroups["cm-test"] = &elasticachetypes.ReplicationGroup{
-			ReplicationGroupId: ptr.To("cm-test"),
-			AuthTokenEnabled:   ptr.To(true),
+			ReplicationGroupId: new("cm-test"),
+			AuthTokenEnabled:   new(true),
 			UserGroupIds:       []string{"cm-test"},
 		}
 

--- a/pkg/kcp/provider/aws/rediscluster/deleteUserGroup.go
+++ b/pkg/kcp/provider/aws/rediscluster/deleteUserGroup.go
@@ -21,6 +21,15 @@ func deleteUserGroup(ctx context.Context, st composed.State) (error, context.Con
 	if userGroupState == awsmeta.ElastiCache_UserGroup_DELETING {
 		return nil, ctx
 	}
+	// Defensive guard against a fresh-create → downgrade race: if the transient
+	// user group was just created (predicate fired) and hasn't reached ACTIVE
+	// yet, AWS rejects DeleteUserGroup on a CREATING resource and lands the
+	// cluster in an error state. Wait for the status to settle before
+	// attempting the delete.
+	if userGroupState == awsmeta.ElastiCache_UserGroup_CREATING {
+		logger.Info("User group is still CREATING, requeueing before delete")
+		return composed.StopWithRequeueDelay(util.Timing.T10000ms()), nil
+	}
 
 	logger.Info("Deleting userGroup")
 

--- a/pkg/kcp/provider/aws/rediscluster/guards_test.go
+++ b/pkg/kcp/provider/aws/rediscluster/guards_test.go
@@ -38,7 +38,7 @@ var _ awsclient.ElastiCacheClient = &elastiCacheStub{}
 
 func (s *elastiCacheStub) CreateUserGroup(ctx context.Context, id string, tags []elasticachetypes.Tag) (*elasticache.CreateUserGroupOutput, error) {
 	s.createUserGroupCalls = append(s.createUserGroupCalls, id)
-	return &elasticache.CreateUserGroupOutput{UserGroupId: ptr.To(id)}, nil
+	return &elasticache.CreateUserGroupOutput{UserGroupId: new(id)}, nil
 }
 
 func (s *elastiCacheStub) DeleteUserGroup(ctx context.Context, id string) error {
@@ -137,7 +137,7 @@ func newTestStateWithClient(t *testing.T, clusterName string, ug *elasticachetyp
 func TestCreateUserGroupGuard_UGAlreadyPresent(t *testing.T) {
 	stub := newElastiCacheStub()
 	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
-		UserGroupId: ptr.To("cm-abc"),
+		UserGroupId: new("cm-abc"),
 		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
 	}, stub)
 
@@ -160,7 +160,7 @@ func TestDeleteUserGroupGuard_UGNil(t *testing.T) {
 func TestDeleteUserGroupGuard_UGDeleting(t *testing.T) {
 	stub := newElastiCacheStub()
 	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
-		UserGroupId: ptr.To("cm-abc"),
+		UserGroupId: new("cm-abc"),
 		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_DELETING)),
 	}, stub)
 
@@ -176,7 +176,7 @@ func TestDeleteUserGroupGuard_UGDeleting(t *testing.T) {
 func TestDeleteUserGroupGuard_UGCreating(t *testing.T) {
 	stub := newElastiCacheStub()
 	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
-		UserGroupId: ptr.To("cm-abc"),
+		UserGroupId: new("cm-abc"),
 		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_CREATING)),
 	}, stub)
 
@@ -216,7 +216,7 @@ func TestLoadUserGroup_ForeignNameUntouched(t *testing.T) {
 	// Pre-seed a foreign UG that must not be affected.
 	foreignName := "cm-different-cluster"
 	foreignUG := &elasticachetypes.UserGroup{
-		UserGroupId: ptr.To(foreignName),
+		UserGroupId: new(foreignName),
 		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
 	}
 	stub.preloadedUserGroups[foreignName] = foreignUG
@@ -224,7 +224,7 @@ func TestLoadUserGroup_ForeignNameUntouched(t *testing.T) {
 	// Also pre-seed our expected name so the load succeeds.
 	ourName := GetAwsElastiCacheUserGroupName("abc")
 	stub.preloadedUserGroups[ourName] = &elasticachetypes.UserGroup{
-		UserGroupId: ptr.To(ourName),
+		UserGroupId: new(ourName),
 		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
 	}
 
@@ -256,7 +256,7 @@ func TestDeleteUserGroupGuard_ProceedsWhenActive(t *testing.T) {
 	stub := newElastiCacheStub()
 	id := GetAwsElastiCacheUserGroupName("abc")
 	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
-		UserGroupId: ptr.To(id),
+		UserGroupId: new(id),
 		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
 	}, stub)
 

--- a/pkg/kcp/provider/aws/rediscluster/guards_test.go
+++ b/pkg/kcp/provider/aws/rediscluster/guards_test.go
@@ -1,0 +1,267 @@
+package rediscluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	secretsmanagertypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	awsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/client"
+	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+)
+
+// elastiCacheStub is a minimal awsclient.ElastiCacheClient implementation for
+// action-guard unit tests. Only the methods the guards can plausibly call are
+// implemented; every other method panics ("unimplemented") so that if a
+// guard's early-return path is broken and a call slips through, the test
+// fails loudly instead of silently accepting a zero-return.
+type elastiCacheStub struct {
+	createUserGroupCalls   []string
+	deleteUserGroupCalls   []string
+	describeUserGroupCalls []string
+	// preloadedUserGroups: DescribeUserGroup will return these unchanged.
+	// Used to prove foreign UG names remain untouched.
+	preloadedUserGroups map[string]*elasticachetypes.UserGroup
+}
+
+func newElastiCacheStub() *elastiCacheStub {
+	return &elastiCacheStub{preloadedUserGroups: map[string]*elasticachetypes.UserGroup{}}
+}
+
+var _ awsclient.ElastiCacheClient = &elastiCacheStub{}
+
+func (s *elastiCacheStub) CreateUserGroup(ctx context.Context, id string, tags []elasticachetypes.Tag) (*elasticache.CreateUserGroupOutput, error) {
+	s.createUserGroupCalls = append(s.createUserGroupCalls, id)
+	return &elasticache.CreateUserGroupOutput{UserGroupId: ptr.To(id)}, nil
+}
+
+func (s *elastiCacheStub) DeleteUserGroup(ctx context.Context, id string) error {
+	s.deleteUserGroupCalls = append(s.deleteUserGroupCalls, id)
+	return nil
+}
+
+func (s *elastiCacheStub) DescribeUserGroup(ctx context.Context, id string) (*elasticachetypes.UserGroup, error) {
+	s.describeUserGroupCalls = append(s.describeUserGroupCalls, id)
+	return s.preloadedUserGroups[id], nil
+}
+
+// All remaining methods must panic — the guards under test should never
+// reach them. A silent nil return would mask a broken guard.
+func (s *elastiCacheStub) DescribeElastiCacheSubnetGroup(ctx context.Context, name string) ([]elasticachetypes.CacheSubnetGroup, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) CreateElastiCacheSubnetGroup(ctx context.Context, name string, subnetIds []string, tags []elasticachetypes.Tag) (*elasticache.CreateCacheSubnetGroupOutput, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DeleteElastiCacheSubnetGroup(ctx context.Context, name string) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DescribeElastiCacheParameterGroup(ctx context.Context, name string) ([]elasticachetypes.CacheParameterGroup, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) CreateElastiCacheParameterGroup(ctx context.Context, name, family string, tags []elasticachetypes.Tag) (*elasticache.CreateCacheParameterGroupOutput, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DeleteElastiCacheParameterGroup(ctx context.Context, name string) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DescribeElastiCacheParameters(ctx context.Context, groupName string) ([]elasticachetypes.Parameter, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) ModifyElastiCacheParameterGroup(ctx context.Context, groupName string, parameters []elasticachetypes.ParameterNameValue) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DescribeEngineDefaultParameters(ctx context.Context, family string) ([]elasticachetypes.Parameter, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) GetAuthTokenSecretValue(ctx context.Context, secretName string) (*secretsmanager.GetSecretValueOutput, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) CreateAuthTokenSecret(ctx context.Context, secretName string, tags []secretsmanagertypes.Tag) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DeleteAuthTokenSecret(ctx context.Context, secretName string) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DescribeElastiCacheReplicationGroup(ctx context.Context, clusterId string) ([]elasticachetypes.ReplicationGroup, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) CreateElastiCacheReplicationGroup(ctx context.Context, tags []elasticachetypes.Tag, options awsclient.CreateElastiCacheClusterOptions) (*elasticache.CreateReplicationGroupOutput, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) ModifyElastiCacheReplicationGroup(ctx context.Context, id string, options awsclient.ModifyElastiCacheClusterOptions) (*elasticache.ModifyReplicationGroupOutput, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DeleteElastiCacheReplicationGroup(ctx context.Context, id string) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DescribeElastiCacheCluster(ctx context.Context, id string) ([]elasticachetypes.CacheCluster, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) ModifyElastiCacheClusterShardConfiguration(ctx context.Context, options awsclient.RescaleElastiCacheClusterShardOptions) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) ModifyElastiCacheClusterReplicaConfiguration(ctx context.Context, options awsclient.RescaleElastiCacheClusterReplicaOptions) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DescribeElastiCacheSecurityGroups(ctx context.Context, filters []ec2types.Filter, groupIds []string) ([]ec2types.SecurityGroup, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) CreateElastiCacheSecurityGroup(ctx context.Context, vpcId, name string, tags []ec2types.Tag) (string, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DeleteElastiCacheSecurityGroup(ctx context.Context, id string) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) AuthorizeElastiCacheSecurityGroupIngress(ctx context.Context, groupId string, ipPermissions []ec2types.IpPermission) error {
+	panic("unimplemented")
+}
+
+// newTestStateWithClient wraps newTestState by attaching a stub AWS client so
+// action guards under test can be exercised without hitting the panicking
+// path. The stub records calls so tests can assert the guard actually
+// short-circuited without issuing AWS calls.
+func newTestStateWithClient(t *testing.T, clusterName string, ug *elasticachetypes.UserGroup, stub *elastiCacheStub) *State {
+	t.Helper()
+	state := newTestState(t, clusterName, false, &elasticachetypes.ReplicationGroup{}, ug)
+	state.awsClient = stub
+	return state
+}
+
+func TestCreateUserGroupGuard_UGAlreadyPresent(t *testing.T) {
+	stub := newElastiCacheStub()
+	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
+		UserGroupId: ptr.To("cm-abc"),
+		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
+	}, stub)
+
+	err, _ := createUserGroup(context.Background(), state)
+
+	assert.Nil(t, err, "createUserGroup must return nil when userGroup is already loaded")
+	assert.Empty(t, stub.createUserGroupCalls, "createUserGroup must not invoke AWS when userGroup is present")
+}
+
+func TestDeleteUserGroupGuard_UGNil(t *testing.T) {
+	stub := newElastiCacheStub()
+	state := newTestStateWithClient(t, "abc", nil, stub)
+
+	err, _ := deleteUserGroup(context.Background(), state)
+
+	assert.Nil(t, err)
+	assert.Empty(t, stub.deleteUserGroupCalls, "deleteUserGroup must not invoke AWS when userGroup is nil")
+}
+
+func TestDeleteUserGroupGuard_UGDeleting(t *testing.T) {
+	stub := newElastiCacheStub()
+	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
+		UserGroupId: ptr.To("cm-abc"),
+		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_DELETING)),
+	}, stub)
+
+	err, _ := deleteUserGroup(context.Background(), state)
+
+	assert.Nil(t, err)
+	assert.Empty(t, stub.deleteUserGroupCalls, "deleteUserGroup must skip AWS when UG is already DELETING")
+}
+
+// Defensive guard against a fresh-create → downgrade race: if the transient
+// user group was just created and hasn't reached ACTIVE yet, AWS rejects
+// DeleteUserGroup on a CREATING resource. The guard must instead requeue.
+func TestDeleteUserGroupGuard_UGCreating(t *testing.T) {
+	stub := newElastiCacheStub()
+	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
+		UserGroupId: ptr.To("cm-abc"),
+		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_CREATING)),
+	}, stub)
+
+	err, _ := deleteUserGroup(context.Background(), state)
+
+	assert.NotNil(t, err, "deleteUserGroup must requeue when UG is still CREATING; got nil")
+	assert.Empty(t, stub.deleteUserGroupCalls, "deleteUserGroup must not invoke AWS on a CREATING UG")
+}
+
+func TestWaitUserGroupActive_UGNil(t *testing.T) {
+	state := newTestStateWithClient(t, "abc", nil, newElastiCacheStub())
+	err, _ := waitUserGroupActive(context.Background(), state)
+	assert.Nil(t, err, "waitUserGroupActive must return nil when userGroup is nil (continues pipeline)")
+}
+
+func TestWaitUserGroupActive_UGActive(t *testing.T) {
+	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
+		Status: ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
+	}, newElastiCacheStub())
+	err, _ := waitUserGroupActive(context.Background(), state)
+	assert.Nil(t, err, "waitUserGroupActive must return nil when UG is ACTIVE (continues pipeline)")
+}
+
+func TestWaitUserGroupActive_UGCreating(t *testing.T) {
+	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
+		Status: ptr.To(string(awsmeta.ElastiCache_UserGroup_CREATING)),
+	}, newElastiCacheStub())
+	err, _ := waitUserGroupActive(context.Background(), state)
+	assert.NotNil(t, err, "waitUserGroupActive must requeue when UG is CREATING")
+}
+
+// Foreign UG safety by construction. loadUserGroup fetches by exact
+// GetAwsElastiCacheUserGroupName(state.Obj().GetName()); a differently-named
+// user group in the same account must not be queried or touched.
+func TestLoadUserGroup_ForeignNameUntouched(t *testing.T) {
+	stub := newElastiCacheStub()
+	// Pre-seed a foreign UG that must not be affected.
+	foreignName := "cm-different-cluster"
+	foreignUG := &elasticachetypes.UserGroup{
+		UserGroupId: ptr.To(foreignName),
+		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
+	}
+	stub.preloadedUserGroups[foreignName] = foreignUG
+
+	// Also pre-seed our expected name so the load succeeds.
+	ourName := GetAwsElastiCacheUserGroupName("abc")
+	stub.preloadedUserGroups[ourName] = &elasticachetypes.UserGroup{
+		UserGroupId: ptr.To(ourName),
+		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
+	}
+
+	state := newTestState(t, "abc", true, &elasticachetypes.ReplicationGroup{}, nil)
+	state.awsClient = stub
+
+	err, _ := loadUserGroup(context.Background(), state)
+
+	assert.Nil(t, err)
+	assert.Equal(t, []string{ourName}, stub.describeUserGroupCalls,
+		"loadUserGroup must query exactly our derived name — never a foreign name")
+	// Foreign UG is unchanged in the stub's inventory.
+	assert.Same(t, foreignUG, stub.preloadedUserGroups[foreignName],
+		"foreign user group must remain untouched")
+	assert.Equal(t, awsmeta.ElastiCache_UserGroup_ACTIVE, awsmeta.ElastiCacheUserGroupState(ptr.Deref(foreignUG.Status, "")))
+}
+
+func TestCreateUserGroupGuard_ProceedsWhenUGNil(t *testing.T) {
+	stub := newElastiCacheStub()
+	state := newTestStateWithClient(t, "abc", nil, stub)
+
+	_, _ = createUserGroup(context.Background(), state)
+
+	assert.Equal(t, []string{GetAwsElastiCacheUserGroupName("abc")}, stub.createUserGroupCalls,
+		"createUserGroup must invoke AWS with the derived cm-<name> id when userGroup is nil")
+}
+
+func TestDeleteUserGroupGuard_ProceedsWhenActive(t *testing.T) {
+	stub := newElastiCacheStub()
+	id := GetAwsElastiCacheUserGroupName("abc")
+	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
+		UserGroupId: ptr.To(id),
+		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
+	}, stub)
+
+	_, _ = deleteUserGroup(context.Background(), state)
+
+	assert.Equal(t, []string{id}, stub.deleteUserGroupCalls,
+		"deleteUserGroup must invoke AWS with the UG id when the UG is ACTIVE")
+}

--- a/pkg/kcp/provider/aws/rediscluster/new.go
+++ b/pkg/kcp/provider/aws/rediscluster/new.go
@@ -66,14 +66,16 @@ func New(stateFactory StateFactory) composed.Action {
 						modifyTempParameterGroup(state),
 					),
 					createAuthTokenSecret,
-					createUserGroup,
+					composed.If(
+						shouldCreateTransientUserGroupPredicate(),
+						composed.ComposeActions("transient-ug-create", createUserGroup, waitUserGroupActive),
+					),
 					createSecurityGroup,
 					authorizeSecurityGroupIngress,
 					createElastiCacheCluster,
 					updateStatusId,
 					addUpdatingCondition,
 					waitElastiCacheAvailable,
-					waitUserGroupActive,
 					modifyCacheNodeType,
 					modifyAutoMinorVersionUpgrade,
 					modifyPreferredMaintenanceWindow,
@@ -81,6 +83,10 @@ func New(stateFactory StateFactory) composed.Action {
 					composed.If(
 						shouldUpdateRedisPredicate(),
 						updateElastiCacheCluster(),
+					),
+					composed.If(
+						shouldDeleteTransientUserGroupPredicate(),
+						composed.ComposeActions("transient-ug-delete", deleteUserGroup, waitUserGroupDeleted),
 					),
 					composed.If(
 						shouldUpgradeRedisPredicate(),

--- a/pkg/kcp/provider/aws/rediscluster/predicates.go
+++ b/pkg/kcp/provider/aws/rediscluster/predicates.go
@@ -2,6 +2,7 @@ package rediscluster
 
 import (
 	"context"
+	"slices"
 
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"k8s.io/utils/ptr"
@@ -125,12 +126,7 @@ func isUserGroupAttached(state *State) bool {
 		return false
 	}
 	name := ptr.Deref(state.userGroup.UserGroupId, "")
-	for _, id := range state.elastiCacheReplicationGroup.UserGroupIds {
-		if id == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(state.elastiCacheReplicationGroup.UserGroupIds, name)
 }
 
 // shouldDeleteTransientUserGroupPredicate fires when the transient user group

--- a/pkg/kcp/provider/aws/rediscluster/predicates.go
+++ b/pkg/kcp/provider/aws/rediscluster/predicates.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"k8s.io/utils/ptr"
 )
 
 func shouldCreateMainParamGroupPredicate() composed.Predicate {
@@ -82,5 +83,74 @@ func shouldDeleteRedundantTempParamGroupPredicate() composed.Predicate {
 
 		return state.elastiCacheReplicationGroup != nil && state.parameterGroup != nil && state.tempParameterGroup != nil &&
 			state.IsMainParamGroupFamilyUpToDate() && !state.IsTempParamGroupUsed()
+	}
+}
+
+// shouldCreateTransientUserGroupPredicate fires exactly when the reconciler
+// needs to attach a transient RBAC user group to disable the cluster's AUTH
+// token (i.e. spec.authEnabled just flipped true → false). The user group is
+// a shim: AWS ElastiCache requires a user group to be attached in the same
+// ModifyReplicationGroup call that deletes the auth token, but nothing
+// long-lived needs it. Once the delete-side predicate detects the group has
+// been detached, deleteUserGroup + waitUserGroupDeleted drives the account
+// back to zero cm-<name> user groups.
+//
+// Returns true iff (a) the replication group has been loaded, (b) the current
+// AWS-side auth is enabled, (c) the desired spec auth is disabled, and
+// (d) no user group has been observed yet. Otherwise false — either there is
+// nothing to downgrade, or the shim already exists.
+func shouldCreateTransientUserGroupPredicate() composed.Predicate {
+	return func(ctx context.Context, st composed.State) bool {
+		state := st.(*State)
+
+		if state.elastiCacheReplicationGroup == nil {
+			return false
+		}
+		if state.userGroup != nil {
+			return false
+		}
+		currentAuth := ptr.Deref(state.elastiCacheReplicationGroup.AuthTokenEnabled, false)
+		desiredAuth := state.ObjAsRedisCluster().Spec.Instance.Aws.AuthEnabled
+
+		return currentAuth && !desiredAuth
+	}
+}
+
+// isUserGroupAttached reports whether the observed replication group currently
+// lists our transient cm-<name> user group among its UserGroupIds. Used by
+// shouldDeleteTransientUserGroupPredicate to distinguish "attached, wait for
+// modify to detach" from "detached, safe to delete".
+func isUserGroupAttached(state *State) bool {
+	if state.userGroup == nil || state.elastiCacheReplicationGroup == nil {
+		return false
+	}
+	name := ptr.Deref(state.userGroup.UserGroupId, "")
+	for _, id := range state.elastiCacheReplicationGroup.UserGroupIds {
+		if id == name {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldDeleteTransientUserGroupPredicate fires when the transient user group
+// exists AND has already been detached from the replication group. This
+// invariant covers every relevant case:
+//
+//   - Downgrade in progress: mid-flow the UG is attached, so predicate returns
+//     false; only after the Remove modify propagates does it fire.
+//   - Upgrade with a stale leftover UG: predicate fires and cleans up. The
+//     ROTATE modify does not re-attach the UG, so a detached UG present at
+//     upgrade start is safe to delete.
+//   - Steady-state orphan on an auth-enabled cluster: predicate fires
+//     (inline backfill of legacy detached-orphan user groups).
+func shouldDeleteTransientUserGroupPredicate() composed.Predicate {
+	return func(ctx context.Context, st composed.State) bool {
+		state := st.(*State)
+
+		if state.userGroup == nil {
+			return false
+		}
+		return !isUserGroupAttached(state)
 	}
 }

--- a/pkg/kcp/provider/aws/rediscluster/predicates_test.go
+++ b/pkg/kcp/provider/aws/rediscluster/predicates_test.go
@@ -1,0 +1,179 @@
+package rediscluster
+
+import (
+	"context"
+	"testing"
+
+	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/common/actions/focal"
+	commonscheme "github.com/kyma-project/cloud-manager/pkg/common/scheme"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/rediscluster/types"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// testRedisClusterState is a minimal types.State impl for exercising
+// predicates and action guards without spinning up testinfra.
+type testRedisClusterState struct {
+	focal.State
+	ipRange *cloudcontrolv1beta1.IpRange
+}
+
+var _ types.State = &testRedisClusterState{}
+
+func (s *testRedisClusterState) ObjAsRedisCluster() *cloudcontrolv1beta1.RedisCluster {
+	return s.Obj().(*cloudcontrolv1beta1.RedisCluster)
+}
+
+func (s *testRedisClusterState) IpRange() *cloudcontrolv1beta1.IpRange {
+	return s.ipRange
+}
+
+func (s *testRedisClusterState) SetIpRange(r *cloudcontrolv1beta1.IpRange) {
+	s.ipRange = r
+}
+
+// newTestState builds a State backed by a real *RedisCluster with the given
+// desiredAuth wired into spec.instance.aws.authEnabled. AWS-client wiring is
+// intentionally omitted — callers under test never invoke a client method.
+func newTestState(t *testing.T, clusterName string, desiredAuth bool, rg *elasticachetypes.ReplicationGroup, ug *elasticachetypes.UserGroup) *State {
+	t.Helper()
+
+	fakeClient := fake.NewClientBuilder().WithScheme(commonscheme.KcpScheme).Build()
+	cluster := composed.NewStateCluster(fakeClient, fakeClient, nil, fakeClient.Scheme())
+
+	obj := &cloudcontrolv1beta1.RedisCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: "kcp-system",
+		},
+		Spec: cloudcontrolv1beta1.RedisClusterSpec{
+			Instance: cloudcontrolv1beta1.RedisClusterInfo{
+				Aws: &cloudcontrolv1beta1.RedisClusterAws{
+					AuthEnabled: desiredAuth,
+				},
+			},
+		},
+	}
+
+	focalState := focal.NewStateFactory().NewState(
+		composed.NewStateFactory(cluster).NewState(k8stypes.NamespacedName{Name: clusterName, Namespace: "kcp-system"}, obj),
+	)
+	focalState.SetScope(&cloudcontrolv1beta1.Scope{})
+
+	return &State{
+		State:                       &testRedisClusterState{State: focalState},
+		elastiCacheReplicationGroup: rg,
+		userGroup:                   ug,
+	}
+}
+
+func TestShouldCreateTransientUserGroupPredicate(t *testing.T) {
+	tests := []struct {
+		name        string
+		rgPresent   bool
+		currentAuth bool
+		desiredAuth bool
+		ugPresent   bool
+		expected    bool
+	}{
+		{"downgrade needed, UG missing", true, true, false, false, true},
+		{"UG already present", true, true, false, true, false},
+		{"no downgrade requested (upgrade)", true, true, true, false, false},
+		{"already downgraded", true, false, false, false, false},
+		{"RG not loaded yet", false, false, false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rg *elasticachetypes.ReplicationGroup
+			if tt.rgPresent {
+				rg = &elasticachetypes.ReplicationGroup{
+					AuthTokenEnabled: ptr.To(tt.currentAuth),
+				}
+			}
+			var ug *elasticachetypes.UserGroup
+			if tt.ugPresent {
+				ug = &elasticachetypes.UserGroup{
+					UserGroupId: ptr.To("cm-test"),
+					Status:      ptr.To("active"),
+				}
+			}
+			state := newTestState(t, "test", tt.desiredAuth, rg, ug)
+
+			got := shouldCreateTransientUserGroupPredicate()(context.Background(), state)
+			assert.Equal(t, tt.expected, got, "predicate returned unexpected value for case %q", tt.name)
+		})
+	}
+}
+
+func TestShouldDeleteTransientUserGroupPredicate(t *testing.T) {
+	// The predicate simplifies to `ugExists AND !ugAttached`.
+	const clusterName = "test"
+	attachedName := GetAwsElastiCacheUserGroupName(clusterName)
+
+	tests := []struct {
+		name         string
+		ugPresent    bool
+		attachedList []string
+		currentAuth  bool
+		desiredAuth  bool
+		expected     bool
+	}{
+		{"orphan on auth-enabled — backfill delete", true, []string{}, true, true, true},
+		{"post-detach: currentAuth=false, desiredAuth=false", true, []string{}, false, false, true},
+		{"upgrade path with leftover UG", true, []string{}, false, true, true},
+		{"mid-downgrade before Add propagated", true, []string{attachedName}, true, false, false},
+		{"mid-downgrade after Add propagated, before Remove", true, []string{attachedName}, false, false, false},
+		{"nothing to delete — ug nil", false, []string{}, false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rg := &elasticachetypes.ReplicationGroup{
+				AuthTokenEnabled: ptr.To(tt.currentAuth),
+				UserGroupIds:     tt.attachedList,
+			}
+			var ug *elasticachetypes.UserGroup
+			if tt.ugPresent {
+				ug = &elasticachetypes.UserGroup{
+					UserGroupId: ptr.To(attachedName),
+					Status:      ptr.To("active"),
+				}
+			}
+			state := newTestState(t, clusterName, tt.desiredAuth, rg, ug)
+
+			got := shouldDeleteTransientUserGroupPredicate()(context.Background(), state)
+			assert.Equal(t, tt.expected, got, "predicate returned unexpected value for case %q", tt.name)
+		})
+	}
+}
+
+func TestIsUserGroupAttached(t *testing.T) {
+	const clusterName = "abc"
+	attached := GetAwsElastiCacheUserGroupName(clusterName)
+
+	tests := []struct {
+		name         string
+		attachedList []string
+		expected     bool
+	}{
+		{"detached", []string{}, false},
+		{"attached exactly", []string{attached}, true},
+		{"other UG attached", []string{"cm-other"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := newTestState(t, clusterName, false,
+				&elasticachetypes.ReplicationGroup{UserGroupIds: tt.attachedList},
+				&elasticachetypes.UserGroup{UserGroupId: ptr.To(attached)},
+			)
+			assert.Equal(t, tt.expected, isUserGroupAttached(state))
+		})
+	}
+}

--- a/pkg/kcp/provider/aws/rediscluster/predicates_test.go
+++ b/pkg/kcp/provider/aws/rediscluster/predicates_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -94,14 +93,14 @@ func TestShouldCreateTransientUserGroupPredicate(t *testing.T) {
 			var rg *elasticachetypes.ReplicationGroup
 			if tt.rgPresent {
 				rg = &elasticachetypes.ReplicationGroup{
-					AuthTokenEnabled: ptr.To(tt.currentAuth),
+					AuthTokenEnabled: new(tt.currentAuth),
 				}
 			}
 			var ug *elasticachetypes.UserGroup
 			if tt.ugPresent {
 				ug = &elasticachetypes.UserGroup{
-					UserGroupId: ptr.To("cm-test"),
-					Status:      ptr.To("active"),
+					UserGroupId: new("cm-test"),
+					Status:      new("active"),
 				}
 			}
 			state := newTestState(t, "test", tt.desiredAuth, rg, ug)
@@ -136,14 +135,14 @@ func TestShouldDeleteTransientUserGroupPredicate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rg := &elasticachetypes.ReplicationGroup{
-				AuthTokenEnabled: ptr.To(tt.currentAuth),
+				AuthTokenEnabled: new(tt.currentAuth),
 				UserGroupIds:     tt.attachedList,
 			}
 			var ug *elasticachetypes.UserGroup
 			if tt.ugPresent {
 				ug = &elasticachetypes.UserGroup{
-					UserGroupId: ptr.To(attachedName),
-					Status:      ptr.To("active"),
+					UserGroupId: new(attachedName),
+					Status:      new("active"),
 				}
 			}
 			state := newTestState(t, clusterName, tt.desiredAuth, rg, ug)
@@ -171,7 +170,7 @@ func TestIsUserGroupAttached(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			state := newTestState(t, clusterName, false,
 				&elasticachetypes.ReplicationGroup{UserGroupIds: tt.attachedList},
-				&elasticachetypes.UserGroup{UserGroupId: ptr.To(attached)},
+				&elasticachetypes.UserGroup{UserGroupId: new(attached)},
 			)
 			assert.Equal(t, tt.expected, isUserGroupAttached(state))
 		})

--- a/pkg/kcp/provider/aws/redisinstance/deleteUserGroup.go
+++ b/pkg/kcp/provider/aws/redisinstance/deleteUserGroup.go
@@ -21,6 +21,15 @@ func deleteUserGroup(ctx context.Context, st composed.State) (error, context.Con
 	if userGroupState == awsmeta.ElastiCache_UserGroup_DELETING {
 		return nil, ctx
 	}
+	// Defensive guard against a fresh-create → downgrade race: if the transient
+	// user group was just created (predicate fired) and hasn't reached ACTIVE
+	// yet, AWS rejects DeleteUserGroup on a CREATING resource and lands the
+	// cluster in an error state. Wait for the status to settle before
+	// attempting the delete.
+	if userGroupState == awsmeta.ElastiCache_UserGroup_CREATING {
+		logger.Info("User group is still CREATING, requeueing before delete")
+		return composed.StopWithRequeueDelay(util.Timing.T10000ms()), nil
+	}
 
 	logger.Info("Deleting userGroup")
 

--- a/pkg/kcp/provider/aws/redisinstance/guards_test.go
+++ b/pkg/kcp/provider/aws/redisinstance/guards_test.go
@@ -35,7 +35,7 @@ var _ awsclient.ElastiCacheClient = &elastiCacheStub{}
 
 func (s *elastiCacheStub) CreateUserGroup(ctx context.Context, id string, tags []elasticachetypes.Tag) (*elasticache.CreateUserGroupOutput, error) {
 	s.createUserGroupCalls = append(s.createUserGroupCalls, id)
-	return &elasticache.CreateUserGroupOutput{UserGroupId: ptr.To(id)}, nil
+	return &elasticache.CreateUserGroupOutput{UserGroupId: new(id)}, nil
 }
 
 func (s *elastiCacheStub) DeleteUserGroup(ctx context.Context, id string) error {
@@ -130,7 +130,7 @@ func newTestStateWithClient(t *testing.T, instanceName string, ug *elasticachety
 func TestCreateUserGroupGuard_UGAlreadyPresent(t *testing.T) {
 	stub := newElastiCacheStub()
 	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
-		UserGroupId: ptr.To("cm-abc"),
+		UserGroupId: new("cm-abc"),
 		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
 	}, stub)
 
@@ -153,7 +153,7 @@ func TestDeleteUserGroupGuard_UGNil(t *testing.T) {
 func TestDeleteUserGroupGuard_UGDeleting(t *testing.T) {
 	stub := newElastiCacheStub()
 	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
-		UserGroupId: ptr.To("cm-abc"),
+		UserGroupId: new("cm-abc"),
 		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_DELETING)),
 	}, stub)
 
@@ -166,7 +166,7 @@ func TestDeleteUserGroupGuard_UGDeleting(t *testing.T) {
 func TestDeleteUserGroupGuard_UGCreating(t *testing.T) {
 	stub := newElastiCacheStub()
 	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
-		UserGroupId: ptr.To("cm-abc"),
+		UserGroupId: new("cm-abc"),
 		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_CREATING)),
 	}, stub)
 
@@ -205,14 +205,14 @@ func TestLoadUserGroup_ForeignNameUntouched(t *testing.T) {
 	stub := newElastiCacheStub()
 	foreignName := "cm-different-instance"
 	foreignUG := &elasticachetypes.UserGroup{
-		UserGroupId: ptr.To(foreignName),
+		UserGroupId: new(foreignName),
 		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
 	}
 	stub.preloadedUserGroups[foreignName] = foreignUG
 
 	ourName := GetAwsElastiCacheUserGroupName("abc")
 	stub.preloadedUserGroups[ourName] = &elasticachetypes.UserGroup{
-		UserGroupId: ptr.To(ourName),
+		UserGroupId: new(ourName),
 		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
 	}
 
@@ -243,7 +243,7 @@ func TestDeleteUserGroupGuard_ProceedsWhenActive(t *testing.T) {
 	stub := newElastiCacheStub()
 	id := GetAwsElastiCacheUserGroupName("abc")
 	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
-		UserGroupId: ptr.To(id),
+		UserGroupId: new(id),
 		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
 	}, stub)
 

--- a/pkg/kcp/provider/aws/redisinstance/guards_test.go
+++ b/pkg/kcp/provider/aws/redisinstance/guards_test.go
@@ -1,0 +1,254 @@
+package redisinstance
+
+import (
+	"context"
+	"testing"
+
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	secretsmanagertypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+
+	awsclient "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/client"
+	awsmeta "github.com/kyma-project/cloud-manager/pkg/kcp/provider/aws/meta"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+)
+
+// elastiCacheStub is a minimal awsclient.ElastiCacheClient for action-guard
+// unit tests. Only the methods the guards can plausibly call are implemented;
+// every other method panics ("unimplemented") so a broken guard that lets a
+// call slip through fails loudly instead of silently accepting a zero-return.
+type elastiCacheStub struct {
+	createUserGroupCalls   []string
+	deleteUserGroupCalls   []string
+	describeUserGroupCalls []string
+	preloadedUserGroups    map[string]*elasticachetypes.UserGroup
+}
+
+func newElastiCacheStub() *elastiCacheStub {
+	return &elastiCacheStub{preloadedUserGroups: map[string]*elasticachetypes.UserGroup{}}
+}
+
+var _ awsclient.ElastiCacheClient = &elastiCacheStub{}
+
+func (s *elastiCacheStub) CreateUserGroup(ctx context.Context, id string, tags []elasticachetypes.Tag) (*elasticache.CreateUserGroupOutput, error) {
+	s.createUserGroupCalls = append(s.createUserGroupCalls, id)
+	return &elasticache.CreateUserGroupOutput{UserGroupId: ptr.To(id)}, nil
+}
+
+func (s *elastiCacheStub) DeleteUserGroup(ctx context.Context, id string) error {
+	s.deleteUserGroupCalls = append(s.deleteUserGroupCalls, id)
+	return nil
+}
+
+func (s *elastiCacheStub) DescribeUserGroup(ctx context.Context, id string) (*elasticachetypes.UserGroup, error) {
+	s.describeUserGroupCalls = append(s.describeUserGroupCalls, id)
+	return s.preloadedUserGroups[id], nil
+}
+
+// All remaining methods must panic — the guards under test should never
+// reach them. A silent nil return would mask a broken guard.
+func (s *elastiCacheStub) DescribeElastiCacheSubnetGroup(ctx context.Context, name string) ([]elasticachetypes.CacheSubnetGroup, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) CreateElastiCacheSubnetGroup(ctx context.Context, name string, subnetIds []string, tags []elasticachetypes.Tag) (*elasticache.CreateCacheSubnetGroupOutput, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DeleteElastiCacheSubnetGroup(ctx context.Context, name string) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DescribeElastiCacheParameterGroup(ctx context.Context, name string) ([]elasticachetypes.CacheParameterGroup, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) CreateElastiCacheParameterGroup(ctx context.Context, name, family string, tags []elasticachetypes.Tag) (*elasticache.CreateCacheParameterGroupOutput, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DeleteElastiCacheParameterGroup(ctx context.Context, name string) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DescribeElastiCacheParameters(ctx context.Context, groupName string) ([]elasticachetypes.Parameter, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) ModifyElastiCacheParameterGroup(ctx context.Context, groupName string, parameters []elasticachetypes.ParameterNameValue) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DescribeEngineDefaultParameters(ctx context.Context, family string) ([]elasticachetypes.Parameter, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) GetAuthTokenSecretValue(ctx context.Context, secretName string) (*secretsmanager.GetSecretValueOutput, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) CreateAuthTokenSecret(ctx context.Context, secretName string, tags []secretsmanagertypes.Tag) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DeleteAuthTokenSecret(ctx context.Context, secretName string) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DescribeElastiCacheReplicationGroup(ctx context.Context, clusterId string) ([]elasticachetypes.ReplicationGroup, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) CreateElastiCacheReplicationGroup(ctx context.Context, tags []elasticachetypes.Tag, options awsclient.CreateElastiCacheClusterOptions) (*elasticache.CreateReplicationGroupOutput, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) ModifyElastiCacheReplicationGroup(ctx context.Context, id string, options awsclient.ModifyElastiCacheClusterOptions) (*elasticache.ModifyReplicationGroupOutput, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DeleteElastiCacheReplicationGroup(ctx context.Context, id string) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DescribeElastiCacheCluster(ctx context.Context, id string) ([]elasticachetypes.CacheCluster, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) ModifyElastiCacheClusterShardConfiguration(ctx context.Context, options awsclient.RescaleElastiCacheClusterShardOptions) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) ModifyElastiCacheClusterReplicaConfiguration(ctx context.Context, options awsclient.RescaleElastiCacheClusterReplicaOptions) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DescribeElastiCacheSecurityGroups(ctx context.Context, filters []ec2types.Filter, groupIds []string) ([]ec2types.SecurityGroup, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) CreateElastiCacheSecurityGroup(ctx context.Context, vpcId, name string, tags []ec2types.Tag) (string, error) {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) DeleteElastiCacheSecurityGroup(ctx context.Context, id string) error {
+	panic("unimplemented")
+}
+func (s *elastiCacheStub) AuthorizeElastiCacheSecurityGroupIngress(ctx context.Context, groupId string, ipPermissions []ec2types.IpPermission) error {
+	panic("unimplemented")
+}
+
+func newTestStateWithClient(t *testing.T, instanceName string, ug *elasticachetypes.UserGroup, stub *elastiCacheStub) *State {
+	t.Helper()
+	state := newTestState(t, instanceName, false, &elasticachetypes.ReplicationGroup{}, ug)
+	state.awsClient = stub
+	return state
+}
+
+func TestCreateUserGroupGuard_UGAlreadyPresent(t *testing.T) {
+	stub := newElastiCacheStub()
+	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
+		UserGroupId: ptr.To("cm-abc"),
+		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
+	}, stub)
+
+	err, _ := createUserGroup(context.Background(), state)
+
+	assert.Nil(t, err, "createUserGroup must return nil when userGroup is already loaded")
+	assert.Empty(t, stub.createUserGroupCalls, "createUserGroup must not invoke AWS when userGroup is present")
+}
+
+func TestDeleteUserGroupGuard_UGNil(t *testing.T) {
+	stub := newElastiCacheStub()
+	state := newTestStateWithClient(t, "abc", nil, stub)
+
+	err, _ := deleteUserGroup(context.Background(), state)
+
+	assert.Nil(t, err)
+	assert.Empty(t, stub.deleteUserGroupCalls, "deleteUserGroup must not invoke AWS when userGroup is nil")
+}
+
+func TestDeleteUserGroupGuard_UGDeleting(t *testing.T) {
+	stub := newElastiCacheStub()
+	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
+		UserGroupId: ptr.To("cm-abc"),
+		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_DELETING)),
+	}, stub)
+
+	err, _ := deleteUserGroup(context.Background(), state)
+
+	assert.Nil(t, err)
+	assert.Empty(t, stub.deleteUserGroupCalls, "deleteUserGroup must skip AWS when UG is already DELETING")
+}
+
+func TestDeleteUserGroupGuard_UGCreating(t *testing.T) {
+	stub := newElastiCacheStub()
+	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
+		UserGroupId: ptr.To("cm-abc"),
+		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_CREATING)),
+	}, stub)
+
+	err, _ := deleteUserGroup(context.Background(), state)
+
+	assert.NotNil(t, err, "deleteUserGroup must requeue when UG is still CREATING; got nil")
+	assert.Empty(t, stub.deleteUserGroupCalls, "deleteUserGroup must not invoke AWS on a CREATING UG")
+}
+
+func TestWaitUserGroupActive_UGNil(t *testing.T) {
+	state := newTestStateWithClient(t, "abc", nil, newElastiCacheStub())
+	err, _ := waitUserGroupActive(context.Background(), state)
+	assert.Nil(t, err, "waitUserGroupActive must return nil when userGroup is nil (continues pipeline)")
+}
+
+func TestWaitUserGroupActive_UGActive(t *testing.T) {
+	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
+		Status: ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
+	}, newElastiCacheStub())
+	err, _ := waitUserGroupActive(context.Background(), state)
+	assert.Nil(t, err, "waitUserGroupActive must return nil when UG is ACTIVE (continues pipeline)")
+}
+
+func TestWaitUserGroupActive_UGCreating(t *testing.T) {
+	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
+		Status: ptr.To(string(awsmeta.ElastiCache_UserGroup_CREATING)),
+	}, newElastiCacheStub())
+	err, _ := waitUserGroupActive(context.Background(), state)
+	assert.NotNil(t, err, "waitUserGroupActive must requeue when UG is CREATING")
+}
+
+// Foreign UG safety by construction. loadUserGroup fetches by exact
+// GetAwsElastiCacheUserGroupName(state.Obj().GetName()); a differently-named
+// user group in the same account must not be queried or touched.
+func TestLoadUserGroup_ForeignNameUntouched(t *testing.T) {
+	stub := newElastiCacheStub()
+	foreignName := "cm-different-instance"
+	foreignUG := &elasticachetypes.UserGroup{
+		UserGroupId: ptr.To(foreignName),
+		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
+	}
+	stub.preloadedUserGroups[foreignName] = foreignUG
+
+	ourName := GetAwsElastiCacheUserGroupName("abc")
+	stub.preloadedUserGroups[ourName] = &elasticachetypes.UserGroup{
+		UserGroupId: ptr.To(ourName),
+		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
+	}
+
+	state := newTestState(t, "abc", true, &elasticachetypes.ReplicationGroup{}, nil)
+	state.awsClient = stub
+
+	err, _ := loadUserGroup(context.Background(), state)
+
+	assert.Nil(t, err)
+	assert.Equal(t, []string{ourName}, stub.describeUserGroupCalls,
+		"loadUserGroup must query exactly our derived name — never a foreign name")
+	assert.Same(t, foreignUG, stub.preloadedUserGroups[foreignName],
+		"foreign user group must remain untouched")
+	assert.Equal(t, awsmeta.ElastiCache_UserGroup_ACTIVE, awsmeta.ElastiCacheUserGroupState(ptr.Deref(foreignUG.Status, "")))
+}
+
+func TestCreateUserGroupGuard_ProceedsWhenUGNil(t *testing.T) {
+	stub := newElastiCacheStub()
+	state := newTestStateWithClient(t, "abc", nil, stub)
+
+	_, _ = createUserGroup(context.Background(), state)
+
+	assert.Equal(t, []string{GetAwsElastiCacheUserGroupName("abc")}, stub.createUserGroupCalls,
+		"createUserGroup must invoke AWS with the derived cm-<name> id when userGroup is nil")
+}
+
+func TestDeleteUserGroupGuard_ProceedsWhenActive(t *testing.T) {
+	stub := newElastiCacheStub()
+	id := GetAwsElastiCacheUserGroupName("abc")
+	state := newTestStateWithClient(t, "abc", &elasticachetypes.UserGroup{
+		UserGroupId: ptr.To(id),
+		Status:      ptr.To(string(awsmeta.ElastiCache_UserGroup_ACTIVE)),
+	}, stub)
+
+	_, _ = deleteUserGroup(context.Background(), state)
+
+	assert.Equal(t, []string{id}, stub.deleteUserGroupCalls,
+		"deleteUserGroup must invoke AWS with the UG id when the UG is ACTIVE")
+}

--- a/pkg/kcp/provider/aws/redisinstance/new.go
+++ b/pkg/kcp/provider/aws/redisinstance/new.go
@@ -66,14 +66,16 @@ func New(stateFactory StateFactory) composed.Action {
 						modifyTempParameterGroup(state),
 					),
 					createAuthTokenSecret,
-					createUserGroup,
+					composed.If(
+						shouldCreateTransientUserGroupPredicate(),
+						composed.ComposeActions("transient-ug-create", createUserGroup, waitUserGroupActive),
+					),
 					createSecurityGroup,
 					authorizeSecurityGroupIngress,
 					createElastiCacheCluster,
 					updateStatusId,
 					addUpdatingCondition,
 					waitElastiCacheAvailable,
-					waitUserGroupActive,
 					modifyCacheNodeType,
 					modifyAutoMinorVersionUpgrade,
 					modifyPreferredMaintenanceWindow,
@@ -81,6 +83,10 @@ func New(stateFactory StateFactory) composed.Action {
 					composed.If(
 						shouldUpdateRedisPredicate(),
 						updateElastiCacheCluster(),
+					),
+					composed.If(
+						shouldDeleteTransientUserGroupPredicate(),
+						composed.ComposeActions("transient-ug-delete", deleteUserGroup, waitUserGroupDeleted),
 					),
 					composed.If(
 						shouldUpgradeRedisPredicate(),

--- a/pkg/kcp/provider/aws/redisinstance/predicates.go
+++ b/pkg/kcp/provider/aws/redisinstance/predicates.go
@@ -2,6 +2,7 @@ package redisinstance
 
 import (
 	"context"
+	"slices"
 
 	"github.com/kyma-project/cloud-manager/pkg/composed"
 	"k8s.io/utils/ptr"
@@ -125,12 +126,7 @@ func isUserGroupAttached(state *State) bool {
 		return false
 	}
 	name := ptr.Deref(state.userGroup.UserGroupId, "")
-	for _, id := range state.elastiCacheReplicationGroup.UserGroupIds {
-		if id == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(state.elastiCacheReplicationGroup.UserGroupIds, name)
 }
 
 // shouldDeleteTransientUserGroupPredicate fires when the transient user group

--- a/pkg/kcp/provider/aws/redisinstance/predicates.go
+++ b/pkg/kcp/provider/aws/redisinstance/predicates.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"k8s.io/utils/ptr"
 )
 
 func shouldCreateMainParamGroupPredicate() composed.Predicate {
@@ -82,5 +83,74 @@ func shouldDeleteRedundantTempParamGroupPredicate() composed.Predicate {
 
 		return state.elastiCacheReplicationGroup != nil && state.parameterGroup != nil && state.tempParameterGroup != nil &&
 			state.IsMainParamGroupFamilyUpToDate() && !state.IsTempParamGroupUsed()
+	}
+}
+
+// shouldCreateTransientUserGroupPredicate fires exactly when the reconciler
+// needs to attach a transient RBAC user group to disable the cluster's AUTH
+// token (i.e. spec.authEnabled just flipped true → false). The user group is
+// a shim: AWS ElastiCache requires a user group to be attached in the same
+// ModifyReplicationGroup call that deletes the auth token, but nothing
+// long-lived needs it. Once the delete-side predicate detects the group has
+// been detached, deleteUserGroup + waitUserGroupDeleted drives the account
+// back to zero cm-<name> user groups.
+//
+// Returns true iff (a) the replication group has been loaded, (b) the current
+// AWS-side auth is enabled, (c) the desired spec auth is disabled, and
+// (d) no user group has been observed yet. Otherwise false — either there is
+// nothing to downgrade, or the shim already exists.
+func shouldCreateTransientUserGroupPredicate() composed.Predicate {
+	return func(ctx context.Context, st composed.State) bool {
+		state := st.(*State)
+
+		if state.elastiCacheReplicationGroup == nil {
+			return false
+		}
+		if state.userGroup != nil {
+			return false
+		}
+		currentAuth := ptr.Deref(state.elastiCacheReplicationGroup.AuthTokenEnabled, false)
+		desiredAuth := state.ObjAsRedisInstance().Spec.Instance.Aws.AuthEnabled
+
+		return currentAuth && !desiredAuth
+	}
+}
+
+// isUserGroupAttached reports whether the observed replication group currently
+// lists our transient cm-<name> user group among its UserGroupIds. Used by
+// shouldDeleteTransientUserGroupPredicate to distinguish "attached, wait for
+// modify to detach" from "detached, safe to delete".
+func isUserGroupAttached(state *State) bool {
+	if state.userGroup == nil || state.elastiCacheReplicationGroup == nil {
+		return false
+	}
+	name := ptr.Deref(state.userGroup.UserGroupId, "")
+	for _, id := range state.elastiCacheReplicationGroup.UserGroupIds {
+		if id == name {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldDeleteTransientUserGroupPredicate fires when the transient user group
+// exists AND has already been detached from the replication group. This
+// invariant covers every relevant case:
+//
+//   - Downgrade in progress: mid-flow the UG is attached, so predicate returns
+//     false; only after the Remove modify propagates does it fire.
+//   - Upgrade with a stale leftover UG: predicate fires and cleans up. The
+//     ROTATE modify does not re-attach the UG, so a detached UG present at
+//     upgrade start is safe to delete.
+//   - Steady-state orphan on an auth-enabled cluster: predicate fires
+//     (inline backfill of legacy detached-orphan user groups).
+func shouldDeleteTransientUserGroupPredicate() composed.Predicate {
+	return func(ctx context.Context, st composed.State) bool {
+		state := st.(*State)
+
+		if state.userGroup == nil {
+			return false
+		}
+		return !isUserGroupAttached(state)
 	}
 }

--- a/pkg/kcp/provider/aws/redisinstance/predicates_test.go
+++ b/pkg/kcp/provider/aws/redisinstance/predicates_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -92,14 +91,14 @@ func TestShouldCreateTransientUserGroupPredicate(t *testing.T) {
 			var rg *elasticachetypes.ReplicationGroup
 			if tt.rgPresent {
 				rg = &elasticachetypes.ReplicationGroup{
-					AuthTokenEnabled: ptr.To(tt.currentAuth),
+					AuthTokenEnabled: new(tt.currentAuth),
 				}
 			}
 			var ug *elasticachetypes.UserGroup
 			if tt.ugPresent {
 				ug = &elasticachetypes.UserGroup{
-					UserGroupId: ptr.To("cm-test"),
-					Status:      ptr.To("active"),
+					UserGroupId: new("cm-test"),
+					Status:      new("active"),
 				}
 			}
 			state := newTestState(t, "test", tt.desiredAuth, rg, ug)
@@ -134,14 +133,14 @@ func TestShouldDeleteTransientUserGroupPredicate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rg := &elasticachetypes.ReplicationGroup{
-				AuthTokenEnabled: ptr.To(tt.currentAuth),
+				AuthTokenEnabled: new(tt.currentAuth),
 				UserGroupIds:     tt.attachedList,
 			}
 			var ug *elasticachetypes.UserGroup
 			if tt.ugPresent {
 				ug = &elasticachetypes.UserGroup{
-					UserGroupId: ptr.To(attachedName),
-					Status:      ptr.To("active"),
+					UserGroupId: new(attachedName),
+					Status:      new("active"),
 				}
 			}
 			state := newTestState(t, instanceName, tt.desiredAuth, rg, ug)
@@ -169,7 +168,7 @@ func TestIsUserGroupAttached(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			state := newTestState(t, instanceName, false,
 				&elasticachetypes.ReplicationGroup{UserGroupIds: tt.attachedList},
-				&elasticachetypes.UserGroup{UserGroupId: ptr.To(attached)},
+				&elasticachetypes.UserGroup{UserGroupId: new(attached)},
 			)
 			assert.Equal(t, tt.expected, isUserGroupAttached(state))
 		})

--- a/pkg/kcp/provider/aws/redisinstance/predicates_test.go
+++ b/pkg/kcp/provider/aws/redisinstance/predicates_test.go
@@ -1,0 +1,177 @@
+package redisinstance
+
+import (
+	"context"
+	"testing"
+
+	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	cloudcontrolv1beta1 "github.com/kyma-project/cloud-manager/api/cloud-control/v1beta1"
+	"github.com/kyma-project/cloud-manager/pkg/common/actions/focal"
+	commonscheme "github.com/kyma-project/cloud-manager/pkg/common/scheme"
+	"github.com/kyma-project/cloud-manager/pkg/composed"
+	"github.com/kyma-project/cloud-manager/pkg/kcp/redisinstance/types"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type testRedisInstanceState struct {
+	focal.State
+	ipRange *cloudcontrolv1beta1.IpRange
+}
+
+var _ types.State = &testRedisInstanceState{}
+
+func (s *testRedisInstanceState) ObjAsRedisInstance() *cloudcontrolv1beta1.RedisInstance {
+	return s.Obj().(*cloudcontrolv1beta1.RedisInstance)
+}
+
+func (s *testRedisInstanceState) IpRange() *cloudcontrolv1beta1.IpRange {
+	return s.ipRange
+}
+
+func (s *testRedisInstanceState) SetIpRange(r *cloudcontrolv1beta1.IpRange) {
+	s.ipRange = r
+}
+
+// newTestState builds a State backed by a real *RedisInstance with the given
+// desiredAuth wired into spec.instance.aws.authEnabled. AWS-client wiring is
+// intentionally omitted — callers under test never invoke a client method.
+func newTestState(t *testing.T, instanceName string, desiredAuth bool, rg *elasticachetypes.ReplicationGroup, ug *elasticachetypes.UserGroup) *State {
+	t.Helper()
+
+	fakeClient := fake.NewClientBuilder().WithScheme(commonscheme.KcpScheme).Build()
+	cluster := composed.NewStateCluster(fakeClient, fakeClient, nil, fakeClient.Scheme())
+
+	obj := &cloudcontrolv1beta1.RedisInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instanceName,
+			Namespace: "kcp-system",
+		},
+		Spec: cloudcontrolv1beta1.RedisInstanceSpec{
+			Instance: cloudcontrolv1beta1.RedisInstanceInfo{
+				Aws: &cloudcontrolv1beta1.RedisInstanceAws{
+					AuthEnabled: desiredAuth,
+				},
+			},
+		},
+	}
+
+	focalState := focal.NewStateFactory().NewState(
+		composed.NewStateFactory(cluster).NewState(k8stypes.NamespacedName{Name: instanceName, Namespace: "kcp-system"}, obj),
+	)
+	focalState.SetScope(&cloudcontrolv1beta1.Scope{})
+
+	return &State{
+		State:                       &testRedisInstanceState{State: focalState},
+		elastiCacheReplicationGroup: rg,
+		userGroup:                   ug,
+	}
+}
+
+func TestShouldCreateTransientUserGroupPredicate(t *testing.T) {
+	tests := []struct {
+		name        string
+		rgPresent   bool
+		currentAuth bool
+		desiredAuth bool
+		ugPresent   bool
+		expected    bool
+	}{
+		{"downgrade needed, UG missing", true, true, false, false, true},
+		{"UG already present", true, true, false, true, false},
+		{"no downgrade requested (upgrade)", true, true, true, false, false},
+		{"already downgraded", true, false, false, false, false},
+		{"RG not loaded yet", false, false, false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rg *elasticachetypes.ReplicationGroup
+			if tt.rgPresent {
+				rg = &elasticachetypes.ReplicationGroup{
+					AuthTokenEnabled: ptr.To(tt.currentAuth),
+				}
+			}
+			var ug *elasticachetypes.UserGroup
+			if tt.ugPresent {
+				ug = &elasticachetypes.UserGroup{
+					UserGroupId: ptr.To("cm-test"),
+					Status:      ptr.To("active"),
+				}
+			}
+			state := newTestState(t, "test", tt.desiredAuth, rg, ug)
+
+			got := shouldCreateTransientUserGroupPredicate()(context.Background(), state)
+			assert.Equal(t, tt.expected, got, "predicate returned unexpected value for case %q", tt.name)
+		})
+	}
+}
+
+func TestShouldDeleteTransientUserGroupPredicate(t *testing.T) {
+	// The predicate simplifies to `ugExists AND !ugAttached`.
+	const instanceName = "test"
+	attachedName := GetAwsElastiCacheUserGroupName(instanceName)
+
+	tests := []struct {
+		name         string
+		ugPresent    bool
+		attachedList []string
+		currentAuth  bool
+		desiredAuth  bool
+		expected     bool
+	}{
+		{"orphan on auth-enabled — backfill delete", true, []string{}, true, true, true},
+		{"post-detach: currentAuth=false, desiredAuth=false", true, []string{}, false, false, true},
+		{"upgrade path with leftover UG", true, []string{}, false, true, true},
+		{"mid-downgrade before Add propagated", true, []string{attachedName}, true, false, false},
+		{"mid-downgrade after Add propagated, before Remove", true, []string{attachedName}, false, false, false},
+		{"nothing to delete — ug nil", false, []string{}, false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rg := &elasticachetypes.ReplicationGroup{
+				AuthTokenEnabled: ptr.To(tt.currentAuth),
+				UserGroupIds:     tt.attachedList,
+			}
+			var ug *elasticachetypes.UserGroup
+			if tt.ugPresent {
+				ug = &elasticachetypes.UserGroup{
+					UserGroupId: ptr.To(attachedName),
+					Status:      ptr.To("active"),
+				}
+			}
+			state := newTestState(t, instanceName, tt.desiredAuth, rg, ug)
+
+			got := shouldDeleteTransientUserGroupPredicate()(context.Background(), state)
+			assert.Equal(t, tt.expected, got, "predicate returned unexpected value for case %q", tt.name)
+		})
+	}
+}
+
+func TestIsUserGroupAttached(t *testing.T) {
+	const instanceName = "abc"
+	attached := GetAwsElastiCacheUserGroupName(instanceName)
+
+	tests := []struct {
+		name         string
+		attachedList []string
+		expected     bool
+	}{
+		{"detached", []string{}, false},
+		{"attached exactly", []string{attached}, true},
+		{"other UG attached", []string{"cm-other"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := newTestState(t, instanceName, false,
+				&elasticachetypes.ReplicationGroup{UserGroupIds: tt.attachedList},
+				&elasticachetypes.UserGroup{UserGroupId: ptr.To(attached)},
+			)
+			assert.Equal(t, tt.expected, isUserGroupAttached(state))
+		})
+	}
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

**Problem.** `createUserGroup` runs unconditionally and no step deletes the UG after detach — every managed cluster leaks one `cm-<name>` UG against the 200/region ElastiCache quota.

**Fix.** Two `composed.If` guards in [new.go](pkg/kcp/provider/aws/rediscluster/new.go): create only when downgrading (`!ugExists && authFlipping`), delete once detached (`ugExists && !ugAttached`). Legacy orphans clean up inline via the same delete predicate.

Steady-state: **0** `cm-*` UGs per account.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/cloud-manager/issues/1957